### PR TITLE
Implement non-flat errors

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/enum_.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/enum_.rs
@@ -31,7 +31,7 @@ impl CodeType for EnumCodeType {
     fn decl_type_label(&self, ci: &ComponentInterface) -> String {
         let nm = CodeOracle.class_name(ci, &self.id);
         if ci.is_name_used_as_error(&self.id) {
-            rewrite_error_name(&nm)
+            rewrite_error_name(&nm).to_string()
         } else {
             nm
         }
@@ -54,9 +54,10 @@ impl CodeType for EnumCodeType {
     }
 }
 
-fn rewrite_error_name(nm: &str) -> String {
-    match nm.strip_suffix("Error") {
-        None => nm.to_string(),
-        Some(stripped) => format!("{stripped}Exception"),
+fn rewrite_error_name(nm: &str) -> &str {
+    if nm == "Error" {
+        "Exception"
+    } else {
+        nm
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/enum_.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/enum_.rs
@@ -20,7 +20,21 @@ impl EnumCodeType {
 
 impl CodeType for EnumCodeType {
     fn type_label(&self, ci: &ComponentInterface) -> String {
-        CodeOracle.class_name(ci, &self.id)
+        let nm = CodeOracle.class_name(ci, &self.id);
+        if ci.is_name_used_as_error(&self.id) {
+            format!("{}Type", rewrite_error_name(&nm))
+        } else {
+            nm
+        }
+    }
+
+    fn decl_type_label(&self, ci: &ComponentInterface) -> String {
+        let nm = CodeOracle.class_name(ci, &self.id);
+        if ci.is_name_used_as_error(&self.id) {
+            rewrite_error_name(&nm)
+        } else {
+            nm
+        }
     }
 
     fn canonical_name(&self) -> String {
@@ -37,5 +51,12 @@ impl CodeType for EnumCodeType {
         } else {
             unreachable!();
         }
+    }
+}
+
+fn rewrite_error_name(nm: &str) -> String {
+    match nm.strip_suffix("Error") {
+        None => nm.to_string(),
+        Some(stripped) => format!("{stripped}Exception"),
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/filters.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/filters.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use super::oracle::{AsCodeType, CodeOracle};
-use heck::ToUpperCamelCase;
 pub(crate) use uniffi_bindgen::backend::filters::*;
 use uniffi_bindgen::{
     backend::{filters::UniFFIError, Literal, Type},
@@ -167,12 +166,6 @@ pub fn arg_name(nm: &str) -> Result<String, askama::Error> {
 /// Get a String representing the name used for an individual enum variant.
 pub fn variant_name(v: &Variant) -> Result<String, askama::Error> {
     Ok(CodeOracle.enum_variant_name(v.name()))
-}
-
-#[allow(unused)]
-pub fn error_variant_name(v: &Variant) -> Result<String, askama::Error> {
-    let name = v.name().to_string().to_upper_camel_case();
-    Ok(CodeOracle.convert_error_suffix(&name))
 }
 
 /// Get the idiomatic Typescript rendering of an FFI callback function name

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/filters.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/filters.rs
@@ -19,6 +19,13 @@ pub(super) fn type_name(
     Ok(as_ct.as_codetype().type_label(ci))
 }
 
+pub(super) fn decl_type_name(
+    as_ct: &impl AsCodeType,
+    ci: &ComponentInterface,
+) -> Result<String, askama::Error> {
+    Ok(as_ct.as_codetype().decl_type_label(ci))
+}
+
 pub(super) fn canonical_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
     Ok(as_ct.as_codetype().canonical_name())
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
@@ -20,12 +20,8 @@ impl CodeOracle {
     }
 
     /// Get the idiomatic Typescript rendering of a class name (for enums, records, errors, etc).
-    pub(crate) fn class_name(&self, ci: &ComponentInterface, nm: &str) -> String {
-        let name = nm.to_string().to_upper_camel_case();
-        // fixup errors.
-        ci.is_name_used_as_error(nm)
-            .then(|| self.convert_error_suffix(&name))
-            .unwrap_or(name)
+    pub(crate) fn class_name(&self, _ci: &ComponentInterface, nm: &str) -> String {
+        nm.to_string().to_upper_camel_case()
     }
 
     pub(crate) fn convert_error_suffix(&self, nm: &str) -> String {
@@ -243,6 +239,14 @@ pub(crate) trait CodeType: std::fmt::Debug {
     /// The language specific label used to reference this type. This will be used in
     /// method signatures and property declarations.
     fn type_label(&self, ci: &ComponentInterface) -> String;
+
+    /// The container type for this type. Most of the time, this is the samne as the type_label.
+    /// However, just occassionally the typescript type is different.
+    /// e.g. errors are instantiated with `new MyError.Foo()`, but have typescript type of
+    /// `MyErrorType`.
+    fn decl_type_label(&self, ci: &ComponentInterface) -> String {
+        self.type_label(ci)
+    }
 
     /// A representation of this type label that can be used as part of another
     /// identifier. e.g. `read_foo()`, or `FooInternals`.

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
@@ -24,13 +24,6 @@ impl CodeOracle {
         nm.to_string().to_upper_camel_case()
     }
 
-    pub(crate) fn convert_error_suffix(&self, nm: &str) -> String {
-        match nm.strip_suffix("Error") {
-            None => nm.to_string(),
-            Some(stripped) => format!("{stripped}Exception"),
-        }
-    }
-
     /// Get the idiomatic Typescript rendering of a function name.
     pub(crate) fn fn_name(&self, nm: &str) -> String {
         if nm == "new" {

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -53,7 +53,7 @@ const {{ trait_impl }}: { vtable: {{ vtable|ffi_type_name }}; register: () => vo
                 /*callStatus:*/ uniffiCallStatus,
                 /*makeCall:*/ uniffiMakeCall,
                 /*writeReturn:*/ uniffiWriteReturn,
-                /*errorType:*/ "{{ error_type|type_name(ci) }}",
+                /*isErrorType:*/ {{ error_type|decl_type_name(ci) }}.instanceOf,
                 /*lowerError:*/ {{ error_type|lower_fn }},
                 /*lowerString:*/ FfiConverterString.lower
             )
@@ -102,7 +102,7 @@ const {{ trait_impl }}: { vtable: {{ vtable|ffi_type_name }}; register: () => vo
                 /*makeCall:*/ uniffiMakeCall,
                 /*handleSuccess:*/ uniffiHandleSuccess,
                 /*handleError:*/ uniffiHandleError,
-                /*errorType:*/ "{{ error_type|type_name(ci) }}",
+                /*isErrorType:*/ {{ error_type|decl_type_name(ci) }}.instanceOf,
                 /*lowerError:*/ {{ error_type|lower_fn }},
                 /*lowerString:*/ FfiConverterString.lower
             )

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -1,71 +1,130 @@
-{{- self.import_infra("rustCallWithError", "rust-call") }}
-
-{%- call ts::docstring(e, 0) %}
-export class {{ type_name }} extends Error {
-    private _uniffiTypeName = "{{ type_name }}";
-    constructor(private _uniffiVariantName: string, message: string) {
-        super(message);
-    }
-    {%- if e.is_flat() %}
-    {%-   for variant in e.variants() %}
-    {%-    call ts::docstring(variant, 4) %}
-    {%-    let var_name = variant.name()|class_name(ci) %}
-    static {{ var_name }}: typeof _{{ type_name }}_{{ var_name }};
-    {% endfor -%}
-    {% else %}
-    // non-flat errors aren't implemented yet.
-    {%- endif %}
-}
-{%- if e.is_flat() %}
-{%-   for variant in e.variants() %}
-{%-    let var_name = variant.name()|class_name(ci) %}
-class _{{ type_name }}_{{ var_name }} extends {{ type_name }} {
-    constructor(message: string) { super("{{ var_name }}", message); }
-}
-{{ type_name }}.{{ var_name }} = _{{ type_name }}_{{ var_name }};
-{%-  endfor %}
+{{- self.import_infra("UniffiError", "errors") }}
+{%- let decl_type_name = e|decl_type_name(ci) %}
+{%- let instance_of = "instanceOf" %}
+{%- let flat = e.is_flat() %}
+{%- if flat %}
+// Flat error type: {{ decl_type_name }}
+{%- else %}
+// Error type: {{ decl_type_name }}
 {%- endif %}
+{%- call ts::docstring(e, 0) %}
+export const {{ decl_type_name }} = (() => {
+    {%- for variant in e.variants() %}
+    {%-   call ts::docstring(variant, 4) %}
+    {%-   let variant_name = variant.name()|class_name(ci) %}
+    class {{ variant_name }} extends UniffiError {
+        constructor(
+            {%- if flat %}message: string
+            {%- else %}
+            {%-   for field in variant.fields() %}
+            public readonly {{ field.name()|var_name }}: {{ field|type_name(ci) }}
+            {%-     match field.default_value() %}
+            {%-       when Some with(literal) %} = {{ literal|render_literal(field, ci) }}
+            {%-     else %}
+            {%-     endmatch -%}
+            {%-     if !loop.last %}, {% endif %}
+            {%-   endfor %}
+            {%- endif -%}
+        ) {
+            super("{{ decl_type_name }}", "{{ variant_name }}", {{ loop.index }}
+                {%- if flat %}, message
+                {%- endif %});
+        }
 
+        {%- if !flat %}
+        toString(): string {
+            return ["{{ decl_type_name }}.{{ variant_name }}:"
+            {%-   for field in variant.fields() %}, {# space #}
+            `{{ field.name()|var_name }}=${this.{{ field.name()|var_name }}}`
+            {%-   endfor %}].join(" ");
+        }
+        {%- endif -%}
+
+        static {{ instance_of }}(e: any): e is {{ variant_name }} {
+            return (
+                {{ instance_of }}(e) && (e as any).__variant === {{ loop.index }}
+            );
+        }
+    }
+    {%- endfor %}
+
+    // Utility function which does not rely on instanceof.
+    function {{ instance_of }}(e: any): e is {# space #}
+    {%- for variant in e.variants() %}
+    {{-   variant.name()|class_name(ci) }}
+    {%-   if !loop.last %} | {% endif -%}
+    {%- endfor %} {
+        return (e as any).__uniffiTypeName === "{{ decl_type_name }}";
+    }
+    return {
+        {%- for variant in e.variants() %}
+        {{   variant.name()|class_name(ci) }},
+        {%- endfor %}
+        {{ instance_of }},
+    };
+})();
+
+// Union type for {{ type_name }} error type.
+export type {{ type_name }} = InstanceType<
+    typeof {{ decl_type_name }}[keyof Omit<typeof {{ decl_type_name }}, '{{ instance_of }}'>]
+>;
 
 const {{ ffi_converter_name }} = (() => {
     const intConverter = FfiConverterInt32;
-    const stringConverter = FfiConverterString;
 
     type TypeName = {{ type_name }};
     class FfiConverter extends AbstractFfiConverterArrayBuffer<TypeName> {
         read(from: RustBuffer): TypeName {
             switch (intConverter.read(from)) {
-            {%- if e.is_flat() %}
             {%-   for variant in e.variants() %}
-                case {{ loop.index }}: return new {{ type_name }}.{{ variant.name()|class_name(ci) }}(
-                    stringConverter.read(from)
+                case {{ loop.index }}: return new {{ decl_type_name }}.{{ variant.name()|class_name(ci) }}(
+                    {%- if flat %}FfiConverterString.read(from)
+                    {%- else %}
+                    {%-   for field in variant.fields() %}
+                    {{      field|ffi_converter_name }}.read(from)
+                    {%-     if !loop.last %}, {% endif %}
+                    {%-   endfor %}
+                    {%- endif %}
                 );
             {%    endfor %}
-            {%- else %}
-                // non-flat errors aren't implement yet.
-            {%  endif %}
                 default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
         }
         write(value: TypeName, into: RustBuffer): void {
-            {%- if e.is_flat() %}
-            switch ((value as any)._uniffiVariantName) {
-            {%- for variant in e.variants() %}
-                case "{{ variant.name()|class_name(ci) }}": {
-                    intConverter.write({{ loop.index }}, into);
+            const obj = value as any;
+            const index = obj.__variant as number;
+            intConverter.write(index, into);
+            {%- if !flat %}
+            switch (index) {
+                {%-   for variant in e.variants() %}
+                case {{ loop.index }}:
+                {%-     for field in variant.fields() %}
+                    {{ field|ffi_converter_name }}.write(obj.{{ field.name()|var_name }} as {{ field|type_name(ci) }}, into);
+                {%-     endfor -%}
                     break;
-                }
-            {%- endfor %}
-                default:{
-                    throw new UniffiInternalError.UnexpectedEnumCase();
-                }
+                {%-   endfor %}
+                    default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
-            {%- else %}
-            throw new Error("Method not implemented.")
             {%- endif %}
         }
         allocationSize(value: TypeName): number {
+            {%- if flat %}
             return intConverter.allocationSize(0);
+            {%- else %}
+            const obj = value as any;
+            const index = obj.__variant as number;
+            switch (index) {
+                {%-   for variant in e.variants() %}
+                case {{ loop.index }}:
+                    return (intConverter.allocationSize({{ loop.index }})
+                {%-     for field in variant.fields() %} + {# space #}
+                    {{ field|ffi_converter_name }}.allocationSize(obj.{{ field.name()|var_name }} as {{ field|type_name(ci) }})
+                {%-     endfor -%}
+                    );
+                {%-   endfor %}
+                    default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+            {%- endif %}
         }
     }
     return new FfiConverter();

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -29,6 +29,7 @@
 {%- macro to_ffi_method_call(obj_factory, func) -%}
     {%- match func.throws_type() -%}
     {%- when Some with (e) -%}
+        {{- self.import_infra("rustCallWithError", "rust-call") }}
         rustCallWithError(
             /*liftError:*/ {{ e|lift_fn }},
             /*caller:*/ (callStatus) => {

--- a/fixtures/callbacks/tests/bindings/test_callbacks.ts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.ts
@@ -4,9 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 import myModule, {
-  ComplexException,
+  ComplexError,
   ForeignGetters,
-  SimpleException,
+  SimpleError,
   RustStringifier,
   RustGetters,
   StoredForeignStringifier,
@@ -46,7 +46,7 @@ class TypeScriptGetters implements ForeignGetters {
   }
   getOption(v: string | undefined, arg2: boolean): string | undefined {
     if (v == BAD_ARGUMENT) {
-      throw new ComplexException.ReallyBadArgument(20);
+      throw new ComplexError.ReallyBadArgument(20);
     }
     if (v == UNEXPECTED_ERROR) {
       throw Error(SOMETHING_FAILED);
@@ -58,7 +58,7 @@ class TypeScriptGetters implements ForeignGetters {
   }
   getNothing(v: string): void {
     if (v == BAD_ARGUMENT) {
-      throw new SimpleException.BadArgument(BAD_ARGUMENT);
+      throw new SimpleError.BadArgument(BAD_ARGUMENT);
     }
     if (v == UNEXPECTED_ERROR) {
       throw Error(SOMETHING_FAILED);
@@ -116,10 +116,10 @@ test("Optional callbacks serialized correctly", (t) => {
 test("Flat errors are propagated correctly", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  t.assertThrows(SimpleException.BadArgument.instanceOf, () =>
+  t.assertThrows(SimpleError.BadArgument.instanceOf, () =>
     rg.getNothing(callbackInterface, BAD_ARGUMENT),
   );
-  t.assertThrows(SimpleException.UnexpectedError.instanceOf, () =>
+  t.assertThrows(SimpleError.UnexpectedError.instanceOf, () =>
     rg.getNothing(callbackInterface, UNEXPECTED_ERROR),
   );
   rg.uniffiDestroy();
@@ -130,7 +130,7 @@ test("Non-flat errors are propagated correctly", (t) => {
   const callbackInterface = new TypeScriptGetters();
   t.assertThrows(
     (err) => {
-      const isError = ComplexException.ReallyBadArgument.instanceOf(err);
+      const isError = ComplexError.ReallyBadArgument.instanceOf(err);
       if (isError) {
         // set in TypesSriptGetters.getOption
         t.assertEqual(err.code, 20);
@@ -141,8 +141,7 @@ test("Non-flat errors are propagated correctly", (t) => {
   );
   t.assertThrows(
     (err) => {
-      const isError =
-        ComplexException.UnexpectedErrorWithReason.instanceOf(err);
+      const isError = ComplexError.UnexpectedErrorWithReason.instanceOf(err);
       if (isError) {
         t.assertEqual(err.reason, `Error: ${SOMETHING_FAILED}`);
       }

--- a/fixtures/coverall/tests/bindings/test_coverall.ts
+++ b/fixtures/coverall/tests/bindings/test_coverall.ts
@@ -9,13 +9,13 @@
 // cargo xtask run ./fixtures/${fixture}/tests/bindings/test_${fixture}.ts --cpp ./fixtures/${fixture}/generated/${fixture}.cpp --crate ./fixtures/${fixture}
 
 import {
-  CoverallException,
-  ComplexException,
+  CoverallError,
+  ComplexError,
   Coveralls,
   createNoneDict,
   createSomeDict,
   getNumAlive,
-  RootException,
+  RootError,
   throwRootError,
   getRootError,
   OtherError,
@@ -124,10 +124,10 @@ test("Simple Errors", (t) => {
     // OK
   }
   // Now the short hand.
-  t.assertThrows(CoverallException.TooManyHoles.instanceOf, () =>
+  t.assertThrows(CoverallError.TooManyHoles.instanceOf, () =>
     coveralls.maybeThrow(true),
   );
-  t.assertThrows(CoverallException.TooManyHoles.instanceOf, () =>
+  t.assertThrows(CoverallError.TooManyHoles.instanceOf, () =>
     coveralls.maybeThrowInto(true),
   );
   coveralls.uniffiDestroy();
@@ -138,7 +138,7 @@ test("Complex errors", (t) => {
   // No errors to throw with 0.
   t.assertTrue(coveralls.maybeThrowComplex(0));
 
-  t.assertThrows(ComplexException.OsError.instanceOf, () => {
+  t.assertThrows(ComplexError.OsError.instanceOf, () => {
     coveralls.maybeThrowComplex(1);
   });
   coveralls.uniffiDestroy();
@@ -146,22 +146,22 @@ test("Complex errors", (t) => {
 
 test("Error Values", (t) => {
   const coveralls = new Coveralls("Testing error values");
-  t.assertThrows(RootException.Complex.instanceOf, () => {
+  t.assertThrows(RootError.Complex.instanceOf, () => {
     throwRootError();
   });
   t.assertThrows(
-    (e) => ComplexException.instanceOf(e.error),
+    (e) => ComplexError.instanceOf(e.error),
     () => {
       throwRootError();
     },
   );
 
   const e = getRootError();
-  t.assertTrue(RootException.Other.instanceOf(e));
+  t.assertTrue(RootError.Other.instanceOf(e));
   t.assertEqual(e.error, OtherError.UNEXPECTED);
 
   const ce = getComplexError(undefined);
-  t.assertTrue(ComplexException.PermissionDenied.instanceOf(ce));
+  t.assertTrue(ComplexError.PermissionDenied.instanceOf(ce));
   t.assertNull(getErrorDict(undefined).complexError);
 
   coveralls.uniffiDestroy();

--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -18,10 +18,10 @@ import myModule, {
   getSayAfterUdlTraits,
   greet,
   Megaphone,
-  MyException,
+  MyError,
   newMegaphone,
   newMyRecord,
-  ParserException,
+  ParserError,
   sayAfter,
   sayAfterWithTokio,
   SharedResourceOptionsFactory,
@@ -166,7 +166,7 @@ class TsAsyncParser implements AsyncParser {
       throw new Error("force-panic");
     }
     if (value == "force-unexpected-exception") {
-      throw new ParserException.UnexpectedError();
+      throw new ParserError.UnexpectedError();
     }
     const v = this.parseInt(value);
     await this.doDelay(delayMs);
@@ -191,7 +191,7 @@ class TsAsyncParser implements AsyncParser {
   private parseInt(value: string): number {
     const num = Number.parseInt(value);
     if (Number.isNaN(num)) {
-      throw new ParserException.NotAnInt();
+      throw new ParserError.NotAnInt();
     }
     return num;
   }
@@ -230,11 +230,11 @@ asyncTest("Async callbacks with errors", async (t) => {
   }
 
   await t.assertThrowsAsync(
-    ParserException.NotAnInt.instanceOf,
+    ParserError.NotAnInt.instanceOf,
     async () => await tryFromStringUsingTrait(traitObj, 1, "fourty-two"),
   );
   await t.assertThrowsAsync(
-    ParserException.UnexpectedError.instanceOf,
+    ParserError.UnexpectedError.instanceOf,
     async () =>
       await tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception"),
   );
@@ -332,7 +332,7 @@ asyncTest("fallible method… which doesn't throw, part II", async (t) => {
 asyncTest("fallible function… which does throw", async (t) => {
   await t.asyncMeasure(
     async () =>
-      await t.assertThrowsAsync(MyException.Foo.instanceOf, async () =>
+      await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
         fallibleMe(true),
       ),
     0,
@@ -342,7 +342,7 @@ asyncTest("fallible function… which does throw", async (t) => {
 });
 
 asyncTest("fallible method… which does throw", async (t) => {
-  await t.assertThrowsAsync(MyException.Foo.instanceOf, async () =>
+  await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
     fallibleStruct(true),
   );
   t.end();
@@ -352,7 +352,7 @@ asyncTest("fallible method… which does throw, part II", async (t) => {
   const megaphone = newMegaphone();
   await t.asyncMeasure(
     async () =>
-      await t.assertThrowsAsync(MyException.Foo.instanceOf, async () =>
+      await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
         megaphone.fallibleMe(true),
       ),
     0,

--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -18,6 +18,7 @@ import myModule, {
   getSayAfterUdlTraits,
   greet,
   Megaphone,
+  MyException,
   newMegaphone,
   newMyRecord,
   ParserException,
@@ -165,10 +166,7 @@ class TsAsyncParser implements AsyncParser {
       throw new Error("force-panic");
     }
     if (value == "force-unexpected-exception") {
-      throw new ParserException(
-        "UnexpectedError",
-        "force-unexpected-exception",
-      );
+      throw new ParserException.UnexpectedError();
     }
     const v = this.parseInt(value);
     await this.doDelay(delayMs);
@@ -193,7 +191,7 @@ class TsAsyncParser implements AsyncParser {
   private parseInt(value: string): number {
     const num = Number.parseInt(value);
     if (Number.isNaN(num)) {
-      throw new ParserException("NotAnInt", "Not a number");
+      throw new ParserException.NotAnInt();
     }
     return num;
   }
@@ -214,7 +212,7 @@ asyncTest("Async callbacks", async (t) => {
   t.end();
 });
 
-xasyncTest("Async callbacks with errors", async (t) => {
+asyncTest("Async callbacks with errors", async (t) => {
   const traitObj = new TsAsyncParser();
 
   try {
@@ -232,11 +230,11 @@ xasyncTest("Async callbacks with errors", async (t) => {
   }
 
   await t.assertThrowsAsync(
-    "ParserException.NotAnInt",
+    ParserException.NotAnInt.instanceOf,
     async () => await tryFromStringUsingTrait(traitObj, 1, "fourty-two"),
   );
   await t.assertThrowsAsync(
-    "ParserException.UnexpectedError",
+    ParserException.UnexpectedError.instanceOf,
     async () =>
       await tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception"),
   );
@@ -331,26 +329,30 @@ asyncTest("fallible method… which doesn't throw, part II", async (t) => {
   t.end();
 });
 
-xasyncTest("fallible function… which does throw", async (t) => {
+asyncTest("fallible function… which does throw", async (t) => {
   await t.asyncMeasure(
     async () =>
-      await t.assertThrowsAsync("MyError.Foo", async () => fallibleMe(true)),
+      await t.assertThrowsAsync(MyException.Foo.instanceOf, async () =>
+        fallibleMe(true),
+      ),
     0,
     100,
   );
   t.end();
 });
 
-xasyncTest("fallible method… which does throw", async (t) => {
-  await t.assertThrowsAsync("MyError.Foo", async () => fallibleStruct(true));
+asyncTest("fallible method… which does throw", async (t) => {
+  await t.assertThrowsAsync(MyException.Foo.instanceOf, async () =>
+    fallibleStruct(true),
+  );
   t.end();
 });
 
-xasyncTest("fallible method… which does throw, part II", async (t) => {
+asyncTest("fallible method… which does throw, part II", async (t) => {
   const megaphone = newMegaphone();
   await t.asyncMeasure(
     async () =>
-      await t.assertThrowsAsync("MyError.Foo", async () =>
+      await t.assertThrowsAsync(MyException.Foo.instanceOf, async () =>
         megaphone.fallibleMe(true),
       ),
     0,

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -61,7 +61,7 @@ export function uniffiTraitInterfaceCallWithError<T, E extends Error>(
   callStatus: UniffiRustCallStatus,
   makeCall: () => T,
   writeReturn: (v: T) => void,
-  errorType: string,
+  isErrorType: (e: any) => boolean,
   lowerError: (err: E) => ArrayBuffer,
   lowerString: (s: string) => ArrayBuffer,
 ): void {
@@ -70,8 +70,7 @@ export function uniffiTraitInterfaceCallWithError<T, E extends Error>(
   } catch (e: any) {
     // Hermes' prototype chain seems buggy, so we need to make our
     // own arrangements
-    const errorTypeName = (e as any)._uniffiTypeName as string | undefined;
-    if (e instanceof Error && errorTypeName === errorType) {
+    if (isErrorType(e)) {
       callStatus.code = CALL_ERROR;
       callStatus.errorBuf = lowerError(e as E);
     } else {

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -3,65 +3,96 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-export class UniffiInternalError extends Error {
-  private constructor(message: string) {
+
+// The top level error class for all uniffi-wrapped errors.
+//
+// The readonly fields are used to implement both the instanceOf checks which are used
+// in tests and in the generated callback code, and more locally the FfiConverters
+// for each error.
+export class UniffiError extends Error {
+  constructor(
+    private readonly __uniffiTypeName: string,
+    private readonly __variantName: string,
+    private readonly __variant: number,
+    message?: string,
+  ) {
     super(message);
   }
-  static NumberOverflow = class NumberOverflow extends UniffiInternalError {
+
+  static instanceOf(err: any): err is UniffiError {
+    return err instanceof Error && (err as any).__uniffiTypeName !== undefined;
+  }
+}
+
+export const UniffiInternalError = (() => {
+  class NumberOverflow extends Error {
     constructor() {
       super("Cannot convert a large BigInt into a number");
     }
-  };
-  static BufferOverflow = class BufferOverflow extends UniffiInternalError {
+  }
+  class BufferOverflow extends Error {
     constructor() {
       super(
         "Reading the requested value would read past the end of the buffer",
       );
     }
-  };
-  static IncompleteData = class IncompleteData extends UniffiInternalError {
+  }
+  class IncompleteData extends Error {
     constructor() {
       super("The buffer still has data after lifting its containing value");
     }
-  };
-  static UnexpectedOptionalTag = class UnexpectedOptionalTag extends UniffiInternalError {
+  }
+  class UnexpectedOptionalTag extends Error {
     constructor() {
       super("Unexpected optional tag; should be 0 or 1");
     }
-  };
-  static UnexpectedEnumCase = class UnexpectedEnumCase extends UniffiInternalError {
+  }
+  class UnexpectedEnumCase extends Error {
     constructor() {
       super("Raw enum value doesn't match any cases");
     }
-  };
-  static UnexpectedNullPointer = class UnexpectedNullPointer extends UniffiInternalError {
+  }
+  class UnexpectedNullPointer extends Error {
     constructor() {
       super("Raw pointer value was null");
     }
-  };
-  static UnexpectedRustCallStatusCode = class UnexpectedRustCallStatusCode extends UniffiInternalError {
+  }
+  class UnexpectedRustCallStatusCode extends Error {
     constructor() {
       super("Unexpected UniffiRustCallStatus code");
     }
-  };
-  static UnexpectedRustCallError = class UnexpectedRustCallError extends UniffiInternalError {
+  }
+  class UnexpectedRustCallError extends Error {
     constructor() {
       super("CALL_ERROR but no errorClass specified");
     }
-  };
-  static UnexpectedStaleHandle = class UnexpectedStaleHandle extends UniffiInternalError {
+  }
+  class UnexpectedStaleHandle extends Error {
     constructor() {
       super("The object in the handle map has been dropped already");
     }
-  };
-  static RustPanic = class RustPanic extends UniffiInternalError {
+  }
+  class RustPanic extends Error {
     constructor(message: string) {
       super(message);
     }
-  };
-  static Unimplemented = class Unimplemented extends UniffiInternalError {
+  }
+  class Unimplemented extends Error {
     constructor(message: string) {
       super(message);
     }
+  }
+  return {
+    NumberOverflow,
+    BufferOverflow,
+    IncompleteData,
+    UnexpectedOptionalTag,
+    UnexpectedEnumCase,
+    UnexpectedNullPointer,
+    UnexpectedRustCallStatusCode,
+    UnexpectedRustCallError,
+    UnexpectedStaleHandle,
+    RustPanic,
+    Unimplemented,
   };
-}
+})();

--- a/typescript/tests/errors.test.ts
+++ b/typescript/tests/errors.test.ts
@@ -1,0 +1,130 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+import { Asserts, test, xtest } from "../testing/asserts";
+import { console } from "../testing/hermes";
+
+// This test is showing and experimenting with the limitations of hermes.
+// The actual Uniffi error may not stay as this implementation.
+class UniffiError extends Error {
+  constructor(
+    private __typename: string,
+    private __variant: string,
+    message?: string,
+  ) {
+    super(message);
+  }
+
+  static instanceOf(err: any): err is UniffiError {
+    return err instanceof Error && (err as any).__typename !== undefined;
+  }
+}
+
+const MyError = (() => {
+  class ThisException extends UniffiError {
+    constructor() {
+      super("ComplexError", "ThisException");
+    }
+    static instanceOf(e: any): e is ThisException {
+      return instanceOf(e) && (e as any).__variant === "ThisException";
+    }
+  }
+  class OtherException extends UniffiError {
+    constructor() {
+      super("ComplexError", "OtherException");
+    }
+    static instanceOf(e: any): e is OtherException {
+      return instanceOf(e) && (e as any).__variant === "OtherException";
+    }
+  }
+  function instanceOf(e: any): e is ThisException | OtherException {
+    return (e as any).__typename === "ComplexError";
+  }
+
+  return {
+    ThisException,
+    OtherException,
+    instanceOf,
+  };
+})();
+
+test("Typesecript type generation", (t) => {
+  // Create a type that represents the instance types of the properties of MyError, excluding 'instanceOf'
+  type MyErrorType = InstanceType<
+    (typeof MyError)[keyof Omit<typeof MyError, "instanceOf">]
+  >;
+  const err: MyErrorType = new MyError.ThisException();
+});
+
+test("Vanilla instanceof tests", (t) => {
+  const err = new MyError.ThisException();
+  t.assertTrue(err instanceof Error, `err is Error`);
+
+  // If this every fails, then hermes now supports instanceof checks
+  // for subclasses. This opens up the possiblility of simplifying the
+  // generated error classes, and error handling logic.
+  //
+  // At that point, we need to: raise a github issue to track that work,
+  // and then flip these tests to assertTrue.
+  t.assertFalse(err instanceof UniffiError, `err is UniffiError`);
+  t.assertFalse(err instanceof MyError.ThisException, `err is ThisException`);
+});
+
+test("Vanilla instanceof tests with constructors", (t) => {
+  const err = new MyError.ThisException();
+  t.assertTrue(err instanceof Error, `err is Error`);
+
+  // If this every fails, then hermes now supports instanceof checks
+  // for subclasses. This opens up the possiblility of simplifying the
+  // generated error classes, and error handling logic.
+  //
+  // At that point, we need to: raise a github issue to track that work,
+  // and then flip these tests to assertEqual.
+  t.assertNotEqual(
+    err.constructor,
+    MyError.ThisException,
+    `err is ThisException`,
+  );
+});
+
+test("Dynamic instanceof tests", (t) => {
+  const err = new MyError.ThisException();
+  const myType = MyError.ThisException;
+  t.assertTrue(MyError.instanceOf(err), `err is MyError`);
+  t.assertTrue(MyError.ThisException.instanceOf(err), `err is ThisException`);
+
+  const myInstanceOf = myType.instanceOf;
+  t.assertTrue(myInstanceOf(err), `Dynamic instanceOf`);
+});
+
+test("Higher order instanceof tests", (t) => {
+  const err = new MyError.ThisException();
+  const myType = MyError.ThisException;
+
+  function checkInstanceOf<T>(e: any, instanceOf: (e: any) => boolean): e is T {
+    return instanceOf(e);
+  }
+
+  const myInstanceOf = myType.instanceOf;
+  t.assertTrue(checkInstanceOf(err, myInstanceOf), `checkInstanceOf`);
+});
+
+test("Higher order type tests", (t) => {
+  const err = new MyError.ThisException();
+  const myType = MyError.ThisException;
+
+  function checkType<T>(e: any, type: new () => T): e is T {
+    return e instanceof type;
+  }
+
+  // If this every fails, then hermes now supports instanceof checks
+  // for subclasses. This opens up the possiblility of simplifying the
+  // generated error classes, and error handling logic.
+  //
+  // At that point, we need to: raise a github issue to track that work,
+  // and then flip the test to assertTrue.
+  t.assertFalse(checkType(err, myType), `checkType`);
+});

--- a/typescript/tests/event-loop.test.ts
+++ b/typescript/tests/event-loop.test.ts
@@ -12,9 +12,12 @@ asyncTest("Dummy test that should end properly", async (t) => {
 // asyncTest("Top level empty test that should error out", async (t) => {});
 
 asyncTest("assertThrowsAsync catches errors", async (t) => {
-  await t.assertThrowsAsync("Error.unknown", async () => {
-    throw new Error();
-  });
+  await t.assertThrowsAsync(
+    () => true,
+    async () => {
+      throw new Error();
+    },
+  );
   t.end();
 });
 


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Rust does not have checked exceptions, instead uses a general purpose `Result<T, E>` enum.

Where `E` is a simple enum, uniffi calls this a "flat errror".

Where `E` to be an enum with associated values, uniffi calls this a "non-flat error".

This PR re-implements the generation of errors for typescript, so as to enable non-flat errors.

As part of this work: 

- implemented a collection of `Error` subclasses, one for each variant in the `Error` enum.
- implemented our own static `instanceOf` method for the (Rust) `Error` enums and (Typescript) `Error` subclasses.
- used these `instanceOf` in the callback and async-callback code to detect if the error was expected or not.
- enabled the skipped tests for futures fixture.
- added more tests to the coverall and callbacks fixture.
- renamed errors that are called `Error` (which collides with JS `Error`) to `Exception`. This tightens up the rule which was really only intended for JVM based languages.
