### PR TITLE
Generate test files from library file, rather than UDL

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod react_native;
 use std::str::FromStr;
 
 use anyhow::Result;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::{command, Args};
 use ubrn_common::mk_dir;
 
@@ -24,6 +24,20 @@ pub struct BindingsArgs {
     source: SourceArgs,
     #[command(flatten)]
     output: OutputArgs,
+}
+
+impl BindingsArgs {
+    pub fn new(source: SourceArgs, output: OutputArgs) -> Self {
+        Self { source, output }
+    }
+
+    pub fn ts_dir(&self) -> &Utf8Path {
+        &self.output.ts_dir
+    }
+
+    pub fn cpp_dir(&self) -> &Utf8Path {
+        &self.output.cpp_dir
+    }
 }
 
 #[derive(Args, Clone, Debug)]
@@ -41,7 +55,17 @@ pub struct OutputArgs {
     cpp_dir: Utf8PathBuf,
 }
 
-#[derive(Args, Clone, Debug)]
+impl OutputArgs {
+    pub fn new(ts_dir: &Utf8Path, cpp_dir: &Utf8Path, no_format: bool) -> Self {
+        Self {
+            ts_dir: ts_dir.to_owned(),
+            cpp_dir: cpp_dir.to_owned(),
+            no_format,
+        }
+    }
+}
+
+#[derive(Args, Clone, Debug, Default)]
 pub struct SourceArgs {
     /// The path to a dynamic library to attempt to extract the definitions from
     /// and extend the component interface with.
@@ -64,6 +88,16 @@ pub struct SourceArgs {
 
     /// A UDL file or library file
     source: Utf8PathBuf,
+}
+
+impl SourceArgs {
+    pub fn library(file: &Utf8PathBuf) -> Self {
+        Self {
+            library_mode: true,
+            source: file.clone(),
+            ..Default::default()
+        }
+    }
 }
 
 impl BindingsArgs {

--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -33,7 +33,7 @@ impl CrateMetadata {
         let library_name = self.library_file(target);
         Ok(match target {
             Some(t) => self.target_dir.join(t).join(profile).join(library_name),
-            None => self.target_dir.join(library_name),
+            None => self.target_dir.join(profile).join(library_name),
         })
     }
 
@@ -100,7 +100,7 @@ fn so_extension_from_cfg<'a>() -> &'a str {
         "dylib"
     } else if cfg!(target_os = "linux") {
         "so"
-   } else {
+    } else {
         unimplemented!("Building only on windows, macos and linux supported right now")
     }
 }
@@ -142,11 +142,13 @@ impl TryFrom<Utf8PathBuf> for CrateMetadata {
 }
 
 fn guess_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> String {
-    find_library_name(metadata, manifest_path).unwrap_or_else(|| {
-        find_package_name(metadata, manifest_path)
-            .expect("Neither a [[package]] `name` or a [[lib]] `name` were found in the manifest")
-            .replace('-', "_")
-    })
+    find_library_name(metadata, manifest_path)
+        .unwrap_or_else(|| {
+            find_package_name(metadata, manifest_path).expect(
+                "Neither a [[package]] `name` or a [[lib]] `name` were found in the manifest",
+            )
+        })
+        .replace('-', "_")
 }
 
 fn find_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<String> {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,8 +3,9 @@ set -e
 root=.
 
 for test in "${root}"/typescript/tests/*.test.ts ; do
-    echo "Running $test"
+    echo "Running test $test"
     cargo xtask run "${test}"
+    echo
 done
 
 declare -a selected_fixtures=()
@@ -29,37 +30,33 @@ done
 if [ ${#selected_fixtures[@]} -eq 0 ]; then
     fixtures=$(cd "${root}/fixtures" && ls)
 else
-    fixtures=${selected_fixtures[@]}
+    fixtures=${selected_fixtures[*]}
 fi
 
-uniffi_bindgen_manifest="${root}/crates/ubrn_cli/Cargo.toml"
 for fixture in ${fixtures} ; do
     if [[ " ${excluded_fixtures[@]} " =~ " ${fixture} " ]]; then
         continue
     fi
+    echo "Running fixture ${fixture}"
     # This should all go in either an xtask or into our uniffi-bindgen command.
     # This builds the crate into the target dir.
     fixture_dir="${root}/fixtures/${fixture}"
-    cargo build --manifest-path "${fixture_dir}/Cargo.toml"
+    test_file="${fixture_dir}/tests/bindings/test_${fixture//-/_}.ts"
 
     out_dir="${fixture_dir}/generated"
     rm -Rf "${out_dir}" 2>/dev/null
 
     cpp_dir="${out_dir}/cpp"
     ts_dir="${out_dir}"
-    # Generate the ts, cpp and hpp files into "${fixture_dir}/generated"
-    # We should use the so or dylib file here but for now we can just use the UDL
-    # fie.
-    RUST_BACKTRACE=1 cargo run --manifest-path "$uniffi_bindgen_manifest" -- \
-        generate \
-        bindings \
-        --ts-dir "${ts_dir}" --cpp-dir "${cpp_dir}" \
-        "${fixture_dir}/src/${fixture}.udl" \
-    # This command discovers where the lib is, and builds the generated C++
-    # against it and hermes. Optionally, it could build the crate for us.
+    # This command discovers where the lib is, generates the ts, cpp and hpp files,
+    # and builds the generated C++ against it and hermes.
+    # Optionally, it could build the crate for us.
     # Generate hermes flavoured JS from typescript, and runs the test.
-    cargo xtask run "${fixture_dir}/tests/bindings/test_${fixture}.ts" \
-        --cpp "${cpp_dir}/${fixture}.cpp" \
+    cargo xtask run \
+        --no-cargo \
+        --cpp-dir "${cpp_dir}" \
+        --ts-dir "${ts_dir}" \
         --crate "${fixture_dir}" \
-        --no-cargo
+        "${test_file}"
+    echo
 done

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,4 +13,5 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true }
 pathdiff = { workspace = true }
+ubrn_bindgen = { path = "../crates/ubrn_bindgen" }
 ubrn_common = { path = "../crates/ubrn_common" }

--- a/xtask/src/run/generate_bindings.rs
+++ b/xtask/src/run/generate_bindings.rs
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use clap::Args;
+use ubrn_bindgen::{BindingsArgs, OutputArgs, SourceArgs};
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct GenerateBindingsArg {
+    /// Directory for the generated Typescript to put in.
+    #[clap(long, requires = "cpp_dir")]
+    pub(crate) ts_dir: Option<Utf8PathBuf>,
+    /// Directory for the generated C++ to put in.
+    #[clap(long, requires = "ts_dir")]
+    pub(crate) cpp_dir: Option<Utf8PathBuf>,
+}
+
+impl GenerateBindingsArg {
+    fn ts_dir(&self) -> Utf8PathBuf {
+        self.ts_dir.clone().unwrap()
+    }
+
+    fn cpp_dir(&self) -> Utf8PathBuf {
+        self.cpp_dir.clone().unwrap()
+    }
+
+    pub(crate) fn generate(&self, library: &Utf8PathBuf) -> Result<Vec<Utf8PathBuf>> {
+        let output = OutputArgs::new(&self.ts_dir(), &self.cpp_dir(), false);
+        let source = SourceArgs::library(library);
+        let bindings = BindingsArgs::new(source, output);
+        let modules = bindings.run()?;
+        let cpp_dir = bindings.cpp_dir();
+        Ok(modules
+            .iter()
+            .map(|m| cpp_dir.join(m.cpp_filename()))
+            .collect())
+    }
+}


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR finishes off the `cargo xtask run` command for running test files.

As we start the newer fixtures and examples, we are no longer able to rely on UDL files: instead we have to use the compiled `.so`/`.dylib` files which include the whole `ComponentInterface` derived from the proc_macros as well as UDL files.