### PR TITLE
Refactor and add --ts-out and --cpp-out to command line

### DIFF
--- a/crates/uniffi-bindgen-react-native/src/bindings/mod.rs
+++ b/crates/uniffi-bindgen-react-native/src/bindings/mod.rs
@@ -3,4 +3,106 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+
 pub(crate) mod react_native;
+
+use std::str::FromStr;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use clap::{command, Args};
+use uniffi_common::mk_dir;
+
+use self::react_native::ReactNativeBindingGenerator;
+
+#[derive(Args, Debug)]
+pub(crate) struct BindingsArgs {
+    #[command(flatten)]
+    source: SourceArgs,
+    #[command(flatten)]
+    output: OutputArgs,
+}
+
+#[derive(Args, Clone, Debug)]
+pub(crate) struct OutputArgs {
+    /// By default, bindgen will attempt to format the code with prettier and clang-format.
+    #[clap(long)]
+    no_format: bool,
+
+    /// The directory in which to put the generated Typescript.
+    #[clap(long)]
+    ts_dir: Utf8PathBuf,
+
+    /// The directory in which to put the generated C++.
+    #[clap(long)]
+    cpp_dir: Utf8PathBuf,
+}
+
+#[derive(Args, Clone, Debug)]
+pub(crate) struct SourceArgs {
+    /// The path to a dynamic library to attempt to extract the definitions from
+    /// and extend the component interface with.
+    #[clap(long)]
+    lib_file: Option<Utf8PathBuf>,
+
+    /// Override the default crate name that is guessed from UDL file path.
+    ///
+    /// In library mode, this
+    #[clap(long = "crate")]
+    crate_name: Option<String>,
+
+    /// The location of the uniffi.toml file
+    #[clap(long)]
+    config: Option<Utf8PathBuf>,
+
+    /// Treat the input file as a library, extracting any Uniffi definitions from that.
+    #[clap(long = "library", conflicts_with_all = ["config", "lib_file"])]
+    library_mode: bool,
+
+    /// A UDL file or library file
+    source: Utf8PathBuf,
+}
+
+impl BindingsArgs {
+    pub(crate) fn run(&self) -> Result<()> {
+        let input = &self.source;
+        let out = &self.output;
+
+        mk_dir(&out.ts_dir)?;
+        mk_dir(&out.cpp_dir)?;
+
+        let generator = ReactNativeBindingGenerator::new(out.clone());
+        let dummy_dir = Utf8PathBuf::from_str(".")?;
+
+        let try_format_code = !out.no_format;
+
+        if input.library_mode {
+            uniffi_bindgen::library_mode::generate_external_bindings(
+                &generator,
+                &input.source,
+                input.crate_name.clone(),
+                input.config.as_deref(),
+                &dummy_dir,
+                try_format_code,
+            )
+            .unwrap();
+        } else {
+            uniffi_bindgen::generate_external_bindings(
+                &generator,
+                input.source.clone(),
+                input.config.as_deref(),
+                Some(&dummy_dir),
+                input.lib_file.clone(),
+                input.crate_name.as_deref(),
+                try_format_code,
+            )
+            .unwrap();
+        }
+
+        if try_format_code {
+            let _ = generator.format_code();
+        }
+
+        Ok(())
+    }
+}

--- a/crates/uniffi-bindgen-react-native/src/main.rs
+++ b/crates/uniffi-bindgen-react-native/src/main.rs
@@ -5,55 +5,32 @@
  */
 mod bindings;
 
-use camino::Utf8PathBuf;
-use clap::Parser;
+use anyhow::Result;
+use clap::{Parser, Subcommand};
 
-use bindings::react_native::ReactNativeBindingGenerator;
+use bindings::BindingsArgs;
 
 #[derive(Parser)]
