### PR TITLE
Change CMakeLists to use node to find correct location of uniffi

### DIFF
--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(
     {{ tm_dir }}
     {{ bindings_dir }}
 
-    ../node_modules/uniffi-bindgen-react-native/cpp/includes
+    $$(shell node -p "require.resolve('uniffi-bindgen-react-native/objects')" | sed 's/\/dist.*//')/cpp/includes
 )
 
 add_library(


### PR DESCRIPTION
Instead of using relative directory, execute node to find the real location of objects.

This does bake in the fact that objects is at dist/objects, but it can only pull in things in the exports of the package.json