### PR TITLE
Export FfiConverters as default exports

### DIFF
--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/wrapper.ts
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/wrapper.ts
@@ -20,13 +20,15 @@ import {
 
 // Get converters from the other files, if any.
 {%- for entry in self.imported_converters.borrow() %}
-{%-   let uniffiConverters = entry.0 %}
+import {{ entry.0.1 }} from "{{ entry.0.0 }}";
+{%- endfor %}
+{%- for entry in self.imported_converters.borrow() %}
 {%-   let converters = entry.1 %}
 const {
 {%-   for converter in converters %}
         {{- converter }},
 {%-   endfor %}
-} = {{ uniffiConverters }};
+} = {{ entry.0.1 }};
 {%- endfor %}
 
 {%- call ts::docstring_value(ci.namespace_docstring(), 0) %}
@@ -49,7 +51,7 @@ import {{ config.ffi_module_name() }}
 {{ type_helper_code }}
 
 {% if !self.exported_converters.is_empty() %}
-export const uniffiConverters = Object.freeze({
+export default Object.freeze({
   {%- for converter in self.exported_converters.borrow() %}
   {{ converter }},
   {%- endfor %}


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR makes the change from FfiConverters being exposed as `uniffiConverters` in each of the generated modules to being exported as the default.

i.e.

```ts
import { FooBar } from './foo';

import uniffiConverters from './foo';
const { FfiConerterTypeFooBar } = uniffiConverters;
```

In the `index.ts` of the crates binding, this allows us to do:

```ts
export { * } from './foo'
export { * } from './bar'
```

so as to export all the generated API, but without the converters– and implementation detail of uniffi.