### PR TITLE
Fix shared library handling for linux target.

### DIFF
--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -98,10 +98,10 @@ fn so_extension_from_cfg<'a>() -> &'a str {
         "dll"
     } else if cfg!(target_os = "macos") {
         "dylib"
-    } else if cfg!(target_os = "unix") {
+    } else if cfg!(target_os = "linux") {
         "so"
-    } else {
-        unimplemented!("Building only on windows, macos and unix supported right now")
+   } else {
+        unimplemented!("Building only on windows, macos and linux supported right now")
     }
 }
 


### PR DESCRIPTION
We previously handled a 'unix' target_os, however that's not a valid value ('unix' is a target family). The 'unix' target family would catch many platforms we don't want, so we specifically target linux.

See: https://stackoverflow.com/a/76480973
