### PR TITLE
Use module destructor to prevent dangling pointers

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/VTableCallbackFunction.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/VTableCallbackFunction.cpp
@@ -155,4 +155,12 @@ namespace {{ ns }} {
         };
         return callback;
     }
+
+    // This method is called from the destructor of {{ module_name }}, which only happens
+    // when the jsi::Runtime is being destroyed.
+    static void cleanup() {
+        // The lambda holds a reference to the the Runtime, so when this is nulled out,
+        // then the pointer will no longer be left dangling.
+        lambda = nullptr;
+    }
 } // namespace {{ ns }}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/macros.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/macros.cpp
@@ -145,6 +145,28 @@ _{{ arg.name() }}_{{ index }}
 {%- endfor %}
 {%- endmacro %}
 
+{#-
+// ns is the namespace used for the callback function.
+// It should match the value rendered by the callback_fn_namespace macro.
+#}
+{%- macro callback_fn_cleanup(callback) %}
+{%- let ns = callback.name()|ffi_callback_name|lower|fmt("uniffi_jsi::{}") %}
+{{- ns }}::cleanup();
+{%- endmacro %}
+
+{#-
+// ns is the namespace used for the free callback function.
+// It should match the value rendered by the callback_fn_namespace macro.
+#}
+{%- macro callback_fn_free_cleanup(callback) %}
+{%- call callback_fn_cleanup(callback) %}
+{%- for st in self.ci.iter_ffi_structs() %}
+{%- let ns = st.name()|lower|fmt("uniffi_jsi::{}::freecallback") %}
+{{- ns }}::cleanup();
+{%- endfor %}
+{%- endmacro %}
+
+
 {%- macro callback_fn_namespace(st, field) %}
 {%- if field.is_free() %}
 {#- // match the callback_fn_free_impl macro  #}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -116,7 +116,19 @@ void {{ module_name }}::set(jsi::Runtime& rt, const jsi::PropNameID& name, const
 }
 
 {{ module_name }}::~{{ module_name }}() {
-    // NOOP
+{%- for def in ci.ffi_definitions() %}
+{%-   match def %}
+{%-     when FfiDefinition::CallbackFunction(callback) %}
+{%-       if callback.is_user_callback() %}
+{%-         if callback.is_free_callback() %}
+{%-           call cpp::callback_fn_free_cleanup(callback) %}
+{%-         else %}
+{%-           call cpp::callback_fn_cleanup(callback) %}
+{%-         endif %}
+{%-       endif %}
+{%-     else %}
+{%-   endmatch %}
+{%- endfor %}
 }
 
 {%- include "StringHelper.cpp" %}


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This small PR adds a destructor to the Native module which nulls out the lambda which holds the dangling pointer to the `jsi::Runtime`.