### PR TITLE
Add event loop to test-runner

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ build/
 *.template.json
 *.md
 package.json
+*.js.inc

--- a/cpp/stubs/ReactCommon/CallInvoker.h
+++ b/cpp/stubs/ReactCommon/CallInvoker.h
@@ -59,25 +59,3 @@ public:
   virtual ~NativeMethodCallInvoker() {}
 };
 } // namespace facebook::react
-
-namespace uniffi::testing {
-class MyCallInvoker : public facebook::react::CallInvoker {
-private:
-  facebook::jsi::Runtime &runtime_;
-
-public:
-  MyCallInvoker(facebook::jsi::Runtime &runtime) : runtime_(runtime) {}
-
-  void invokeAsync(facebook::react::CallFunc &&func) noexcept override {
-    // Implement this method with your own logic
-    // You can use runtime_ here
-  }
-
-  void invokeSync(facebook::react::CallFunc &&func) override {
-    // Implement this method with your own logic
-    // You can use runtime_ here
-  }
-
-  ~MyCallInvoker() override {}
-};
-} // namespace uniffi::testing

--- a/cpp/test-harness/MyCallInvoker.h
+++ b/cpp/test-harness/MyCallInvoker.h
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+#include <ReactCommon/CallInvoker.h>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <queue>
+
+namespace uniffi::testing {
+class MyCallInvoker : public facebook::react::CallInvoker {
+private:
+  facebook::jsi::Runtime &runtime_;
+  std::queue<facebook::react::CallFunc> tasks_;
+  mutable std::mutex queueMutex_;
+  std::condition_variable newTaskCond_;
+
+public:
+  MyCallInvoker(facebook::jsi::Runtime &runtime) : runtime_(runtime) {}
+
+  void invokeAsync(facebook::react::CallFunc &&func) noexcept override {
+    {
+      std::lock_guard<std::mutex> lock(queueMutex_);
+      tasks_.push(std::move(func));
+    }
+    newTaskCond_.notify_one();
+  }
+
+  void invokeSync(facebook::react::CallFunc &&func) override {
+    // Implement this method with your own logic
+    // You can use runtime_ here
+  }
+
+  std::optional<facebook::react::CallFunc> nextTask() {
+    std::lock_guard<std::mutex> lock(queueMutex_);
+    if (tasks_.empty()) {
+      return std::nullopt; // Return an empty optional
+    }
+    auto task = std::move(tasks_.front());
+    tasks_.pop();
+    return task; // Return the task wrapped in an optional
+  }
+
+  bool waitForTaskOrTimeout(double duration) {
+    auto timeout = std::chrono::milliseconds((int_least64_t)duration);
+    std::unique_lock<std::mutex> lock(queueMutex_);
+    newTaskCond_.wait_for(lock, timeout, [this] { return !tasks_.empty(); });
+    return !tasks_.empty();
+  }
+
+  bool isEmpty() const {
+    std::lock_guard<std::mutex> lock(queueMutex_);
+    return tasks_.empty();
+  }
+
+  void drainTasks(facebook::jsi::Runtime &runtime) {
+    while (true) {
+      auto optionalFunc = this->nextTask();
+      if (!optionalFunc.has_value()) {
+        return;
+      }
+      auto &func = *optionalFunc;
+      func(runtime);
+    }
+  }
+
+  ~MyCallInvoker() override {}
+};
+} // namespace uniffi::testing

--- a/cpp/test-harness/timers.js.inc
+++ b/cpp/test-harness/timers.js.inc
@@ -1,0 +1,60 @@
+R"((function() {
+    "use strict";
+
+    var tasks = [];
+    var nextTaskID = 0;
+    var curTime = 0;
+
+    // Return the deadline of the next task, or -1 if there is no task.
+    function peekMacroTask() {
+        return tasks.length ? tasks[0].deadline : -1;
+    }
+
+    // Run the next task if it's time.
+    // `tm` is the current time.
+    function runMacroTask(tm) {
+        curTime = tm;
+        if (tasks.length && tasks[0].deadline <= tm) {
+            var task = tasks.shift();
+            task.fn.apply(undefined, task.args);
+        }
+    }
+
+    function setTimeout(fn, ms = 0, ...args) {
+        var id = nextTaskID++;
+        var task = {id, fn, deadline: curTime + Math.max(0, ms | 0), args};
+        // Insert the task in the sorted list.
+        var i = 0;
+        for (i = 0; i < tasks.length; ++i) {
+            if (tasks[i].deadline > task.deadline) {
+                break;
+            }
+        }
+        tasks.splice(i, 0, task);
+        return id;
+    }
+
+    function clearTimeout(id) {
+        for (var i = 0; i < tasks.length; i++) {
+            if (tasks[i].id === id) {
+                tasks.splice(i, 1);
+                break;
+            }
+        }
+    }
+
+    function setImmediate(fn, ...args) {
+        return setTimeout(fn, 0, ...args);
+    }
+    function clearImmediate(id) {
+        return clearTimeout(id);
+    }
+
+    globalThis.setTimeout = setTimeout;
+    globalThis.clearTimeout = clearTimeout;
+    globalThis.setImmediate = setImmediate;
+    globalThis.clearImmediate = clearImmediate;
+
+    return {peek: peekMacroTask, run: runMacroTask};
+})();
+)"

--- a/fixtures/arithmetic/tests/bindings/test_arithmetic.ts
+++ b/fixtures/arithmetic/tests/bindings/test_arithmetic.ts
@@ -8,13 +8,19 @@
 // cargo xtask run ./fixtures/${fixture}/tests/bindings/test_${fixture}.ts --cpp ./fixtures/${fixture}/generated/${fixture}.cpp --crate ./fixtures/${fixture}
 
 import * as rust from "../../generated/arithmetic";
-import { assertEqual } from "@/asserts";
+import { test } from "@/asserts";
 import { console } from "@/hermes";
 
 const a = BigInt(39);
 const b = BigInt(3);
 
-console.log(`${a} + ${b} = ${rust.add(a, b)}`);
-assertEqual(a + b, rust.add(a, b));
-assertEqual(a - b, rust.sub(a, b));
-assertEqual(a / b, rust.div(a, b));
+test("add", (t) => {
+  console.log(`${a} + ${b} = ${rust.add(a, b)}`);
+  t.assertEqual(a + b, rust.add(a, b));
+});
+test("sub", (t) => {
+  t.assertEqual(a - b, rust.sub(a, b));
+});
+test("div", (t) => {
+  t.assertEqual(a / b, rust.div(a, b));
+});

