### PR TITLE
Add cli to build rust for android and ios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1"
 camino = "1.1.6"
+cargo_metadata = "0.18.1"
 clap = { version = "4.5.4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 uniffi = "0.27.1"

--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -5,11 +5,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 #
 set -e
-root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-manifest_path="${root_dir}/crates/uniffi-bindgen-react-native/Cargo.toml"
-
-executable="$root_dir/target/debug/uniffi-bindgen-react-native"
-if [ ! -x "$executable" ]; then
-    cargo build --manifest-path "${manifest_path}"
+script_dir="$(dirname "${BASH_SOURCE[0]}")"
+if [[ "$script_dir" == *".bin" ]] ; then
+    root_dir="$(cd "$script_dir/../uniffi-bindgen-react-native" && pwd)"
+elif [[ "$script_dir" == *"bin" ]] ; then
+    root_dir="$(cd "$script_dir/.." && pwd)"
+else
+    echo "Unable to locate the uniffi-bindgen-react-native directory" 2>/dev/null
+    exit 1
 fi
- "$executable" "$@"
+
+manifest_path="${root_dir}/crates/cli/Cargo.toml"
+
+cargo run --manifest-path "${manifest_path}" -- "$@"

--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+#
+set -e
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+manifest_path="${root_dir}/crates/uniffi-bindgen-react-native/Cargo.toml"
+
+executable="$root_dir/target/debug/uniffi-bindgen-react-native"
+if [ ! -x "$executable" ]; then
+    cargo build --manifest-path "${manifest_path}"
+fi
+ "$executable" "$@"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "urn-cli"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "urn-cli"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+askama = "0.12.1"
+camino = { workspace = true }
+clap = { workspace = true }
+heck = "0.5.0"
+paste = "1.0.14"
+serde = { workspace = true }
+textwrap = "0.16.1"
+uniffi_bindgen = { workspace = true }
+uniffi_meta = { workspace = true }
+uniffi-common = { path = "../uniffi-common" }
+extend = "1.2.0"
+topological-sort = "0.2.2"

--- a/crates/cli/src/android.rs
+++ b/crates/cli/src/android.rs
@@ -41,6 +41,12 @@ pub(crate) struct AndroidConfig {
     pub(crate) package_name: String,
 }
 
+impl Default for AndroidConfig {
+    fn default() -> Self {
+        uniffi_common::default()
+    }
+}
+
 impl AndroidConfig {
     fn default_package_name() -> String {
         // TODO: derive this from package.json.

--- a/crates/cli/src/android.rs
+++ b/crates/cli/src/android.rs
@@ -1,0 +1,138 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use serde::Deserialize;
+use std::process::Command;
+
+use clap::Args;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use uniffi_common::{rm_dir, run_cmd};
+
+use crate::{
+    building::{CommonBuildArgs, ExtraArgs},
+    config::ProjectConfig,
+    workspace,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AndroidConfig {
+    #[serde(default = "AndroidConfig::default_directory")]
+    pub(crate) directory: String,
+
+    #[serde(default = "AndroidConfig::default_jni_libs")]
+    pub(crate) jni_libs: String,
+
+    #[serde(default = "AndroidConfig::default_targets")]
+    pub(crate) targets: Vec<String>,
+
+    #[serde(default = "AndroidConfig::default_cargo_extras")]
+    pub(crate) cargo_extras: ExtraArgs,
+
+    #[serde(default = "AndroidConfig::default_platform")]
+    pub(crate) api_level: usize,
+
+    #[allow(dead_code)]
+    #[serde(default = "AndroidConfig::default_package_name")]
+    pub(crate) package_name: String,
+}
+
+impl AndroidConfig {
+    fn default_package_name() -> String {
+        // TODO: derive this from package.json.
+        "com.example.rust.package".to_string()
+    }
+
+    fn default_cargo_extras() -> ExtraArgs {
+        let args: &[&str] = &[];
+        args.into()
+    }
+
+    fn default_targets() -> Vec<String> {
+        let args: &[&str] = &[
+            "aarch64-linux-android",
+            "armv7-linux-androideabi",
+            "i686-linux-android",
+            "x86_64-linux-android",
+        ];
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn default_platform() -> usize {
+        21
+    }
+
+    fn default_directory() -> String {
+        "android".to_string()
+    }
+
+    fn default_jni_libs() -> String {
+        "src/main/jniLibs".to_string()
+    }
+}
+
+impl AndroidConfig {
+    fn directory(&self) -> Result<Utf8PathBuf> {
+        Ok(workspace::project_root()?.join(&self.directory))
+    }
+
+    fn jni_libs(&self) -> Result<Utf8PathBuf> {
+        Ok(self.directory()?.join(&self.jni_libs))
+    }
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AndroidArgs {
+    /// The configuration file for this build
+    #[clap(long)]
+    config: Utf8PathBuf,
+
+    #[clap(flatten)]
+    common_args: CommonBuildArgs,
+}
+
+impl AndroidArgs {
+    pub(crate) fn build(&self) -> Result<()> {
+        let config: ProjectConfig = self.config.clone().try_into()?;
+        let crate_ = &config.crate_;
+        let rust_dir = crate_.directory()?;
+        let manifest_path = crate_.manifest_path()?;
+
+        let android = config.android;
+
+        let jni_libs = android.jni_libs()?;
+        rm_dir(&jni_libs)?;
+
+        for target in &android.targets {
+            let mut cmd = Command::new("cargo");
+            cmd.arg("ndk")
+                .arg("--manifest-path")
+                .arg(&manifest_path)
+                .arg("--target")
+                .arg(target)
+                .arg("--platform")
+                .arg(format!("{}", android.api_level))
+                .arg("--output-dir")
+                .arg(&jni_libs);
+
+            if !self.common_args.release {
+                cmd.arg("--no-strip");
+            }
+
+            cmd.arg("--").arg("build");
+            if self.common_args.release {
+                cmd.arg("--release");
+            }
+
+            cmd.args(android.cargo_extras.clone());
+
+            run_cmd(cmd.current_dir(&rust_dir))?
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/building.rs
+++ b/crates/cli/src/building.rs
@@ -7,8 +7,9 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use serde::Deserialize;
+use uniffi_common::CrateMetadata;
 
-use crate::android::AndroidArgs;
+use crate::{android::AndroidArgs, ios::IOsArgs};
 
 #[derive(Args, Debug)]
 pub(crate) struct BuildArgs {
@@ -19,6 +20,7 @@ pub(crate) struct BuildArgs {
 #[derive(Subcommand, Debug)]
 pub(crate) enum BuildCmd {
     Android(AndroidArgs),
+    Ios(IOsArgs),
 }
 
 impl BuildArgs {
@@ -31,6 +33,7 @@ impl BuildCmd {
     pub(crate) fn build(&self) -> Result<()> {
         match self {
             Self::Android(a) => a.build(),
+            Self::Ios(a) => a.build(),
         }
     }
 }
@@ -40,6 +43,12 @@ pub(crate) struct CommonBuildArgs {
     /// Build a release build
     #[clap(long, short, default_value = "false")]
     pub(crate) release: bool,
+}
+
+impl CommonBuildArgs {
+    pub(crate) fn profile<'a>(&self) -> &'a str {
+        CrateMetadata::profile(self.release)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/cli/src/building.rs
+++ b/crates/cli/src/building.rs
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use serde::Deserialize;
+
+use crate::android::AndroidArgs;
+
+#[derive(Args, Debug)]
+pub(crate) struct BuildArgs {
+    #[clap(subcommand)]
+    cmd: BuildCmd,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum BuildCmd {
+    Android(AndroidArgs),
+}
+
+impl BuildArgs {
+    pub(crate) fn build(&self) -> Result<()> {
+        self.cmd.build()
+    }
+}
+
+impl BuildCmd {
+    pub(crate) fn build(&self) -> Result<()> {
+        match self {
+            Self::Android(a) => a.build(),
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct CommonBuildArgs {
+    /// Build a release build
+    #[clap(long, short, default_value = "false")]
+    pub(crate) release: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum ExtraArgs {
+    AsList(Vec<String>),
+    AsString(String),
+}
+
+impl IntoIterator for ExtraArgs {
+    type Item = String;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            ExtraArgs::AsList(v) => v.into_iter(),
+            ExtraArgs::AsString(s) => s
+                .split_whitespace()
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>()
+                .into_iter(),
+        }
+    }
+}
+
+impl Default for ExtraArgs {
+    fn default() -> Self {
+        Self::AsList(Default::default())
+    }
+}
+
+impl From<&[&str]> for ExtraArgs {
+    fn from(value: &[&str]) -> Self {
+        let vec = value.iter().map(|&s| s.to_string()).collect();
+        ExtraArgs::AsList(vec)
+    }
+}

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use crate::{
+    building::BuildArgs,
+    repo::{CheckoutArgs, GitRepoArgs},
+    AsConfig,
+};
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+pub(crate) struct CliArgs {
+    #[command(subcommand)]
+    pub(crate) cmd: CliCmd,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum CliCmd {
+    /// Checkout a given Github repo into `rust_modules`
+    Checkout(CheckoutArgs),
+    /// Build for android, ios or testing
+    Build(BuildArgs),
+}
+
+impl CliCmd {
+    pub(crate) fn run(&self) -> Result<()> {
+        match self {
+            Self::Checkout(c) => AsConfig::<GitRepoArgs>::as_config(c)?.checkout(),
+            Self::Build(b) => b.build(),
+        }
+    }
+}

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use crate::{android::AndroidConfig, rust::CrateConfig};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProjectConfig {
+    #[serde(rename = "crate")]
+    pub(crate) crate_: CrateConfig,
+
+    #[serde(default)]
+    pub(crate) android: AndroidConfig,
+}

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -4,8 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-use crate::{android::AndroidConfig, rust::CrateConfig};
 use serde::Deserialize;
+
+use crate::{android::AndroidConfig, ios::IOsConfig, rust::CrateConfig};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,4 +16,7 @@ pub(crate) struct ProjectConfig {
 
     #[serde(default)]
     pub(crate) android: AndroidConfig,
+
+    #[serde(default)]
+    pub(crate) ios: IOsConfig,
 }

--- a/crates/cli/src/ios.rs
+++ b/crates/cli/src/ios.rs
@@ -3,3 +3,161 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+
+use std::process::Command;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use clap::Args;
+use serde::Deserialize;
+use uniffi_common::{rm_dir, run_cmd};
+
+use crate::{
+    building::{CommonBuildArgs, ExtraArgs},
+    config::ProjectConfig,
+    workspace,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IOsConfig {
+    #[serde(default = "IOsConfig::default_directory")]
+    pub(crate) directory: String,
+
+    #[serde(default = "IOsConfig::default_framework_name")]
+    pub(crate) framework_name: String,
+
+    #[serde(default = "IOsConfig::default_xcodebuild_extras")]
+    pub(crate) xcodebuild_extras: ExtraArgs,
+
+    #[serde(default = "IOsConfig::default_targets")]
+    pub(crate) targets: Vec<String>,
+
+    #[serde(default = "IOsConfig::default_cargo_extras")]
+    pub(crate) cargo_extras: ExtraArgs,
+}
+
+impl IOsConfig {
+    fn default_directory() -> String {
+        "ios".to_string()
+    }
+
+    fn default_framework_name() -> String {
+        // TODO: derive this from package.json.
+        "RustFramework".to_string()
+    }
+
+    fn default_cargo_extras() -> ExtraArgs {
+        let args: &[&str] = &[];
+        args.into()
+    }
+
+    fn default_xcodebuild_extras() -> ExtraArgs {
+        let args: &[&str] = &[];
+        args.into()
+    }
+
+    fn default_targets() -> Vec<String> {
+        let args: &[&str] = &[
+            "aarch64-apple-ios",
+            "x86_64-apple-ios",
+            // xcodebuild error:
+            // Both 'ios-arm64-simulator' and 'ios-x86_64-simulator'
+            // represent two equivalent library definitions.
+            // "aarch64-apple-ios-sim",
+        ];
+        args.iter().map(|s| s.to_string()).collect()
+    }
+}
+
+impl Default for IOsConfig {
+    fn default() -> Self {
+        uniffi_common::default()
+    }
+}
+
+impl IOsConfig {
+    pub(crate) fn directory(&self) -> Result<Utf8PathBuf> {
+        Ok(workspace::project_root()?.join(&self.directory))
+    }
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct IOsArgs {
+    /// The configuration file for this build
+    #[clap(long)]
+    config: Utf8PathBuf,
+
+    /// Only build for the simulator
+    #[clap(long, default_value = "false")]
+    sim_only: bool,
+
+    /// Exclude builds for the simulator
+    #[clap(long, conflicts_with_all = ["sim_only"], default_value = "false")]
+    no_sim: bool,
+
+    #[clap(flatten)]
+    common_args: CommonBuildArgs,
+}
+
+impl IOsArgs {
+    pub(crate) fn build(&self) -> Result<()> {
+        let config: ProjectConfig = self.config.clone().try_into()?;
+        let crate_ = &config.crate_;
+        let metadata = crate_.metadata()?;
+        let rust_dir = crate_.directory()?;
+        let profile = self.common_args.profile();
+        let manifest_path = crate_.manifest_path()?;
+
+        let ios = config.ios;
+        let mut library_args = Vec::default();
+        for target in &ios.targets {
+            if self.no_sim && target.contains("sim") {
+                continue;
+            }
+            if self.sim_only && !target.contains("sim") {
+                continue;
+            }
+
+            let mut cmd = Command::new("cargo");
+            cmd.arg("build")
+                .arg("--manifest-path")
+                .arg(&manifest_path)
+                .arg("--target")
+                .arg(target);
+            if self.common_args.release {
+                cmd.arg("--release");
+            }
+
+            cmd.args(ios.cargo_extras.clone());
+            run_cmd(cmd.current_dir(&rust_dir))?;
+
+            // Now we need to get the path to the lib.a file,
+            // to feed to xcodebuild.
+            let library = metadata.library_path(Some(target), profile)?;
+            if !library.exists() {
+                anyhow::bail!("Calculated library doesn't exist. This may be because `staticlib` is not in the `crate_type` list in the [[lib]] entry of Cargo.toml.");
+            }
+            // :eyes: single dash arg.
+            library_args.push("-library".to_string());
+            library_args.push(library.to_string());
+        }
+
+        let framework_name = format!("{}.xcframework", ios.framework_name);
+        let framework_path = ios.directory()?.join(framework_name);
+        if framework_path.exists() {
+            rm_dir(&framework_path)?;
+        }
+        let mut cmd = Command::new("xcodebuild");
+        // :eyes: single dash arg.
+        cmd.arg("-create-xcframework")
+            .args(library_args)
+            .arg("-output")
+            .arg(&framework_path)
+            .args(ios.xcodebuild_extras.clone());
+
+        run_cmd(cmd.current_dir(ios.directory()?))?;
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/ios.rs
+++ b/crates/cli/src/ios.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/crates/cli/src/repo.rs
+++ b/crates/cli/src/repo.rs
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::process::Command;
+
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::Args;
+use serde::Deserialize;
+use uniffi_common::run_cmd;
+
+use crate::{config::ProjectConfig, workspace, AsConfig};
+
+#[derive(Args, Clone, Debug, Deserialize)]
+pub(crate) struct GitRepoArgs {
+    /// The repository where to get the crate
+    pub(crate) repo: String,
+    /// The branch or tag which to checkout
+    #[clap(long, default_value = "main")]
+    #[serde(default = "GitRepoArgs::default_branch")]
+    pub(crate) branch: String,
+}
+
+impl GitRepoArgs {
+    fn default_branch() -> String {
+        "main".into()
+    }
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct CheckoutArgs {
+    #[clap(long, conflicts_with_all = ["repo"])]
+    config: Option<Utf8PathBuf>,
+
+    #[clap(flatten)]
+    repo: Option<GitRepoArgs>,
+}
+
+impl TryFrom<ProjectConfig> for GitRepoArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ProjectConfig) -> Result<Self> {
+        value.crate_.src.try_into()
+    }
+}
+
+impl AsConfig<GitRepoArgs> for CheckoutArgs {
+    fn config_file(&self) -> Option<Utf8PathBuf> {
+        self.config.clone()
+    }
+
+    fn get(&self) -> Option<GitRepoArgs> {
+        self.repo.clone()
+    }
+}
+
+impl GitRepoArgs {
+    pub(crate) fn directory(&self) -> Result<Utf8PathBuf> {
+        // Use Utf8Path for URL operations is a little bit hacky,
+        // but as we only need URL for this operation, we can avoid
+        // dragging in another dependency.
+        let url_path = Utf8Path::new(self.repo.as_str());
+        let repo_name = url_path.file_name().unwrap();
+        let repo_name = repo_name.strip_suffix(".git").unwrap_or(repo_name);
+        let root = workspace::project_root()?;
+        Ok(root.join("rust_modules").join(repo_name))
+    }
+
+    pub(crate) fn checkout(&self) -> Result<()> {
+        let mut cmd = Command::new("git");
+        cmd.arg("clone")
+            .arg(&self.repo)
+            .arg(self.directory()?)
+            .arg("--single-branch")
+            .arg("--branch")
+            .arg(&self.branch);
+        run_cmd(&mut cmd)
+    }
+}

--- a/crates/cli/src/rust.rs
+++ b/crates/cli/src/rust.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 
 use anyhow::{Error, Result};
 use camino::Utf8PathBuf;
+use uniffi_common::CrateMetadata;
 
 use crate::{repo::GitRepoArgs, workspace};
 
@@ -33,6 +34,10 @@ impl CrateConfig {
 
     pub(crate) fn manifest_path(&self) -> Result<Utf8PathBuf> {
         Ok(self.directory()?.join(&self.manifest_path))
+    }
+
+    pub(crate) fn metadata(&self) -> Result<CrateMetadata> {
+        self.manifest_path()?.try_into()
     }
 }
 

--- a/crates/cli/src/rust.rs
+++ b/crates/cli/src/rust.rs
@@ -1,0 +1,70 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use serde::Deserialize;
+
+use anyhow::{Error, Result};
+use camino::Utf8PathBuf;
+
+use crate::{repo::GitRepoArgs, workspace};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CrateConfig {
+    #[serde(default = "CrateConfig::default_manifest_path")]
+    pub(crate) manifest_path: String,
+    #[serde(flatten)]
+    pub(crate) src: RustSource,
+}
+
+impl CrateConfig {
+    fn default_manifest_path() -> String {
+        "Cargo.toml".to_string()
+    }
+}
+
+impl CrateConfig {
+    pub(crate) fn directory(&self) -> Result<Utf8PathBuf> {
+        self.src.directory()
+    }
+
+    pub(crate) fn manifest_path(&self) -> Result<Utf8PathBuf> {
+        Ok(self.directory()?.join(&self.manifest_path))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum RustSource {
+    OnDisk(OnDiskArgs),
+    GitRepo(GitRepoArgs),
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OnDiskArgs {
+    #[serde(alias = "rust")]
+    pub(crate) src: String,
+}
+
+impl RustSource {
+    pub(crate) fn directory(&self) -> Result<Utf8PathBuf> {
+        Ok(match self {
+            Self::OnDisk(OnDiskArgs { src }) => workspace::project_root()?.join(src),
+            Self::GitRepo(c) => c.directory()?,
+        })
+    }
+}
+
+impl TryFrom<RustSource> for GitRepoArgs {
+    type Error = Error;
+
+    fn try_from(value: RustSource) -> Result<Self> {
+        match value {
+            RustSource::GitRepo(args) => Ok(args),
+            _ => anyhow::bail!("Nothing to do"),
+        }
+    }
+}

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1,0 +1,11 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use anyhow::Result;
+use camino::Utf8PathBuf;
+
+pub(crate) fn project_root() -> Result<Utf8PathBuf> {
+    Ok(Utf8PathBuf::new())
+}

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -6,6 +6,15 @@
 use anyhow::Result;
 use camino::Utf8PathBuf;
 
+pub(crate) fn package_json() -> Result<Utf8PathBuf> {
+    let pwd = uniffi_common::pwd()?;
+
+    let package_json = uniffi_common::resolve(pwd, "package.json")?;
+    Ok(package_json.expect("Must be run under a directory containing a package.json file"))
+}
+
 pub(crate) fn project_root() -> Result<Utf8PathBuf> {
-    Ok(Utf8PathBuf::new())
+    let package_json = package_json()?;
+    let dir = package_json.parent().expect("Must be a directory");
+    Ok(dir.into())
 }

--- a/crates/uniffi-common/Cargo.toml
+++ b/crates/uniffi-common/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
+cargo_metadata = { workspace = true }
 glob = "0.3.1"
 serde = { workspace = true }
 serde_json = "1.0.117"

--- a/crates/uniffi-common/Cargo.toml
+++ b/crates/uniffi-common/Cargo.toml
@@ -8,4 +8,7 @@ publish = false
 anyhow = { workspace = true }
 camino = { workspace = true }
 glob = "0.3.1"
+serde = { workspace = true }
+serde_json = "1.0.117"
+serde_yaml = "0.9.34"
 which = "6.0.1"

--- a/crates/uniffi-common/src/files.rs
+++ b/crates/uniffi-common/src/files.rs
@@ -7,6 +7,7 @@ use std::fs;
 
 use anyhow::{bail, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use serde::Deserialize;
 
 /// Finds a file in the given directory.
 ///
@@ -78,4 +79,25 @@ pub fn mk_dir<P: AsRef<Utf8Path>>(dir: P) -> Result<()> {
         fs::create_dir_all(dir)?;
         Ok(())
     }
+}
+
+pub fn read_from_file<P, T>(file: P) -> Result<T>
+where
+    P: AsRef<Utf8Path>,
+    for<'a> T: Deserialize<'a>,
+{
+    let s = std::fs::read_to_string(file.as_ref())?;
+    Ok(if is_yaml(&file) {
+        serde_yaml::from_str(&s)?
+    } else {
+        serde_json::from_str(&s)?
+    })
+}
+
+fn is_yaml<P>(file: P) -> bool
+where
+    P: AsRef<Utf8Path>,
+{
+    let ext = file.as_ref().extension().unwrap_or_default();
+    ext == "yaml" || ext == "yml"
 }

--- a/crates/uniffi-common/src/lib.rs
+++ b/crates/uniffi-common/src/lib.rs
@@ -6,6 +6,8 @@
 mod commands;
 mod files;
 pub mod fmt;
+mod rust_crate;
 
 pub use commands::*;
 pub use files::*;
+pub use rust_crate::*;

--- a/crates/uniffi-common/src/lib.rs
+++ b/crates/uniffi-common/src/lib.rs
@@ -7,7 +7,9 @@ mod commands;
 mod files;
 pub mod fmt;
 mod rust_crate;
+mod serde;
 
 pub use commands::*;
 pub use files::*;
 pub use rust_crate::*;
+pub use serde::*;

--- a/crates/uniffi-common/src/rust_crate.rs
+++ b/crates/uniffi-common/src/rust_crate.rs
@@ -1,0 +1,159 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::process::Command;
+
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use cargo_metadata::{Metadata, MetadataCommand};
+
+use crate::run_cmd_quietly;
+
+#[derive(Debug, Clone)]
+pub struct CrateMetadata {
+    #[allow(unused)]
+    pub(crate) manifest_path: Utf8PathBuf,
+    pub(crate) crate_dir: Utf8PathBuf,
+    pub(crate) target_dir: Utf8PathBuf,
+    pub(crate) library_name: String,
+}
+
+impl CrateMetadata {
+    pub fn profile<'a>(release: bool) -> &'a str {
+        if release {
+            "release"
+        } else {
+            "debug"
+        }
+    }
+
+    pub fn library_path(&self, target: Option<&str>, profile: &str) -> Result<Utf8PathBuf> {
+        let ext = so_extension(target);
+        let library_name = format!("lib{}.{ext}", &self.library_name);
+        Ok(match target {
+            Some(t) => self.target_dir.join(t).join(profile).join(library_name),
+            None => self.target_dir.join(library_name),
+        })
+    }
+
+    pub fn target_dir(&self) -> &Utf8Path {
+        &self.target_dir
+    }
+
+    pub fn crate_dir(&self) -> &Utf8Path {
+        &self.crate_dir
+    }
+
+    pub fn library_name(&self) -> &str {
+        &self.library_name
+    }
+
+    pub fn cargo_clean(&self) -> Result<()> {
+        let mut cmd = Command::new("cargo");
+        run_cmd_quietly(cmd.arg("clean").current_dir(&self.crate_dir))?;
+        Ok(())
+    }
+}
+
+pub fn so_extension<'a>(target: Option<&str>) -> &'a str {
+    match target {
+        Some(t) => so_extension_from_target(t),
+        _ => so_extension_from_cfg(),
+    }
+}
+
+fn so_extension_from_target<'a>(target: &str) -> &'a str {
+    if target.contains("windows") {
+        "dll"
+    } else if target.contains("darwin") {
+        "dylib"
+    } else if target.contains("ios") {
+        "a"
+    } else if target.contains("android") {
+        "so"
+    } else {
+        unimplemented!("Building targeting only on android and ios supported right now")
+    }
+}
+
+fn so_extension_from_cfg<'a>() -> &'a str {
+    if cfg!(target_os = "windows") {
+        "dll"
+    } else if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "unix") {
+        "so"
+    } else {
+        unimplemented!("Building only on windows, macos and unix supported right now")
+    }
+}
+
+impl TryFrom<Utf8PathBuf> for CrateMetadata {
+    type Error = anyhow::Error;
+
+    fn try_from(manifest_path: Utf8PathBuf) -> Result<Self> {
+        let (manifest_path, crate_dir) = if !manifest_path.ends_with("Cargo.toml") {
+            if !manifest_path.is_dir() {
+                anyhow::bail!("Crate should either be a path to a Cargo.toml or a directory containing a Cargo.toml file");
+            }
+            (manifest_path.join("Cargo.toml"), manifest_path)
+        } else {
+            let crate_dir = manifest_path
+                .parent()
+                .expect("A valid parent for the crate manifest")
+                .into();
+            (manifest_path, crate_dir)
+        };
+        if !manifest_path.exists() {
+            anyhow::bail!("Crate manifest doesn't exist");
+        }
+        // Run `cargo metadata`
+        let metadata = MetadataCommand::new()
+            .manifest_path(&manifest_path)
+            .exec()?;
+
+        let library_name = guess_library_name(&metadata, &manifest_path.canonicalize_utf8()?);
+        let target_dir = metadata.target_directory;
+
+        Ok(Self {
+            manifest_path,
+            library_name,
+            target_dir,
+            crate_dir,
+        })
+    }
+}
+
+fn guess_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> String {
+    find_library_name(metadata, manifest_path).unwrap_or_else(|| {
+        find_package_name(metadata, manifest_path)
+            .expect("Neither a [[package]] `name` or a [[lib]] `name` were found in the manifest")
+            .replace('-', "_")
+    })
+}
+
+fn find_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<String> {
+    // Get the library name
+    let lib = "lib".to_owned();
+    metadata
+        .packages
+        .iter()
+        .find(|package| package.manifest_path == *manifest_path)
+        .and_then(|package| {
+            package
+                .targets
+                .iter()
+                .find(|target| target.kind.contains(&lib))
+        })
+        .map(|target| target.name.clone())
+}
+
+fn find_package_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<String> {
+    metadata
+        .packages
+        .iter()
+        .find(|package| package.manifest_path == *manifest_path)
+        .map(|package| package.name.clone())
+}

--- a/crates/uniffi-common/src/serde.rs
+++ b/crates/uniffi-common/src/serde.rs
@@ -1,0 +1,17 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use serde::de::DeserializeOwned;
+
+/// Convenience method to implement Default, but in terms of the `serde(default_value)` rather
+/// than `derive(Default)`.
+pub fn default<T>() -> T
+where
+    T: DeserializeOwned,
+{
+    let empty = serde_json::Value::Object(Default::default());
+    serde_json::from_value(empty).unwrap_or_else(|_| panic!("Failed to create default"))
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "./rust-call": "./typescript/src/rust-call.ts",
     "./records": "./typescript/src/records.ts"
   },
+  "bin": {
+    "uniffi-bindgen-react-native": "./bin/cli.sh"
+  },
   "devDependencies": {
     "metro": "^0.80.8",
     "metro-core": "^0.80.8",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,7 +11,6 @@ test = false
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
-cargo_metadata = "0.18.1"
 clap = { workspace = true }
 pathdiff = { version = "0.2.1", features = ["camino"] }
 uniffi-common = { path = "../crates/uniffi-common" }

--- a/xtask/src/run/cpp_bindings.rs
+++ b/xtask/src/run/cpp_bindings.rs
@@ -8,11 +8,11 @@ use std::{fs, process::Command};
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
-use uniffi_common::{rm_dir, run_cmd_quietly};
+use uniffi_common::{rm_dir, run_cmd_quietly, so_extension};
 
 use crate::{
     bootstrap::{Bootstrap, HermesCmd, TestRunnerCmd},
-    util::{build_root, so_extension_name},
+    util::build_root,
 };
 
 #[derive(Debug, Args)]
@@ -70,7 +70,7 @@ impl CppBindingArg {
         let mut cmd = Command::new("ninja");
         run_cmd_quietly(cmd.current_dir(&build_dir))?;
 
-        Ok(build_dir.join(format!("lib{extension_name}.{}", so_extension_name())))
+        Ok(build_dir.join(format!("lib{extension_name}.{}", so_extension(None))))
     }
 
     pub(crate) fn compile_without_crate(&self, clean: bool) -> Result<Utf8PathBuf> {
@@ -107,6 +107,6 @@ impl CppBindingArg {
         let mut cmd = Command::new("ninja");
         run_cmd_quietly(cmd.current_dir(&build_dir))?;
 
-        Ok(build_dir.join(format!("lib{extension_name}.{}", so_extension_name())))
+        Ok(build_dir.join(format!("lib{extension_name}.{}", so_extension(None))))
     }
 }

--- a/xtask/src/run/cpp_bindings.rs
+++ b/xtask/src/run/cpp_bindings.rs
@@ -62,7 +62,7 @@ impl CppBindingArg {
                 .arg(format!("-DHERMES_BUILD_DIR={}", &hermes_build))
                 .arg(format!("-DHERMES_EXTENSION_NAME={}", &extension_name))
                 .arg(format!("-DRUST_LIB_NAME={lib_name}"))
-                .arg(format!("-DRUST_TARGET_DIR={}", &target_dir))
+                .arg(format!("-DRUST_TARGET_DIR={}/debug", &target_dir))
                 .arg(format!("-DHERMES_EXTENSION_CPP={cpp_file}",))
                 .arg(&src_dir),
         )?;

--- a/xtask/src/util/mod.rs
+++ b/xtask/src/util/mod.rs
@@ -21,15 +21,3 @@ pub fn cpp_modules() -> Result<Utf8PathBuf> {
     let dir = repository_root()?;
     Ok(dir.join("cpp_modules"))
 }
-
-pub(crate) fn so_extension_name() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "dll"
-    } else if cfg!(target_os = "macos") {
-        "dylib"
-    } else if cfg!(target_os = "unix") {
-        "so"
-    } else {
-        unimplemented!("Building only on windows, macos and unix supported right now")
-    }
-}


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is part of a small project to add the developer UI to uniffi-bindgen-react-native.

There seems to be quite a lot of code here, but it's all fairly vanilla, lots of clap (command line parsing) and serde (config files).

The idea is that we have: 

- `uniffi-bindgen-react-native checkout         --config rondpoint.yaml`
- `uniffi-bindgen-react-native build android    --config rondpoint.yaml`
- `uniffi-bindgen-react-native build ios        --config rondpoint.yaml`

The config file format is currently (all with sensible defaults):

```yaml
crate:
  repo: https://github.com/matrix-org/matrix-rust-sdk
  branch: main
  manifestPath: bindings/matrix-sdk-ffi/Cargo.toml
android:
  directory: ./android
  jniLibs: src/main/jniLibs
  targets: 
    - aarch64-linux-android
    - x86_64-linux-android
  cargoExtras: ""
ios:
  directory: ./ios
  cargoExtras: ""
  xcodebuildExtras: ""
  targets:
    - aarch64-apple-ios
```

I'm not wedded to YAML, but like it because you can document things more easily than JSON.

Currently it loads YAML if it's called YAML and JSON if it's called JSON.