### PR TITLE
Linting based on first integration

### DIFF
--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -14,7 +14,7 @@ export class {{ type_name }} extends Error {
     }
     {% endfor -%}
     {% else %}
-    // non-flat errors aren't implement yet.
+    // non-flat errors aren't implemented yet.
     {%- endif %}
 }
 
@@ -37,7 +37,6 @@ const {{ ffi_converter_name }} = (() => {
             {%  endif %}
                 default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
-            throw new Error("Method not implemented.")
         }
         write(value: TypeName, into: RustBuffer): void {
             {%- if e.is_flat() %}
@@ -56,7 +55,6 @@ const {{ ffi_converter_name }} = (() => {
         allocationSize(value: TypeName): number {
             throw new Error("Method not implemented.")
         }
-
     }
     return new FfiConverter();
 })();

--- a/crates/uniffi-common/src/files.rs
+++ b/crates/uniffi-common/src/files.rs
@@ -7,7 +7,6 @@ use std::fs;
 
 use anyhow::{bail, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use glob;
 
 /// Finds a file in the given directory.
 ///

--- a/typescript/src/async-rust-call.ts
+++ b/typescript/src/async-rust-call.ts
@@ -5,8 +5,8 @@
  */
 import { UniffiHandleMap, type UniffiHandle } from "./handle-map";
 import {
-  UniffiErrorHandler,
-  UniffiRustCallStatus,
+  type UniffiErrorHandler,
+  type UniffiRustCallStatus,
   makeRustCall,
 } from "./rust-call";
 

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -37,7 +37,7 @@ export class RustBuffer {
     return value as T;
   }
 
-  write<T>(numBytes: number, writer: () => ArrayBuffer) {
+  write(numBytes: number, writer: () => ArrayBuffer) {
     const start = this.writeOffset;
     const end = this.checkOverflow(start, numBytes);
 

--- a/typescript/src/rust-call.ts
+++ b/typescript/src/rust-call.ts
@@ -4,7 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 import { UniffiInternalError } from "./errors";
-import { RustBuffer } from "./ffi-types";
 
 const CALL_SUCCESS = 0;
 const CALL_ERROR = 1;
@@ -82,7 +81,9 @@ function uniffiCheckCallStatus(
     }
 
     case CALL_CANCELLED:
-      new UniffiInternalError.Unimplemented("Cancellation not supported yet");
+      throw new UniffiInternalError.Unimplemented(
+        "Cancellation not supported yet",
+      );
 
     default:
       throw new UniffiInternalError.UnexpectedRustCallStatusCode();


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_m_) change.

This small PR has a series of one line fixes detected in the (mostly typescript) when integrating the first crate.