### PR TITLE
Combine build and generate commands on the command line.

### DIFF
--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -17,4 +17,4 @@ fi
 
 manifest_path="${root_dir}/crates/ubrn_cli/Cargo.toml"
 
-cargo run --manifest-path "${manifest_path}" -- "$@"
+cargo run --quiet --manifest-path "${manifest_path}" -- "$@"

--- a/crates/ubrn_cli/src/cli.rs
+++ b/crates/ubrn_cli/src/cli.rs
@@ -22,9 +22,11 @@ pub(crate) struct CliArgs {
 pub(crate) enum CliCmd {
     /// Checkout a given Github repo into `rust_modules`
     Checkout(CheckoutArgs),
-    /// Build for android, ios or testing
+    /// Build (and optionally generate code) for Android or iOS
     Build(BuildArgs),
-    /// Generate code from the Rust.
+    /// Generate bindings or the turbo-module glue code from the Rust.
+    ///
+    /// These steps are already performed when building with `--and-generate`.
     Generate(GenerateArgs),
 }
 

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -60,6 +60,11 @@ pub fn pwd() -> Result<Utf8PathBuf> {
     Ok(Utf8PathBuf::try_from(path)?)
 }
 
+pub fn cd(dir: &Utf8Path) -> Result<()> {
+    std::env::set_current_dir(dir)?;
+    Ok(())
+}
+
 pub fn rm_dir<P: AsRef<Utf8Path>>(dir: P) -> Result<()> {
     if dir.as_ref().exists() {
         fs::remove_dir_all(dir.as_ref())?;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "./type-utils": "./dist/type-utils.js"
   },
   "bin": {
+    "ubrn": "./bin/cli.sh",
     "uniffi-bindgen-react-native": "./bin/cli.sh"
   },
   "scripts": {


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR combines the `build` step with the `generate bindings` and `generate turbo-module` steps.

Instead of:

```sh
ubrn build ios --config matrix-sdk.yaml
(cd rust_modules/matrix-rust-sdk && ubrn generate bindings --library target/aarch64-apple-ios/debug/libmatrix_sdk.a --ts-dir ../../src/generated --cpp-dir ../../cpp/generated )
ubrn generate turbo-module --config matrix-sdk.yaml matrix_sdk matrix_sdk_ui matrix_sdk_ffi
```

Now, we only have to add `--and-generate` to the build command:
```sh
ubrn build ios --config matrix-sdk.yaml --and-generate
```