### PR TITLE
Typescript was unhappy when publishing the matrix-rust-sdk

### DIFF
--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -7,6 +7,7 @@ export class {{ type_name }} extends Error {
     }
     {%- if e.is_flat() %}
     {%-   for variant in e.variants() %}
+    {%-    call ts::docstring(variant, 4) %}
     {%-    let var_name = variant.name()|class_name(ci) %}
     static {{ var_name }}: typeof _{{ type_name }}_{{ var_name }};
     {% endfor -%}
@@ -16,7 +17,6 @@ export class {{ type_name }} extends Error {
 }
 {%- if e.is_flat() %}
 {%-   for variant in e.variants() %}
-{%-    call ts::docstring(variant, 4) %}
 {%-    let var_name = variant.name()|class_name(ci) %}
 class _{{ type_name }}_{{ var_name }} extends {{ type_name }} {
     constructor(message: string) { super(message); }

--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -2,21 +2,29 @@
 
 {%- call ts::docstring(e, 0) %}
 export class {{ type_name }} extends Error {
-    private constructor(message: string) {
+    constructor(message: string) {
         super(message);
     }
     {%- if e.is_flat() %}
     {%-   for variant in e.variants() %}
-    {%-    call ts::docstring(variant, 4) %}
     {%-    let var_name = variant.name()|class_name(ci) %}
-    static {{ var_name }} = class {{ var_name }} extends {{ type_name }} {
-        constructor(message: string) { super(message); }
-    }
+    static {{ var_name }}: typeof _{{ type_name }}_{{ var_name }};
     {% endfor -%}
     {% else %}
     // non-flat errors aren't implemented yet.
     {%- endif %}
 }
+{%- if e.is_flat() %}
+{%-   for variant in e.variants() %}
+{%-    call ts::docstring(variant, 4) %}
+{%-    let var_name = variant.name()|class_name(ci) %}
+class _{{ type_name }}_{{ var_name }} extends {{ type_name }} {
+    constructor(message: string) { super(message); }
+}
+{{ type_name }}.{{ var_name }} = _{{ type_name }}_{{ var_name }};
+{% endfor -%}
+{%- endif %}
+
 
 const {{ ffi_converter_name }} = (() => {
     const intConverter = FfiConverterInt32;

--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -22,7 +22,7 @@ class _{{ type_name }}_{{ var_name }} extends {{ type_name }} {
     constructor(message: string) { super(message); }
 }
 {{ type_name }}.{{ var_name }} = _{{ type_name }}_{{ var_name }};
-{% endfor -%}
+{%-  endfor %}
 {%- endif %}
 
 

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -6,7 +6,7 @@
 
 import { type FfiConverter, FfiConverterUInt64 } from "./ffi-converters";
 import { RustBuffer } from "./ffi-types";
-import { UniffiRustArcPtr } from "./rust-call";
+import type { UniffiRustArcPtr } from "./rust-call";
 
 /**
  * Marker interface for all `interface` objects that cross the FFI.

--- a/typescript/src/rust-call.ts
+++ b/typescript/src/rust-call.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 import { UniffiInternalError } from "./errors";
-import { UnsafeMutableRawPointer } from "./objects";
+import type { UnsafeMutableRawPointer } from "./objects";
 
 const CALL_SUCCESS = 0;
 const CALL_ERROR = 1;


### PR DESCRIPTION
The complexity of the anonymous classes was presenting challenges for Typescript compiler when trying to publish the matrix-rust-sdk.

The fix was to generate local classes, and refer to them in the static class, like so:
```
export class AuthenticationException extends Error {
  constructor(message: string) {
    super(message);
  }
  static ClientMissing: typeof _AuthenticationException_ClientMissing;

  static InvalidServerName: typeof _AuthenticationException_InvalidServerName;
   ...
}
class _AuthenticationException_ClientMissing extends AuthenticationException {
  constructor(message: string) {
    super(message);
  }
}
AuthenticationException.ClientMissing = _AuthenticationException_ClientMissing;

class _AuthenticationException_InvalidServerName extends AuthenticationException {
  constructor(message: string) {
    super(message);
  }
}
AuthenticationException.InvalidServerName =
  _AuthenticationException_InvalidServerName;
```

I don't know if the use of underscores is best here, but it seemed like something was needed to avoid name collisions at the top level.  Open to other conventions, since these aren't exported I figured it didn't matter *that* much?


Also found two errors with imports of Arc pointer types, where it wanted it to be `import type`.  It seems like the generated ones were already correct, there were just two hard-coded ones.