### PR TITLE
Make C++ buildable from iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": "https://github.com/jhugman/uniffi-bindgen-react-native.git",
   "license": "MPL-2.0",
-  "author": "James Hugman <james@hugman.tv>",
+  "author": {
+    "name": "James Hugman",
+    "email": "james@hugman.tv"
+  },
   "type": "module",
   "exports": {
     "./async-rust-call": "./typescript/src/async-rust-call.ts",

--- a/uniffi-bindgen-react-native.podspec
+++ b/uniffi-bindgen-react-native.podspec
@@ -1,0 +1,15 @@
+require 'json'
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name             = package['name']
+  s.version          = package['version']
+  s.summary          = package['description']
+  s.homepage         = package['homepage']
+  s.license          = { :type => package['license'], :file => 'LICENSE' }
+  s.author           = { package['author']['name'] => package['author']['email'] }
+  s.source           = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.platform     = :ios, '9.0'
+  s.source_files  = 'cpp/includes/*.{h,cpp,hpp}'
+  s.dependency 'React'
+end


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is a small addition to add the *.h files to Xcode for depending libraries.

Until we add this to a pod spec repository, the apps using depending libraries will need to add the following line to their Podfiles:

```ruby
pod 'uniffi-bindgen-react-native', :path => './node_modules/uniffi-bindgen-react-native'
```

After we add this to a pod spec repository, the depending libraries can add:

```ruby
s.dependency 'uniffi-bindgen-react-native'
```