### PR TITLE
Wrap callInvoker in a UniffiCallInvoker

### DIFF
--- a/cpp/includes/UniffiCallInvoker.h
+++ b/cpp/includes/UniffiCallInvoker.h
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+#pragma once
+#include <ReactCommon/CallInvoker.h>
+#include <future>
+#include <memory>
+#include <thread>
+
+namespace uniffi_runtime {
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+using CallFunc = std::function<void(jsi::Runtime &)>;
+
+/**
+ * A wrapper class to invoke a callback function on the JS thread.
+ *
+ * The is intended to have two methods: `invokeSync(func)` and
+ * `invokeAsync(func)`, one for invoking a callback that should return on the
+ * same thread it was invoked upon, and the other for invoking the callback and
+ * returning a promise.
+ */
+class UniffiCallInvoker {
+private:
+  std::shared_ptr<react::CallInvoker> callInvoker_;
+  std::thread::id threadId_;
+
+public:
+  UniffiCallInvoker(std::shared_ptr<react::CallInvoker> callInvoker)
+      : callInvoker_(callInvoker), threadId_(std::this_thread::get_id()) {}
+
+  /**
+   * Invokes the given function on the JS thread.
+   *
+   * If called from the JS thread, then the callback func is invoked
+   * immediately.
+   *
+   * Otherwise, the callback is invoked on the JS thread, and this thread blocks
+   * until it completes.
+   */
+  void invokeSync(jsi::Runtime &rt, CallFunc &func) {
+    if (std::this_thread::get_id() == threadId_) {
+      func(rt);
+    } else {
+      std::promise<void> promise;
+      auto future = promise.get_future();
+      callInvoker_->invokeAsync([&rt, &func, &promise]() {
+        func(rt);
+        promise.set_value();
+      });
+      future.wait();
+    }
+  }
+};
+} // namespace uniffi_runtime

--- a/cpp/includes/UniffiJsiTypes.h
+++ b/cpp/includes/UniffiJsiTypes.h
@@ -21,6 +21,7 @@
 #include "ForeignBytes.h"
 #include "ReferenceHolder.h"
 #include "RustBuffer.h"
+#include "UniffiCallInvoker.h"
 #include "UniffiString.h"
 
 #include "RustArcPtr.h"

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/VTableStruct.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/VTableStruct.cpp
@@ -3,7 +3,7 @@ namespace uniffi_jsi {
 using namespace facebook;
 
 template <> struct Bridging<{{ struct_name }}> {
-  static {{ struct_name }} fromJs(jsi::Runtime &rt, const jsi::Value &jsValue, std::shared_ptr<react::CallInvoker> callInvoker) {
+  static {{ struct_name }} fromJs(jsi::Runtime &rt, const jsi::Value &jsValue, std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker) {
     // Check if the input is an object
     if (!jsValue.isObject()) {
       throw jsi::JSError(rt, "Expected an object for {{ struct_name }}");

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -68,7 +68,7 @@ extern "C" {
 
 {{ module_name }}::{{ module_name }}(
     jsi::Runtime &rt,
-    std::shared_ptr<react::CallInvoker> invoker
+    std::shared_ptr<uniffi_runtime::UniffiCallInvoker> invoker
 ) : props(), callInvoker(invoker) {
     // Map from Javascript names to the cpp names
     {%- for func in ci.iter_ffi_functions_js_to_cpp() %}
@@ -85,7 +85,8 @@ extern "C" {
 }
 
 void {{ module_name }}::registerModule(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> callInvoker) {
-    auto tm = std::make_shared<{{ module_name }}>(rt, callInvoker);
+    auto invoker = std::make_shared<uniffi_runtime::UniffiCallInvoker>(callInvoker);
+    auto tm = std::make_shared<{{ module_name }}>(rt, invoker);
     auto obj = rt.global().createFromHostObject(rt, tm);
     rt.global().setProperty(rt, "{{ module_name }}", obj);
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.hpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.hpp
@@ -6,23 +6,24 @@
 #include <map>
 #include <memory>
 #include <ReactCommon/CallInvoker.h>
-
+#include "UniffiCallInvoker.h"
 
 namespace react = facebook::react;
 namespace jsi = facebook::jsi;
 
 class {{ module_name }} : public jsi::HostObject {
+  private:
+    // For calling back into JS from Rust.
+    std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker;
+
   protected:
     std::map<std::string,jsi::Value> props;
     {%- for func in ci.iter_ffi_functions_js_to_cpp() %}
     jsi::Value {% call cpp::cpp_func_name(func) %}(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     {%- endfor %}
 
-    // For calling back into JS from Rust.
-    std::shared_ptr<react::CallInvoker> callInvoker;
-
   public:
-    {{ module_name }}(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> callInvoker);
+    {{ module_name }}(jsi::Runtime &rt, std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker);
     virtual ~{{ module_name }}();
 
     /**


### PR DESCRIPTION
This PR introduces a `UniffiCallInvoker` to isolate the logic of calling functions that return a promise and don't return a promise, when called from Rust regardless of which thread it is executed on.

This PR only deals with calling JS functions that do not return a promise (i.e. non-async ones).