-struct Args {
-    #[clap(long, short)]
-    config: Option<Utf8PathBuf>,
-    #[clap(long, short)]
-    out_dir: Option<Utf8PathBuf>,
-    #[clap(long)]
-    no_format: bool,
-    #[clap(long)]
-    lib_file: Option<Utf8PathBuf>,
-    #[clap(long = "library", conflicts_with_all = ["config", "lib_file"], requires = "out_dir")]
-    library_mode: bool,
-    #[clap(long = "scaffolding")]
-    scaffolding_mode: bool,
-    #[clap(long = "crate")]
-    crate_name: Option<String>,
-    source: Utf8PathBuf,
+struct CliArgs {
+    #[command(subcommand)]
+    cmd: CliCmd,
 }
 
-fn main() {
-    let args = Args::parse();
+#[derive(Subcommand, Debug)]
+enum CliCmd {
+    /// Generates bindings from a Rust crate or UDL file
+    Bindings(BindingsArgs),
+}
 
-    let ts = ReactNativeBindingGenerator;
-
-    if args.library_mode {
-        uniffi_bindgen::library_mode::generate_external_bindings(
-            &ts,
-            &args.source,
-            args.crate_name,
-            args.config.as_deref(),
-            &args.out_dir.unwrap(),
-            !args.no_format,
-        )
-        .unwrap();
-    } else {
-        uniffi_bindgen::generate_external_bindings(
-            &ts,
-            args.source,
-            args.config.as_deref(),
-            args.out_dir,
-            args.lib_file,
-            args.crate_name.as_deref(),
-            !args.no_format,
-        )
-        .unwrap();
+impl CliCmd {
+    fn run(&self) -> Result<()> {
+        match self {
+            Self::Bindings(a) => a.run(),
+        }
     }
+}
+
+fn main() -> Result<()> {
+    let args = CliArgs::parse();
+    args.cmd.run()
 }

--- a/crates/uniffi-common/Cargo.toml
+++ b/crates/uniffi-common/Cargo.toml
@@ -7,3 +7,5 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
+glob = "0.3.1"
+which = "6.0.1"

--- a/crates/uniffi-common/src/files.rs
+++ b/crates/uniffi-common/src/files.rs
@@ -5,11 +5,16 @@
  */
 use std::fs;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use glob;
 
-pub fn resolve<P: AsRef<Utf8Path>>(path: P, file_suffix: &str) -> Result<Option<Utf8PathBuf>> {
-    let full_path = path.as_ref().canonicalize_utf8()?;
+/// Finds a file in the given directory.
+///
+/// If None exists, then search in the parent directory, recursively until it is found.
+/// If None is found, then return None.
+pub fn resolve<P: AsRef<Utf8Path>>(directory: P, file_suffix: &str) -> Result<Option<Utf8PathBuf>> {
+    let full_path = directory.as_ref().canonicalize_utf8()?;
     resolve_from_canonical(full_path, file_suffix)
 }
 
@@ -21,10 +26,38 @@ fn resolve_from_canonical<P: AsRef<Utf8Path>>(
     if full_path.exists() {
         Ok(Some(full_path))
     } else if let Some(parent) = path.as_ref().parent() {
-        resolve(parent, file_suffix)
+        resolve_from_canonical(parent, file_suffix)
     } else {
         Ok(None)
     }
+}
+
+/// Search the directory for a file with the given filename.
+///
+/// If none exists, return None.
+pub fn find<P: AsRef<Utf8Path>>(directory: P, filename: &str) -> Option<Utf8PathBuf> {
+    let path = glob::glob(&format!("{base}/**/{filename}", base = directory.as_ref()))
+        .unwrap()
+        .find_map(Result::ok)?;
+    let path: Utf8PathBuf = path.try_into().unwrap_or_else(|_| panic!("not a utf path"));
+    Some(path)
+}
+
+pub fn file_paths(pattern: &str) -> Result<Vec<std::ffi::OsString>, anyhow::Error> {
+    let files = glob::glob(pattern)?;
+    let files: Vec<_> = files
+        .into_iter()
+        .map(|pb| {
+            let file = pb.expect("is valid PathBuf");
+            file.into_os_string()
+        })
+        .collect();
+    Ok(files)
+}
+
+pub fn pwd() -> Result<Utf8PathBuf> {
+    let path = std::env::current_dir()?;
+    Ok(Utf8PathBuf::try_from(path)?)
 }
 
 pub fn rm_dir<P: AsRef<Utf8Path>>(dir: P) -> Result<()> {
@@ -32,4 +65,18 @@ pub fn rm_dir<P: AsRef<Utf8Path>>(dir: P) -> Result<()> {
         fs::remove_dir_all(dir.as_ref())?;
     }
     Ok(())
+}
+
+pub fn mk_dir<P: AsRef<Utf8Path>>(dir: P) -> Result<()> {
+    let dir = pwd()?.join(dir);
+    if dir.exists() {
+        if dir.is_dir() {
+            Ok(())
+        } else {
+            bail!("{dir} is supposed to be a directory but is not")
+        }
+    } else {
+        fs::create_dir_all(dir)?;
+        Ok(())
+    }
 }

--- a/crates/uniffi-common/src/fmt.rs
+++ b/crates/uniffi-common/src/fmt.rs
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use anyhow::Result;
+use camino::Utf8Path;
+use std::process::Command;
+use which::which;
+
+use crate::{file_paths, resolve};
+
+pub fn clang_format<P: AsRef<Utf8Path>>(path: P) -> Result<Option<Command>> {
+    if which("clang-format").is_err() {
+        return Ok(None);
+    }
+
+    let path = path.as_ref();
+    let mut cmd = Command::new("clang-format");
+    cmd.arg("-i")
+        .arg("--style=file")
+        .arg("--fallback-style=LLVM")
+        .args(file_paths(&format!("{path}/**/*.[ch]"))?)
+        .args(file_paths(&format!("{path}/**/*.[ch]pp"))?)
+        .current_dir(path);
+    Ok(Some(cmd))
+}
+
+pub fn prettier<P: AsRef<Utf8Path>>(out_dir: P) -> Result<Option<Command>> {
+    let prettier = resolve(&out_dir, "node_modules/.bin/prettier")?;
+    Ok(if let Some(prettier) = prettier {
+        let mut cmd = Command::new(prettier);
+        cmd.arg(".").arg("--write").current_dir(out_dir.as_ref());
+        Some(cmd)
+    } else {
+        None
+    })
+}

--- a/crates/uniffi-common/src/lib.rs
+++ b/crates/uniffi-common/src/lib.rs
@@ -5,6 +5,7 @@
  */
 mod commands;
 mod files;
+pub mod fmt;
 
 pub use commands::*;
 pub use files::*;

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 root=.
 
 for test in "${root}"/typescript/tests/*.test.ts ; do
@@ -13,17 +14,23 @@ for fixture in $(cd "${root}/fixtures" && ls) ; do
     fixture_dir="${root}/fixtures/${fixture}"
     cargo build --manifest-path "${fixture_dir}/Cargo.toml"
 
+    out_dir="${fixture_dir}/generated"
+    rm -Rf "${out_dir}" 2>/dev/null
+
+    cpp_dir="${out_dir}/cpp"
+    ts_dir="${out_dir}"
     # Generate the ts, cpp and hpp files into "${fixture_dir}/generated"
     # We should use the so or dylib file here but for now we can just use the UDL
     # fie.
-    cargo run --manifest-path "$uniffi_bindgen_manifest" -- \
+    RUST_BACKTRACE=1 cargo run --manifest-path "$uniffi_bindgen_manifest" -- \
+        bindings \
+        --ts-dir "${ts_dir}" --cpp-dir "${cpp_dir}" \
         "${fixture_dir}/src/${fixture}.udl" \
-        --out-dir "${fixture_dir}/generated"
     # This command discovers where the lib is, and builds the generated C++
     # against it and hermes. Optionally, it could build the crate for us.
     # Generate hermes flavoured JS from typescript, and runs the test.
     cargo xtask run "${fixture_dir}/tests/bindings/test_${fixture}.ts" \
-        --cpp "${fixture_dir}/generated/${fixture}.cpp" \
+        --cpp "${cpp_dir}/${fixture}.cpp" \
         --crate "${fixture_dir}" \
         --no-cargo
 done

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,5 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 cargo_metadata = "0.18.1"
 clap = { workspace = true }
-glob = "0.3.1"
 pathdiff = { version = "0.2.1", features = ["camino"] }
 uniffi-common = { path = "../crates/uniffi-common" }

--- a/xtask/src/run/typescript.rs
+++ b/xtask/src/run/typescript.rs
@@ -7,7 +7,7 @@ use std::{fs, process::Command};
 
 use crate::{
     bootstrap::{Bootstrap, YarnCmd},
-    util::{build_root, find, repository_root},
+    util::{build_root, repository_root},
 };
 
 use anyhow::Result;
@@ -15,7 +15,7 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
 use pathdiff::diff_utf8_paths;
-use uniffi_common::run_cmd_quietly;
+use uniffi_common::{find, run_cmd_quietly};
 
 fn typescript_dir() -> Result<Utf8PathBuf> {
     let root = repository_root()?;

--- a/xtask/src/util/mod.rs
+++ b/xtask/src/util/mod.rs
@@ -33,11 +33,3 @@ pub(crate) fn so_extension_name() -> &'static str {
         unimplemented!("Building only on windows, macos and unix supported right now")
     }
 }
-
-pub(crate) fn find<P: AsRef<Utf8Path>>(base: P, filename: &str) -> Option<Utf8PathBuf> {
-    let path = glob::glob(&format!("{base}/**/{filename}", base = base.as_ref()))
-        .unwrap()
-        .find_map(Result::ok)?;
-    let path: Utf8PathBuf = path.try_into().unwrap_or_else(|_| panic!("not a utf path"));
-    Some(path)
-}


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_m*n_) change. (with a small _m_)

This PR works on the command line of the `uniffi-bindgen-react-native`.

It changes it to use a subcommand for the existing functionality:

Previously:

```sh
uniffi-bindgen-react-native --out-dir ./generated --library target/debug/libfoo.dylib
```

Now:

```sh
uniffi-bindgen-react-native bindings --ts-out ./src/generated --cpp-out ./cpp/generated --library target/debug/libfoo.dylib
```

As part of this work, it turned out to be running the typescript formatter on the same files multiple times; this resulted in a refactor of the formatting, and rationalizing some duplicated code (from `xtask` and `uniffi-bindgen-react-native` crates) into the `uniffi_common` crate.