### PR TITLE
Delay callback initialization until after the module is loaded

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
@@ -210,7 +210,7 @@ impl<'a> TypeRenderer<'a> {
                         self.import_ext(&name, &namespace);
                     }
                 }
-                let converters = format!("uniffi{}Converters", namespace.to_upper_camel_case());
+                let converters = format!("uniffi{}Module", namespace.to_upper_camel_case());
                 let src = format!("./{namespace}");
                 let ffi_converter_name = ffi_converter_name(external)
                     .expect("FfiConverter for External type will always exist");

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/InitializationTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/InitializationTemplate.ts
@@ -1,14 +1,14 @@
-(() => {
+function uniffiEnsureInitialized() {
     // Get the bindings contract version from our ComponentInterface
     const bindingsContractVersion = {{ ci.uniffi_contract_version() }};
     // Get the scaffolding contract version by calling the into the dylib
     const scaffoldingContractVersion = nativeModule().{{ ci.ffi_uniffi_contract_version().name() }}();
-    if (bindingsContractVersion != scaffoldingContractVersion) {
+    if (bindingsContractVersion !== scaffoldingContractVersion) {
         throw new Error("contractVersionMismatch");
     }
 
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
-    if (nativeModule().{{ name }}() != {{ expected_checksum }}) {
+    if (nativeModule().{{ name }}() !== {{ expected_checksum }}) {
         throw new Error("apiChecksumMismatch: {{ name }}");
     }
     {%- endfor %}
@@ -16,4 +16,4 @@
     {% for fn in self.initialization_fns() -%}
     {{ fn }}();
     {% endfor -%}
-})();
+}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper.ts
@@ -38,7 +38,7 @@ const {
 {%-   for converter in converters %}
         {{- converter }},
 {%-   endfor %}
-} = {{ entry.0.1 }};
+} = {{ entry.0.1 }}.converters;
 {%- endfor %}
 
 {%- call ts::docstring_value(ci.namespace_docstring(), 0) %}
@@ -62,10 +62,12 @@ import {{ config.ffi_module_name() }}
 
 {% include "InitializationTemplate.ts" %}
 
-{% if !self.exported_converters.is_empty() %}
 export default Object.freeze({
+  initialize: uniffiEnsureInitialized,
+  {%- if !self.exported_converters.is_empty() %}
+  converters: {
   {%- for converter in self.exported_converters.borrow() %}
-  {{ converter }},
+    {{ converter }},
   {%- endfor %}
+  }{% endif %}
 });
-{% endif %}

--- a/crates/ubrn_cli/src/codegen/templates/index.ts
+++ b/crates/ubrn_cli/src/codegen/templates/index.ts
@@ -16,3 +16,12 @@ export function multiply(a: number, b: number): number {
 {%- for m in self.config.modules %}
 export * from './{{ bindings }}/{{ m.ts() }}';
 {%- endfor %}
+
+// Initialize the generated bindings: mostly checksums, but also callbacks.
+{%- for m in self.config.modules %}
+import {{ m.ts() }}_ from './{{ bindings }}/{{ m.ts() }}';
+{%- endfor %}
+{% for m in self.config.modules %}
+{{ m.ts() }}_.initialize();
+{%- endfor %}
+{# space #}

--- a/fixtures/callbacks/tests/bindings/test_callbacks.ts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import {
+import myModule, {
   ComplexException,
   ForeignGetters,
   SimpleException,
@@ -12,6 +12,10 @@ import {
   StoredForeignStringifier,
 } from "../../generated/callbacks";
 import { test } from "@/asserts";
+
+// Initialize the callbacks for the module.
+// This will be hidden in the installation process.
+myModule.initialize();
 
 const BAD_ARGUMENT = "bad-argument";
 const UNEXPECTED_ERROR = "unexpected-error";

--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-import {
+import myModule, {
   alwaysReady,
   asStringUsingTrait,
   asyncNewMegaphone,
@@ -32,6 +32,10 @@ import {
 } from "../../generated/futures";
 import { asyncTest, xasyncTest } from "@/asserts";
 import { console } from "@/hermes";
+
+// Initialize the callbacks for the module.
+// This will be hidden in the installation process.
+myModule.initialize();
 
 asyncTest("alwaysReady", async (t) => {
   const result = await alwaysReady();


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR separates out the callback registration and checksum (in other backends this is called `uniffiEnsureInitialized`) with the module loading.

This was found in the differences between testing against hermes in a test harness and in a React Native setting.

It does this by changing the default export of the module from an object containing `FfiConverters` to one containing the the `initialize` function and the `converters`.

The `converters` import is changed to match this new export, and the `index.ts` template in the `generate turbo-module` job is also change to call the `initialize` functions.