--- a/fixtures/callbacks/tests/bindings/test_callbacks.ts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.ts
@@ -11,14 +11,7 @@ import {
   RustGetters,
   StoredForeignStringifier,
 } from "../../generated/callbacks";
-import {
-  assertEqual,
-  assertNull,
-  assertThrows,
-  fail,
-  test,
-  xtest,
-} from "@/asserts";
+import { test } from "@/asserts";
 
 const BAD_ARGUMENT = "bad-argument";
 const UNEXPECTED_ERROR = "unexpected-error";
@@ -69,60 +62,60 @@ class TypeScriptGetters implements ForeignGetters {
   }
 }
 
-test("Boolean values passed between callback interfaces", () => {
+test("Boolean values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
   const flag = true;
   for (const v of inputData.boolean) {
     const expected = callbackInterface.getBool(v, flag);
     const observed = rg.getBool(callbackInterface, v, flag);
-    assertEqual(observed, expected);
+    t.assertEqual(observed, expected);
   }
   rg.uniffiDestroy();
 });
 
-test("List values passed between callback interfaces", () => {
+test("List values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
   const flag = true;
   for (const v of inputData.string) {
     const expected = callbackInterface.getString(v, flag);
     const observed = rg.getString(callbackInterface, v, flag);
-    assertEqual(observed, expected);
+    t.assertEqual(observed, expected);
   }
   rg.uniffiDestroy();
 });
 
-test("String values passed between callback interfaces", () => {
+test("String values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
   const flag = true;
   for (const v of inputData.listInt) {
     const expected = callbackInterface.getList(v, flag);
     const observed = rg.getList(callbackInterface, v, flag);
-    assertEqual(observed, expected);
+    t.assertEqual(observed, expected);
   }
   rg.uniffiDestroy();
 });
 
-test("Optional callbacks serialized correctly", () => {
+test("Optional callbacks serialized correctly", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  assertEqual(
+  t.assertEqual(
     rg.getStringOptionalCallback(callbackInterface, "TestString", false),
     "TestString",
   );
-  assertNull(rg.getStringOptionalCallback(undefined, "TestString", false));
+  t.assertNull(rg.getStringOptionalCallback(undefined, "TestString", false));
   rg.uniffiDestroy();
 });
 
-test("Errors are propagated correctly", () => {
+test("Errors are propagated correctly", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  assertThrows("SimpleException.BadArgument", () =>
+  t.assertThrows("SimpleException.BadArgument", () =>
     rg.getNothing(callbackInterface, BAD_ARGUMENT),
   );
-  assertThrows("SimpleException.UnexpectedError", () =>
+  t.assertThrows("SimpleException.UnexpectedError", () =>
     rg.getNothing(callbackInterface, UNEXPECTED_ERROR),
   );
   rg.uniffiDestroy();
@@ -146,12 +139,12 @@ class StoredTypeScriptStringifier implements StoredForeignStringifier {
     }
   }
 }
-test("A callback passed into the constructor", () => {
+test("A callback passed into the constructor", (t) => {
   const stringifierCallback = new StoredTypeScriptStringifier();
   const rustStringifier = new RustStringifier(stringifierCallback);
 
   const expected = stringifierCallback.fromSimpleType(42);
   const observed = rustStringifier.fromSimpleType(42);
 
-  assertEqual(observed, expected);
+  t.assertEqual(observed, expected);
 });

--- a/fixtures/coverall/tests/bindings/test_coverall.ts
+++ b/fixtures/coverall/tests/bindings/test_coverall.ts
@@ -15,82 +15,70 @@ import {
   createSomeDict,
   getNumAlive,
 } from "../../generated/coverall";
-import {
-  assertEqual,
-  assertFalse,
-  assertThrows,
-  assertTrue,
-  fail,
-  test,
-  xtest,
-} from "@/asserts";
+import { test } from "@/asserts";
 import { console } from "@/hermes";
 
 // floats should be "close enough".
 const almostEquals = (this_: number, that: number): boolean =>
   Math.abs(this_ - that) < 0.000001;
 
-test("test create_some_dict() with default values", () => {
+test("test create_some_dict() with default values", (t) => {
   const d = createSomeDict();
-  assertEqual(d.text, "text");
-  assertEqual(d.maybeText, "maybe_text");
+  t.assertEqual(d.text, "text");
+  t.assertEqual(d.maybeText, "maybe_text");
   // Hermes doesn't support string --> ArrayBuffer
-  // assertEqual(d.someBytes.contentEquals("some_bytes".toByteArray(Charsets.UTF_8)))
-  // assertEqual(d.maybeSomeBytes.contentEquals("maybe_some_bytes".toByteArray(Charsets.UTF_8)))
-  assertTrue(d.aBool);
-  assertEqual(d.maybeABool, false);
-  assertEqual(d.unsigned8, 1);
-  assertEqual(d.maybeUnsigned8, 2);
-  assertEqual(d.unsigned16, 3);
-  assertEqual(d.maybeUnsigned16, 4);
-  // Test failing: observed: 18446744073709551616
-  // assertEqual(d.unsigned64, BigInt("18446744073709551615"))
-  assertEqual(d.maybeUnsigned64, BigInt("0"));
-  assertEqual(d.signed8, 8);
-  assertEqual(d.maybeSigned8, 0);
-  // Test failing: observed: 9223372036854775808
-  // assertEqual(d.signed64, BigInt("9223372036854775807"))
-  assertEqual(d.maybeSigned64, BigInt("0"));
+  // t.assertEqual(d.someBytes.contentEquals("some_bytes".toByteArray(Charsets.UTF_8)))
+  // t.assertEqual(d.maybeSomeBytes.contentEquals("maybe_some_bytes".toByteArray(Charsets.UTF_8)))
+  t.assertTrue(d.aBool);
+  t.assertEqual(d.maybeABool, false);
+  t.assertEqual(d.unsigned8, 1);
+  t.assertEqual(d.maybeUnsigned8, 2);
+  t.assertEqual(d.unsigned16, 3);
+  t.assertEqual(d.maybeUnsigned16, 4);
+  t.assertEqual(d.unsigned64, BigInt("0x10000000000000000"));
+  t.assertEqual(d.maybeUnsigned64, BigInt("0"));
+  t.assertEqual(d.signed8, 8);
+  t.assertEqual(d.maybeSigned8, 0);
+  t.assertEqual(d.signed64, BigInt("0x8000000000000000"));
+  t.assertEqual(d.maybeSigned64, BigInt("0"));
 
-  assertEqual(d.float32, 1.2345, undefined, almostEquals);
-  assertEqual(d.maybeFloat32!, 22.0 / 7.0, undefined, almostEquals);
-  assertEqual(d.float64, 0, undefined, almostEquals);
-  assertEqual(d.maybeFloat64!, 1.0, undefined, almostEquals);
+  t.assertEqual(d.float32, 1.2345, undefined, almostEquals);
+  t.assertEqual(d.maybeFloat32!, 22.0 / 7.0, undefined, almostEquals);
+  t.assertEqual(d.float64, 0, undefined, almostEquals);
+  t.assertEqual(d.maybeFloat64!, 1.0, undefined, almostEquals);
 
-  assertEqual(d.coveralls!.getName(), "some_dict");
+  t.assertEqual(d.coveralls!.getName(), "some_dict");
 });
 
-test("test create_none_dict() with default values", () => {
+test("test create_none_dict() with default values", (t) => {
   const d = createNoneDict();
-  assertEqual(d.text, "text");
-  assertEqual(d.maybeText, undefined);
+  t.assertEqual(d.text, "text");
+  t.assertEqual(d.maybeText, undefined);
   // Hermes doesn't support string --> ArrayBuffer
-  // assertEqual(d.someBytes.contentEquals("some_bytes".toByteArray(Charsets.UTF_8)))
-  // assertEqual(d.maybeSomeBytes.contentEquals("maybe_some_bytes".toByteArray(Charsets.UTF_8)))
-  assertTrue(d.aBool);
-  assertEqual(d.maybeABool, undefined);
-  assertEqual(d.unsigned8, 1);
-  assertEqual(d.maybeUnsigned8, undefined);
-  assertEqual(d.unsigned16, 3);
-  assertEqual(d.maybeUnsigned16, undefined);
-  // Test failing: observed: 18446744073709551616
-  // assertEqual(d.unsigned64, BigInt("18446744073709551615"))
-  assertEqual(d.maybeUnsigned64, undefined);
-  assertEqual(d.signed8, 8);
-  assertEqual(d.maybeSigned8, undefined);
-  // Test failing: observed: 9223372036854775808
-  // assertEqual(d.signed64, BigInt("9223372036854775807"))
-  assertEqual(d.maybeSigned64, undefined);
+  // t.assertEqual(d.someBytes.contentEquals("some_bytes".toByteArray(Charsets.UTF_8)))
+  // t.assertEqual(d.maybeSomeBytes.contentEquals("maybe_some_bytes".toByteArray(Charsets.UTF_8)))
+  t.assertTrue(d.aBool);
+  t.assertEqual(d.maybeABool, undefined);
+  t.assertEqual(d.unsigned8, 1);
+  t.assertEqual(d.maybeUnsigned8, undefined);
+  t.assertEqual(d.unsigned16, 3);
+  t.assertEqual(d.maybeUnsigned16, undefined);
+  t.assertEqual(d.unsigned64, BigInt("0x10000000000000000"));
+  t.assertEqual(d.maybeUnsigned64, undefined);
+  t.assertEqual(d.signed8, 8);
+  t.assertEqual(d.maybeSigned8, undefined);
+  t.assertEqual(d.signed64, BigInt("0x8000000000000000"));
+  t.assertEqual(d.maybeSigned64, undefined);
 
-  assertEqual(d.float32, 1.2345, undefined, almostEquals);
-  assertEqual(d.maybeFloat32, undefined);
-  assertEqual(d.float64, 0, undefined, almostEquals);
-  assertEqual(d.maybeFloat64, undefined);
+  t.assertEqual(d.float32, 1.2345, undefined, almostEquals);
+  t.assertEqual(d.maybeFloat32, undefined);
+  t.assertEqual(d.float64, 0, undefined, almostEquals);
+  t.assertEqual(d.maybeFloat64, undefined);
 
-  assertEqual(d.coveralls, undefined);
+  t.assertEqual(d.coveralls, undefined);
 });
 
-test("Given 1000 objects, when they go out of scope, then they are dropped by rust", () => {
+test("Given 1000 objects, when they go out of scope, then they are dropped by rust", (t) => {
   // The GC test; we should have 1000 alive by the end of the loop.
   //
   // Later on, nearer the end of the script, we'll test again, when the cleaner
@@ -113,15 +101,15 @@ test("Given 1000 objects, when they go out of scope, then they are dropped by ru
   // the garbage objects have been collected, and the Rust counter parts have been dropped.
   makeCoveralls(1000);
 
-  assertEqual(getNumAlive(), initial);
+  t.assertEqual(getNumAlive(), initial);
 });
 
-test("Catching errors", () => {
+test("Catching errors", (t) => {
   const coveralls = new Coveralls("Testing errors");
-  assertThrows("CoverallException.TooManyHoles", () =>
+  t.assertThrows("CoverallException.TooManyHoles", () =>
     coveralls.maybeThrow(true),
   );
-  assertThrows("CoverallException.TooManyHoles", () =>
+  t.assertThrows("CoverallException.TooManyHoles", () =>
     coveralls.maybeThrowInto(true),
   );
   coveralls.uniffiDestroy();

--- a/fixtures/rondpoint/tests/bindings/test_rondpoint.ts
+++ b/fixtures/rondpoint/tests/bindings/test_rondpoint.ts
@@ -8,7 +8,7 @@
 // cargo run --manifest-path ./crates/uniffi-bindgen-react-native/Cargo.toml -- ./fixtures/${fixture}/src/${fixture}.udl --out-dir ./fixtures/${fixture}/generated
 // cargo xtask run ./fixtures/${fixture}/tests/bindings/test_${fixture}.ts --cpp ./fixtures/${fixture}/generated/${fixture}.cpp --crate ./fixtures/${fixture}
 
-import { assertEqual, assertNotEqual, assertNotNull, test } from "@/asserts";
+import { Asserts, test } from "@/asserts";
 import {
   Enumeration,
   type EnumerationAvecDonnees,
@@ -27,19 +27,19 @@ import {
 } from "../../generated/rondpoint";
 import { numberToString } from "@/simulated";
 
-test("Round trip a single enum", () => {
+test("Round trip a single enum", (t) => {
   const input = Enumeration.DEUX;
   const output = copieEnumeration(input);
-  assertEqual(input, output);
+  t.assertEqual(input, output);
 });
 
-test("Round trip a list of enum", () => {
+test("Round trip a list of enum", (t) => {
   const input = [Enumeration.UN, Enumeration.DEUX];
   const output = copieEnumerations(input);
-  assertEqual(input, output);
+  t.assertEqual(input, output);
 });
 
-test("Round trip an object literal, without strings", () => {
+test("Round trip an object literal, without strings", (t) => {
   const input = DictionnaireFactory.create({
     un: Enumeration.DEUX,
     deux: true,
@@ -47,10 +47,10 @@ test("Round trip an object literal, without strings", () => {
     grosNombre: BigInt("123456789"),
   });
   const output = copieDictionnaire(input);
-  assertEqual(input, output);
+  t.assertEqual(input, output);
 });
 
-test("Round trip a map<string, *> of strings to enums with values", () => {
+test("Round trip a map<string, *> of strings to enums with values", (t) => {
   const input = new Map<string, EnumerationAvecDonnees>([
     ["0", { kind: EnumerationAvecDonneesKind.ZERO }],
     ["1", { kind: EnumerationAvecDonneesKind.UN, value: { premier: 1 } }],
@@ -63,23 +63,24 @@ test("Round trip a map<string, *> of strings to enums with values", () => {
     ],
   ]);
   const output = copieCarte(input);
-  assertEqual(input, output);
+  t.assertEqual(input, output);
 });
 
-test("Round trip a boolean", () => {
+test("Round trip a boolean", (t) => {
   const input = false;
   const output = switcheroo(input);
-  assertNotEqual(input, output);
+  t.assertNotEqual(input, output);
 });
 
 const affirmAllerRetour = <T>(
+  t: Asserts,
   fn: (input: T) => T,
   fnName: string,
   inputs: T[],
 ) => {
   for (const input of inputs) {
     const output = fn(input);
-    assertEqual(input, output, `${fnName} roundtrip failing`);
+    t.assertEqual(input, output, `${fnName} roundtrip failing`);
   }
 };
 
@@ -115,37 +116,48 @@ const inputData = {
 // i.e. it shows that lowering from kotlin and lifting into rust is symmetrical with
 //      lowering from rust and lifting into typescript.
 
-test("Using an object to roundtrip primitives", () => {
+test("Using an object to roundtrip primitives", (t) => {
   const rt = new Retourneur();
-  assertNotNull(rt);
+  t.assertNotNull(rt);
   affirmAllerRetour(
+    t,
     rt.identiqueBoolean.bind(rt),
     "identiqueBoolean",
     inputData.boolean,
   );
 
   // 8 bit
-  affirmAllerRetour(rt.identiqueI8.bind(rt), "identiqueI8", inputData.i8);
-  affirmAllerRetour(rt.identiqueU8.bind(rt), "identiqueU8", inputData.u8);
+  affirmAllerRetour(t, rt.identiqueI8.bind(rt), "identiqueI8", inputData.i8);
+  affirmAllerRetour(t, rt.identiqueU8.bind(rt), "identiqueU8", inputData.u8);
 
   // 16 bit
-  affirmAllerRetour(rt.identiqueI16.bind(rt), "identiqueI16", inputData.i16);
-  affirmAllerRetour(rt.identiqueU16.bind(rt), "identiqueU16", inputData.u16);
+  affirmAllerRetour(t, rt.identiqueI16.bind(rt), "identiqueI16", inputData.i16);
+  affirmAllerRetour(t, rt.identiqueU16.bind(rt), "identiqueU16", inputData.u16);
 
   // 32 bits
-  affirmAllerRetour(rt.identiqueI32.bind(rt), "identiqueI32", inputData.i32);
-  affirmAllerRetour(rt.identiqueU32.bind(rt), "identiqueU32", inputData.u32);
-  affirmAllerRetour(rt.identiqueFloat.bind(rt), "identiqueF32", inputData.f32);
+  affirmAllerRetour(t, rt.identiqueI32.bind(rt), "identiqueI32", inputData.i32);
+  affirmAllerRetour(t, rt.identiqueU32.bind(rt), "identiqueU32", inputData.u32);
+  affirmAllerRetour(
+    t,
+    rt.identiqueFloat.bind(rt),
+    "identiqueF32",
+    inputData.f32,
+  );
 
   // 64 bits
-  affirmAllerRetour(rt.identiqueI64.bind(rt), "identiqueI64", inputData.i64);
-  affirmAllerRetour(rt.identiqueU64.bind(rt), "identiqueU64", inputData.u64);
-  affirmAllerRetour(rt.identiqueDouble.bind(rt), "identiqueF32", inputData.f64);
+  affirmAllerRetour(t, rt.identiqueI64.bind(rt), "identiqueI64", inputData.i64);
+  affirmAllerRetour(t, rt.identiqueU64.bind(rt), "identiqueU64", inputData.u64);
+  affirmAllerRetour(
+    t,
+    rt.identiqueDouble.bind(rt),
+    "identiqueF32",
+    inputData.f64,
+  );
 
   rt.uniffiDestroy();
 });
 
-test("Testing defaulting properties in record types", () => {
+test("Testing defaulting properties in record types", (t) => {
   const rt = new Retourneur();
   const defaulted: OptionneurDictionnaire =
     OptionneurDictionnaireFactory.create({});
@@ -166,12 +178,13 @@ test("Testing defaulting properties in record types", () => {
     enumerationVar: Enumeration.DEUX,
     dictionnaireVar: undefined,
   });
-  assertEqual(explicit, defaulted);
+  t.assertEqual(explicit, defaulted);
 
   const actualDefaults = OptionneurDictionnaireFactory.defaults();
-  assertEqual(defaulted, actualDefaults);
+  t.assertEqual(defaulted, actualDefaults);
 
   affirmAllerRetour(
+    t,
     rt.identiqueOptionneurDictionnaire.bind(rt),
     "identiqueOptionneurDictionnaire",
     [explicit],
@@ -179,10 +192,11 @@ test("Testing defaulting properties in record types", () => {
   rt.uniffiDestroy();
 });
 
-test("Using an object to roundtrip strings", () => {
+test("Using an object to roundtrip strings", (t) => {
   const rt = new Retourneur();
-  assertNotNull(rt);
+  t.assertNotNull(rt);
   affirmAllerRetour(
+    t,
     rt.identiqueString.bind(rt),
     "identiqueString",
     inputData.string,
@@ -206,6 +220,7 @@ test("Using an object to roundtrip strings", () => {
 
 type TypescriptToString<T> = (value: T) => string;
 function affirmEnchaine<T>(
+  t: Asserts,
   fn: (input: T) => string,
   fnName: string,
   inputs: T[],
@@ -214,37 +229,40 @@ function affirmEnchaine<T>(
   for (const input of inputs) {
     const expected = toString(input);
     const observed = fn(input);
-    assertEqual(expected, observed, `Stringifier ${fnName} failing`);
+    t.assertEqual(expected, observed, `Stringifier ${fnName} failing`);
   }
 }
 
-test("Using an object convert into strings", () => {
+test("Using an object convert into strings", (t) => {
   const st = new Stringifier();
-  assertNotNull(st);
+  t.assertNotNull(st);
 
   const input = "JS on Hermes";
-  assertEqual(`uniffi 💚 ${input}!`, st.wellKnownString(input));
+  t.assertEqual(`uniffi 💚 ${input}!`, st.wellKnownString(input));
 
   affirmEnchaine(
+    t,
     st.toStringBoolean.bind(st),
     "toStringBoolean",
     inputData.boolean,
   );
-  affirmEnchaine(st.toStringI8.bind(st), "toStringI8", inputData.i8);
-  affirmEnchaine(st.toStringU8.bind(st), "toStringU8", inputData.u8);
-  affirmEnchaine(st.toStringI16.bind(st), "toStringI16", inputData.i16);
-  affirmEnchaine(st.toStringU16.bind(st), "toStringU16", inputData.u16);
-  affirmEnchaine(st.toStringI32.bind(st), "toStringI32", inputData.i32);
-  affirmEnchaine(st.toStringU32.bind(st), "toStringU32", inputData.u32);
-  affirmEnchaine(st.toStringI64.bind(st), "toStringI64", inputData.i64);
-  affirmEnchaine(st.toStringU64.bind(st), "toStringU64", inputData.u64);
+  affirmEnchaine(t, st.toStringI8.bind(st), "toStringI8", inputData.i8);
+  affirmEnchaine(t, st.toStringU8.bind(st), "toStringU8", inputData.u8);
+  affirmEnchaine(t, st.toStringI16.bind(st), "toStringI16", inputData.i16);
+  affirmEnchaine(t, st.toStringU16.bind(st), "toStringU16", inputData.u16);
+  affirmEnchaine(t, st.toStringI32.bind(st), "toStringI32", inputData.i32);
+  affirmEnchaine(t, st.toStringU32.bind(st), "toStringU32", inputData.u32);
+  affirmEnchaine(t, st.toStringI64.bind(st), "toStringI64", inputData.i64);
+  affirmEnchaine(t, st.toStringU64.bind(st), "toStringU64", inputData.u64);
   affirmEnchaine(
+    t,
     st.toStringFloat.bind(st),
     "toStringFloat",
     inputData.f32,
     numberToString,
   );
   affirmEnchaine(
+    t,
     st.toStringDouble.bind(st),
     "toStringDouble",
     inputData.f64,
@@ -254,53 +272,53 @@ test("Using an object convert into strings", () => {
   st.uniffiDestroy();
 });
 
-test("Default arguments are defaulting", () => {
+test("Default arguments are defaulting", (t) => {
   // Prove to ourselves that default arguments are being used.
   // Step 1: call the methods without arguments, and check against the UDL.
   const op = new Optionneur();
 
-  assertEqual(op.sinonString(), "default");
-  assertEqual(op.sinonBoolean(), false);
-  assertEqual(op.sinonSequence(), []);
+  t.assertEqual(op.sinonString(), "default");
+  t.assertEqual(op.sinonBoolean(), false);
+  t.assertEqual(op.sinonSequence(), []);
 
   // optionals
-  assertEqual(op.sinonNull(), null);
-  assertEqual(op.sinonZero(), 0);
+  t.assertEqual(op.sinonNull(), null);
+  t.assertEqual(op.sinonZero(), 0);
 
   // decimal integers
-  assertEqual(op.sinonI8Dec(), -42);
-  assertEqual(op.sinonU8Dec(), 42);
-  assertEqual(op.sinonI16Dec(), 42);
-  assertEqual(op.sinonU16Dec(), 42);
-  assertEqual(op.sinonI32Dec(), 42);
-  assertEqual(op.sinonU32Dec(), 42);
-  assertEqual(op.sinonI64Dec(), BigInt("42"));
-  assertEqual(op.sinonU64Dec(), BigInt("42"));
+  t.assertEqual(op.sinonI8Dec(), -42);
+  t.assertEqual(op.sinonU8Dec(), 42);
+  t.assertEqual(op.sinonI16Dec(), 42);
+  t.assertEqual(op.sinonU16Dec(), 42);
+  t.assertEqual(op.sinonI32Dec(), 42);
+  t.assertEqual(op.sinonU32Dec(), 42);
+  t.assertEqual(op.sinonI64Dec(), BigInt("42"));
+  t.assertEqual(op.sinonU64Dec(), BigInt("42"));
 
   // hexadecimal integers
-  assertEqual(op.sinonI8Hex(), -0x7f);
-  assertEqual(op.sinonU8Hex(), 0xff);
-  assertEqual(op.sinonI16Hex(), 0x7f);
-  assertEqual(op.sinonU16Hex(), 0xffff);
-  assertEqual(op.sinonI32Hex(), 0x7fffffff);
-  assertEqual(op.sinonU32Hex(), 0xffffffff);
-  assertEqual(op.sinonI64Hex(), BigInt("0x7fffffffffffffff"));
-  assertEqual(op.sinonU64Hex(), BigInt("0xffffffffffffffff"));
+  t.assertEqual(op.sinonI8Hex(), -0x7f);
+  t.assertEqual(op.sinonU8Hex(), 0xff);
+  t.assertEqual(op.sinonI16Hex(), 0x7f);
+  t.assertEqual(op.sinonU16Hex(), 0xffff);
+  t.assertEqual(op.sinonI32Hex(), 0x7fffffff);
+  t.assertEqual(op.sinonU32Hex(), 0xffffffff);
+  t.assertEqual(op.sinonI64Hex(), BigInt("0x7fffffffffffffff"));
+  t.assertEqual(op.sinonU64Hex(), BigInt("0xffffffffffffffff"));
 
   // octal integers
-  assertEqual(op.sinonU32Oct(), 493); // 0o755
+  t.assertEqual(op.sinonU32Oct(), 493); // 0o755
 
   // floats
-  assertEqual(op.sinonF32(), 42.0);
-  assertEqual(op.sinonF64(), 42.1);
+  t.assertEqual(op.sinonF32(), 42.0);
+  t.assertEqual(op.sinonF64(), 42.1);
 
   // enums
-  assertEqual(op.sinonEnum(), Enumeration.TROIS);
+  t.assertEqual(op.sinonEnum(), Enumeration.TROIS);
 
   op.uniffiDestroy();
 });
 
-test("Default arguments are overridden", () => {
+test("Default arguments are overridden", (t) => {
   // Step 2. Convince ourselves that if we pass something else, then that changes the output.
   //         We have shown something coming out of the sinon methods, but without eyeballing the Rust
   //         we can't be sure that the arguments will change the return value.
@@ -308,42 +326,43 @@ test("Default arguments are overridden", () => {
 
   // Now passing an argument, showing that it wasn't hardcoded anywhere.
   affirmAllerRetour(
+    t,
     op.sinonBoolean.bind(op),
     "sinonBoolean",
     inputData.boolean,
   );
 
   // 8 bit
-  affirmAllerRetour(op.sinonI8Dec.bind(op), "sinonI8Dec", inputData.i8);
-  affirmAllerRetour(op.sinonI8Hex.bind(op), "sinonI8Hex", inputData.i8);
-  affirmAllerRetour(op.sinonU8Dec.bind(op), "sinonU8Dec", inputData.u8);
-  affirmAllerRetour(op.sinonU8Hex.bind(op), "sinonU8Hex", inputData.u8);
+  affirmAllerRetour(t, op.sinonI8Dec.bind(op), "sinonI8Dec", inputData.i8);
+  affirmAllerRetour(t, op.sinonI8Hex.bind(op), "sinonI8Hex", inputData.i8);
+  affirmAllerRetour(t, op.sinonU8Dec.bind(op), "sinonU8Dec", inputData.u8);
+  affirmAllerRetour(t, op.sinonU8Hex.bind(op), "sinonU8Hex", inputData.u8);
 
   // 16 bit
-  affirmAllerRetour(op.sinonI16Dec.bind(op), "sinonI16Dec", inputData.i16);
-  affirmAllerRetour(op.sinonI16Hex.bind(op), "sinonI16Hex", inputData.i16);
-  affirmAllerRetour(op.sinonU16Dec.bind(op), "sinonU16Dec", inputData.u16);
-  affirmAllerRetour(op.sinonU16Hex.bind(op), "sinonU16Hex", inputData.u16);
+  affirmAllerRetour(t, op.sinonI16Dec.bind(op), "sinonI16Dec", inputData.i16);
+  affirmAllerRetour(t, op.sinonI16Hex.bind(op), "sinonI16Hex", inputData.i16);
+  affirmAllerRetour(t, op.sinonU16Dec.bind(op), "sinonU16Dec", inputData.u16);
+  affirmAllerRetour(t, op.sinonU16Hex.bind(op), "sinonU16Hex", inputData.u16);
 
   // 32 bits
-  affirmAllerRetour(op.sinonI32Dec.bind(op), "sinonI32Dec", inputData.i32);
-  affirmAllerRetour(op.sinonI32Hex.bind(op), "sinonI32Hex", inputData.i32);
-  affirmAllerRetour(op.sinonU32Dec.bind(op), "sinonU32Dec", inputData.u32);
-  affirmAllerRetour(op.sinonU32Hex.bind(op), "sinonU32Hex", inputData.u32);
-  affirmAllerRetour(op.sinonU32Oct.bind(op), "sinonU32Oct", inputData.u32);
+  affirmAllerRetour(t, op.sinonI32Dec.bind(op), "sinonI32Dec", inputData.i32);
+  affirmAllerRetour(t, op.sinonI32Hex.bind(op), "sinonI32Hex", inputData.i32);
+  affirmAllerRetour(t, op.sinonU32Dec.bind(op), "sinonU32Dec", inputData.u32);
+  affirmAllerRetour(t, op.sinonU32Hex.bind(op), "sinonU32Hex", inputData.u32);
+  affirmAllerRetour(t, op.sinonU32Oct.bind(op), "sinonU32Oct", inputData.u32);
   // 32 bit float
-  affirmAllerRetour(op.sinonF32.bind(op), "sinonF32", inputData.f32);
+  affirmAllerRetour(t, op.sinonF32.bind(op), "sinonF32", inputData.f32);
 
   // 64 bits
-  affirmAllerRetour(op.sinonI64Dec.bind(op), "sinonI64Dec", inputData.i64);
-  affirmAllerRetour(op.sinonI64Hex.bind(op), "sinonI64Hex", inputData.i64);
-  affirmAllerRetour(op.sinonU64Dec.bind(op), "sinonU64Dec", inputData.u64);
-  affirmAllerRetour(op.sinonU64Hex.bind(op), "sinonU64Hex", inputData.u64);
+  affirmAllerRetour(t, op.sinonI64Dec.bind(op), "sinonI64Dec", inputData.i64);
+  affirmAllerRetour(t, op.sinonI64Hex.bind(op), "sinonI64Hex", inputData.i64);
+  affirmAllerRetour(t, op.sinonU64Dec.bind(op), "sinonU64Dec", inputData.u64);
+  affirmAllerRetour(t, op.sinonU64Hex.bind(op), "sinonU64Hex", inputData.u64);
 
   // 64 bit float
-  affirmAllerRetour(op.sinonF64.bind(op), "sinonF64", inputData.f64);
+  affirmAllerRetour(t, op.sinonF64.bind(op), "sinonF64", inputData.f64);
 
-  affirmAllerRetour(op.sinonEnum.bind(op), "sinonEnum", inputData.enums);
+  affirmAllerRetour(t, op.sinonEnum.bind(op), "sinonEnum", inputData.enums);
 
   op.uniffiDestroy();
 });

--- a/typescript/testing/asserts.ts
+++ b/typescript/testing/asserts.ts
@@ -16,66 +16,95 @@ export class AssertError extends Error {
   }
 }
 
-export function fail(message?: string, error?: Error): never {
-  throw new AssertError(message ?? "Assertion failed", error);
+function isEqual<T>(a: T, b: T): boolean {
+  return a === b || a == b || stringify(a) === stringify(b);
 }
 
-export function assertTrue(condition: boolean, message?: string): void {
-  if (condition) {
-    return;
+function checkThrown(t: Asserts, errorVariant: string, e: any | undefined) {
+  if (e === undefined) {
+    t.fail("No error was thrown");
+  } else if (e instanceof Error) {
+    // Good, success!
+    t.assertEqual(
+      getErrorName(e),
+      errorVariant,
+      "Error is thrown, but the wrong one",
+    );
+  } else {
+    t.fail(`Something else was thrown: ${e}`);
   }
-  fail(message ?? "Expected true, was false");
 }
 
-export function assertFalse(condition: boolean, message?: string): void {
-  assertTrue(!condition, message ?? "Expected false, was true");
+function getErrorName(error: Error): string {
+  const typeName = (error as any)._uniffiTypeName ?? "Error";
+  const variantName = (error as any)._uniffiVariantName ?? "unknown";
+  return `${typeName}.${variantName}`;
 }
 
-export function assertNotNull(
-  thing: any | undefined | null,
-  message?: string,
-): void {
-  const m = message ?? "Expected to be defined, but was";
-  assertTrue(thing !== undefined && thing !== null, `${m}: ${thing}`);
+// All the assert methods in a single class
+export class Asserts {
+  fail(message?: string, error?: Error): never {
+    throw new AssertError(message ?? "Assertion failed", error);
+  }
+  assertTrue(condition: boolean, message?: string): void {
+    if (condition) {
+      return;
+    }
+    this.fail(message ?? "Expected true, was false");
+  }
+  assertFalse(condition: boolean, message?: string): void {
+    this.assertTrue(!condition, message ?? "Expected false, was true");
+  }
+  assertNotNull(thing: any | undefined | null, message?: string): void {
+    const m = message ?? "Expected to be defined, but was";
+    this.assertTrue(thing !== undefined && thing !== null, `${m}: ${thing}`);
+  }
+  assertNull(thing: any | undefined | null, message?: string): void {
+    const m = message ?? "Expected to be null or undefined, but was";
+    this.assertTrue(thing === undefined || thing === null, `${m}: ${thing}`);
+  }
+  assertEqual<T>(
+    left: T,
+    right: T,
+    message?: string,
+    equality: (a: T, b: T) => boolean = isEqual,
+  ): void {
+    const m = message ?? "Expected left and right to be equal";
+    this.assertTrue(
+      equality(left, right),
+      `${m}: ${stringify(left)} !== ${stringify(right)}`,
+    );
+  }
+  assertNotEqual<T>(
+    left: T,
+    right: T,
+    message?: string,
+    equality: (a: T, b: T) => boolean = isEqual,
+  ): void {
+    const m = message ?? "Expected left and right to not be equal";
+    this.assertFalse(
+      equality(left, right),
+      `${m}: ${stringify(left)} === ${stringify(right)}`,
+    );
+  }
+
+  /// We can't use instanceof here: hermes does not seem to generate the right
+  /// prototype chain, so we'll check the error message instead.
+  assertThrows<T>(errorVariant: string, fn: () => T): void {
+    let error: any | undefined;
+    try {
+      fn();
+    } catch (e: any) {
+      error = e;
+    }
+    checkThrown(this, errorVariant, error);
+  }
 }
 
-export function assertNull(
-  thing: any | undefined | null,
-  message?: string,
-): void {
-  const m = message ?? "Expected to be null or undefined, but was";
-  assertTrue(thing === undefined || thing === null, `${m}: ${thing}`);
-}
-
-export function assertEqual<T>(
-  left: T,
-  right: T,
-  message?: string,
-  equality: (a: T, b: T) => boolean = isEqual,
-): void {
-  const m = message ?? "Expected left and right to be equal";
-  assertTrue(
-    equality(left, right),
-    `${m}: ${stringify(left)} !== ${stringify(right)}`,
-  );
-}
-
-export function assertNotEqual<T>(
-  left: T,
-  right: T,
-  message?: string,
-  equality: (a: T, b: T) => boolean = isEqual,
-): void {
-  const m = message ?? "Expected left and right to not be equal";
-  assertFalse(
-    equality(left, right),
-    `${m}: ${stringify(left)} === ${stringify(right)}`,
-  );
-}
-
-export function test<T>(testName: string, testBlock: () => T): T {
+// For running the tests themselves.
+export function test<T>(testName: string, testBlock: (t: Asserts) => T): T {
   try {
-    return testBlock();
+    return testBlock(new Asserts());
   } catch (e) {
     console.error(testName, e);
     throw e;
@@ -84,34 +113,4 @@ export function test<T>(testName: string, testBlock: () => T): T {
 
 export function xtest<T>(testName: string, testBlock: () => T): void {
   console.log(`Skipping: ${testName}`);
-}
-
-function isEqual<T>(a: T, b: T): boolean {
-  return a === b || a == b || stringify(a) === stringify(b);
-}
-
-/// We can't use instanceof here: hermes does not seem to generate the right
-/// prototype chain, so we'll check the error message instead.
-export function assertThrows<T>(errorVariant: string, fn: () => T) {
-  try {
-    fn();
-    fail("No error was thrown");
-  } catch (e: any) {
-    if (e instanceof Error) {
-      // Good, success!
-      assertEqual(
-        getErrorName(e),
-        errorVariant,
-        "Error is thrown, but the wrong one",
-      );
-    } else {
-      fail(`Something else was thrown: ${e}`);
-    }
-  }
-}
-
-function getErrorName(error: Error): string {
-  const typeName = (error as any)._uniffiTypeName ?? "Error";
-  const variantName = (error as any)._uniffiVariantName ?? "unknown";
-  return `${typeName}.${variantName}`;
 }

--- a/typescript/tests/event-loop.test.ts
+++ b/typescript/tests/event-loop.test.ts
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { asyncTest } from "../testing/asserts";
+
+asyncTest("Dummy test that should end properly", async (t) => {
+  t.end();
+});
+
+// asyncTest("Top level empty test that should error out", async (t) => {});
+
+asyncTest("assertThrowsAsync catches errors", async (t) => {
+  await t.assertThrowsAsync("Error.unknown", async () => {
+    throw new Error();
+  });
+  t.end();
+});
+
+asyncTest("t.end() ends asynchronously", async (t) => {
+  setTimeout(async () => {
+    t.end();
+  }, 20);
+});

--- a/typescript/tests/ffi-converters.test.ts
+++ b/typescript/tests/ffi-converters.test.ts
@@ -17,7 +17,7 @@ import {
   FfiConverterUInt16,
   FfiConverterUInt8,
 } from "../src/ffi-converters";
-import { assertEqual, test } from "../testing/asserts";
+import { Asserts, test } from "../testing/asserts";
 
 class TestConverter<
   R extends any,
@@ -38,83 +38,84 @@ class TestConverter<
 }
 
 function testConverter<T>(
+  t: Asserts,
   converter: AbstractFfiConverterArrayBuffer<T>,
   input: T,
 ) {
   const lowered = converter.lower(input);
-  assertEqual(
+  t.assertEqual(
     lowered.byteLength,
     converter.allocationSize(input),
     "allocated size doesn't match",
   );
   const output = converter.lift(lowered);
-  assertEqual(input, output, "Round trip failed");
+  t.assertEqual(input, output, "Round trip failed");
 }
 
-test("1 byte converter", () => {
+test("1 byte converter", (t) => {
   const converter = new TestConverter(FfiConverterInt8);
-  testConverter(converter, -(1 << 7) + 1);
-  testConverter(converter, 0);
-  testConverter(converter, (1 << 7) - 1);
+  testConverter(t, converter, -0x7f);
+  testConverter(t, converter, 0);
+  testConverter(t, converter, 0x7f);
 });
 
-test("boolean converter", () => {
+test("boolean converter", (t) => {
   const converter = new TestConverter(FfiConverterBool);
-  testConverter(converter, true);
-  testConverter(converter, false);
+  testConverter(t, converter, true);
+  testConverter(t, converter, false);
 });
 
-test("2 byte converter", () => {
+test("2 byte converter", (t) => {
   const converter = new TestConverter(FfiConverterInt16);
-  testConverter(converter, -(1 << 15) + 1);
-  testConverter(converter, 0);
-  testConverter(converter, (1 << 15) - 1);
+  testConverter(t, converter, -0x7fff);
+  testConverter(t, converter, 0);
+  testConverter(t, converter, 0x7fff);
 });
 
-test("4 byte converter", () => {
+test("4 byte converter", (t) => {
   const converter = new TestConverter(FfiConverterInt32);
-  testConverter(converter, -(1 << 30));
-  testConverter(converter, 0);
-  testConverter(converter, 1 << 30);
+  testConverter(t, converter, -0x7fffffff);
+  testConverter(t, converter, 0);
+  testConverter(t, converter, 0x7fffffff);
 });
 
-test("Optional 1 byte converter", () => {
+test("Optional 1 byte converter", (t) => {
   const converter = new FfiConverterOptional(FfiConverterInt8);
-  testConverter(converter, -(1 << 7) + 1);
-  testConverter(converter, 0);
-  testConverter(converter, (1 << 7) - 1);
-  testConverter(converter, undefined);
+  testConverter(t, converter, -0x7f);
+  testConverter(t, converter, 0);
+  testConverter(t, converter, 0x7f);
+  testConverter(t, converter, undefined);
 });
 
-test("Optional 2 byte converter (mixed width byte array)", () => {
+test("Optional 2 byte converter (mixed width byte array)", (t) => {
   const converter = new FfiConverterOptional(FfiConverterInt16);
-  testConverter(converter, -(1 << 15) + 1);
-  testConverter(converter, 0);
-  testConverter(converter, (1 << 15) - 1);
-  testConverter(converter, undefined);
+  testConverter(t, converter, -0x7fff);
+  testConverter(t, converter, 0);
+  testConverter(t, converter, 0x7fff);
+  testConverter(t, converter, undefined);
 });
 
-test("Array of bytes", () => {
+test("Array of bytes", (t) => {
   const converter = new FfiConverterArray(FfiConverterUInt8);
-  testConverter(converter, [1, 2, 3]);
-  testConverter(converter, [0]);
-  testConverter(converter, new Array(100).fill(128));
+  testConverter(t, converter, [1, 2, 3]);
+  testConverter(t, converter, [0]);
+  testConverter(t, converter, new Array(100).fill(128));
 });
 
-test("Array of shorts", () => {
+test("Array of shorts", (t) => {
   const converter = new FfiConverterArray(FfiConverterUInt16);
-  testConverter(converter, [1, 2, 3]);
-  testConverter(converter, [0]);
-  testConverter(converter, new Array(100).fill(128));
+  testConverter(t, converter, [1, 2, 3]);
+  testConverter(t, converter, [0]);
+  testConverter(t, converter, new Array(100).fill(128));
 });
 
-test("Array of optional shorts", () => {
+test("Array of optional shorts", (t) => {
   const converter = new FfiConverterArray(
     new FfiConverterOptional(FfiConverterUInt16),
   );
-  testConverter(converter, [1, 2, 3]);
-  testConverter(converter, [0]);
-  testConverter(converter, [0, undefined, 1]);
-  testConverter(converter, new Array(100).fill(128));
-  testConverter(converter, new Array(100).fill(undefined));
+  testConverter(t, converter, [1, 2, 3]);
+  testConverter(t, converter, [0]);
+  testConverter(t, converter, [0, undefined, 1]);
+  testConverter(t, converter, new Array(100).fill(128));
+  testConverter(t, converter, new Array(100).fill(undefined));
 });


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR adds a crude event loop to the test runner. Specifically:

- `setTimeout`/`clearTimeout`/`setImmediate`. This is largely derived from https://github.com/tmikov/hermes-jsi-demos/blob/master/evloop/evloop.cpp
- an implementation of the `ReactCommon::CallInvoker` interface
- an `asyncTest` method to the asserts library

The runner now runs until there are no more tasks left, either from `setTimeout` or
from in-flght callbacks on other threads.

This does not need to be more robust than that: any long-running Rust tasks should
protect the test-runner from exiting by setting a timeout in the test.

This is done implicitly by the `asyncTest` method.