### PR TITLE
Add async primary constructors

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
@@ -37,7 +37,11 @@ impl CodeOracle {
 
     /// Get the idiomatic Typescript rendering of a function name.
     pub(crate) fn fn_name(&self, nm: &str) -> String {
-        rewrite_keywords(nm.to_string().to_lower_camel_case())
+        if nm == "new" {
+            "create".to_string()
+        } else {
+            rewrite_keywords(nm.to_string().to_lower_camel_case())
+        }
     }
 
     /// Get the idiomatic Typescript rendering of a variable name.

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -76,21 +76,11 @@
 {%- macro ctor_decl(obj_factory, callable, indent) %}
 {%- call docstring(callable, indent) %}
     constructor(
-    {%- call arg_list_decl(callable) -%}) {%- call async(callable) %} {%- call throws(callable) %} {
-    {%- if callable.is_async() %}
-        const pointer =
-            {%- call call_async(obj_factory, callable) %}
-            {# The async mechanism returns an already constructed self.
-            We work around that by cloning the pointer from that object, then
-            assune the old object dies as there are no other references possible.
-            #}
-            .uniffiClonePointer()
-        {%- else %}
+    {%- call arg_list_decl(callable) -%}) {%- call throws(callable) %} {
         super();
         const pointer =
             {% call to_ffi_method_call(obj_factory, callable) %};
         this._rustArcPtr = {{ obj_factory }}.bless(pointer);
-    {%- endif %}
     }
 {%- endmacro %}
 


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR rewrites primary constructors that are async into `public static async` constructor methods.