### PR TITLE
Add an entry point for react-native to initialize the module

### DIFF
--- a/cpp/includes/registerNatives.h
+++ b/cpp/includes/registerNatives.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hermes/hermes.h>
+#include <jsi/jsi.h>
 
 /// Register host functions into the given runtime.
 extern "C" void registerNatives(facebook::jsi::Runtime &rt);

--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -21,7 +21,7 @@ using namespace facebook;
 
 // Initialization into the Hermes Runtime
 extern "C" void registerNatives(jsi::Runtime &rt) {
-    rt.global().setProperty(rt, "{{ module_name }}", {{ module_name }}::makeNativeObject(rt));
+    {{ module_name }}::registerModule(rt);
 }
 
 {% include "RustCallStatus.cpp" %}
@@ -51,7 +51,15 @@ extern "C" {
     {%- endfor %}
 }
 
-jsi::Object {{ module_name }}::makeNativeObject(jsi::Runtime& rt) {
+void {{ module_name }}::registerModule(jsi::Runtime &rt) {
+    rt.global().setProperty(rt, "{{ module_name }}", {{ module_name }}::makeNativeObject(rt));
+}
+
+void {{ module_name }}::unregisterModule(jsi::Runtime &rt) {
+    // NOOP
+}
+
+jsi::Object {{ module_name }}::makeNativeObject(jsi::Runtime &rt) {
     auto obj = std::make_shared<{{ module_name }}>(rt);
     auto rval = rt.global().createFromHostObject(rt,obj);
 

--- a/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_cpp/templates/wrapper.hpp
+++ b/crates/uniffi-bindgen-react-native/src/bindings/react_native/gen_cpp/templates/wrapper.hpp
@@ -16,7 +16,24 @@ class {{ module_name }} : public jsi::HostObject {
   public:
     {{ module_name }}(jsi::Runtime &rt);
 
-    static jsi::Object makeNativeObject(jsi::Runtime& rt);
+    /**
+     * The entry point into the crate.
+     *
+     * React Native must call `{{ module_name }}.registerModule(rt)` before using
+     * the Javascript interface.
+     */
+    static void registerModule(jsi::Runtime &rt);
+
+    /**
+     * Some cleanup into the crate goes here.
+     *
+     * Current implementation is empty, however, this is not guaranteed to always be the case.
+     *
+     * Clients should call `{{ module_name }}.unregisterModule(rt)` after final use where possible.
+     */
+    static void unregisterModule(jsi::Runtime &rt);
+
+    static jsi::Object makeNativeObject(jsi::Runtime &rt);
 
     virtual ~{{ module_name }}();
 


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This small PR adds an entry point for react-native C++ to call into the generated binding.