### PR TITLE
Remove need for `enablePackageExports` in depending projects

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
@@ -162,17 +162,17 @@ impl<'a> TypeRenderer<'a> {
     // ```
     //
     // Returns an empty string so that it can be used inside an askama `{{ }}` block.
-    fn import_infra(&self, what: &str, from: &str) -> &str {
+    fn import_infra(&self, what: &str, _from: &str) -> &str {
         self.add_import(
             Imported::JSType(what.to_owned()),
-            &format!("uniffi-bindgen-react-native/{from}"),
+            "uniffi-bindgen-react-native",
         )
     }
 
-    fn import_infra_type(&self, what: &str, from: &str) -> &str {
+    fn import_infra_type(&self, what: &str, _from: &str) -> &str {
         self.add_import(
             Imported::TSType(what.to_owned()),
-            &format!("uniffi-bindgen-react-native/{from}"),
+            "uniffi-bindgen-react-native",
         )
     }
 

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper-ffi.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper-ffi.ts
@@ -1,7 +1,9 @@
-import { type UniffiRustFutureContinuationCallback as RuntimeUniffiRustFutureContinuationCallback } from 'uniffi-bindgen-react-native/async-rust-call';
-import { type StructuralEquality as UniffiStructuralEquality } from 'uniffi-bindgen-react-native/type-utils';
-import { type UniffiRustCallStatus } from 'uniffi-bindgen-react-native/rust-call';
-import { type UniffiReferenceHolder } from 'uniffi-bindgen-react-native/callbacks';
+import {
+  type StructuralEquality as UniffiStructuralEquality,
+  type UniffiReferenceHolder,
+  type UniffiRustCallStatus,
+  type UniffiRustFutureContinuationCallback as RuntimeUniffiRustFutureContinuationCallback,
+ } from 'uniffi-bindgen-react-native';
 
 interface NativeModuleInterface {
     {%- for func in ci.iter_ffi_functions_js_to_cpp() %}

--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -11,12 +11,23 @@ project({{ self.config.project.cpp_filename() }})
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 17)
 
+# Resolve the path to the uniffi-bindgen-react-native package
+execute_process(
+    COMMAND node -p "require.resolve('uniffi-bindgen-react-native')"
+    OUTPUT_VARIABLE UNIFFI_BINDGEN_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(REGEX
+  REPLACE "/typescript/src/index\\.ts$" ""
+  UNIFFI_BINDGEN_PATH ${UNIFFI_BINDGEN_PATH}
+)
+
 # Specifies a path to native header files.
 include_directories(
     {{ tm_dir }}
     {{ bindings_dir }}
 
-    $$(shell node -p "require.resolve('uniffi-bindgen-react-native/objects')" | sed 's/\/dist.*//')/cpp/includes
+    ${UNIFFI_BINDGEN_PATH}/cpp/includes
 )
 
 add_library(

--- a/package.json
+++ b/package.json
@@ -12,19 +12,7 @@
     "email": "james@hugman.tv"
   },
   "type": "module",
-  "exports": {
-    "./async-rust-call": "./dist/async-rust-call.js",
-    "./async-callbacks": "./dist/async-callbacks.js",
-    "./callbacks": "./dist/callbacks.js",
-    "./errors": "./dist/errors.js",
-    "./ffi-converters": "./dist/ffi-converters.js",
-    "./ffi-types": "./dist/ffi-types.js",
-    "./handle-map": "./dist/handle-map.js",
-    "./objects": "./dist/objects.js",
-    "./rust-call": "./dist/rust-call.js",
-    "./records": "./dist/records.js",
-    "./type-utils": "./dist/type-utils.js"
-  },
+  "main": "./typescript/src/index.ts",
   "bin": {
     "ubrn": "./bin/cli.sh",
     "uniffi-bindgen-react-native": "./bin/cli.sh"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,8 @@
     "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "module": "commonjs",                                /* Specify what module code is generated. */
     "paths": {                                           /* Specify a set of entries that re-map imports to additional lookup locations. */
-      "uniffi-bindgen-react-native/*": ["./typescript/src/*"],
       "@/*": ["./typescript/testing/*"],
     },
-    "outDir": "./dist",
-    "declaration": true,
-    "declarationDir": "./dist",
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
     "strict": true,                                      /* Enable all strict type-checking options. */

--- a/typescript/src/async-callbacks.ts
+++ b/typescript/src/async-callbacks.ts
@@ -3,10 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { RustBuffer } from "./ffi-types";
 import { CALL_ERROR, CALL_UNEXPECTED_ERROR } from "./rust-call";
 import {
-  UniffiHandle,
+  type UniffiHandle,
   UniffiHandleMap,
   defaultUniffiHandle,
 } from "./handle-map";

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -6,14 +6,14 @@
 import { type FfiConverter, FfiConverterUInt64 } from "./ffi-converters";
 import { RustBuffer } from "./ffi-types";
 import {
-  UniffiHandle,
+  type UniffiHandle,
   UniffiHandleMap,
   defaultUniffiHandle,
 } from "./handle-map";
 import {
   CALL_ERROR,
   CALL_UNEXPECTED_ERROR,
-  UniffiRustCallStatus,
+  type UniffiRustCallStatus,
 } from "./rust-call";
 
 const handleConverter = FfiConverterUInt64;

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Entry point for the runtime for uniffi-bindgen-react-native.
+// This modules is not needed directly, but is imported from generated code.
+//
+export * from "./async-callbacks";
+export * from "./async-rust-call";
+export * from "./callbacks";
+export * from "./errors";
+export * from "./ffi-converters";
+export * from "./ffi-types";
+export * from "./handle-map";
+export * from "./objects";
+export * from "./records";
+export * from "./rust-call";
+export * from "./type-utils";

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -7,7 +7,7 @@
 import { type FfiConverter, FfiConverterUInt64 } from "./ffi-converters";
 import { RustBuffer } from "./ffi-types";
 import type { UniffiRustArcPtr } from "./rust-call";
-import { UniffiHandle, UniffiHandleMap } from "./handle-map";
+import { type UniffiHandle, UniffiHandleMap } from "./handle-map";
 import { type StructuralEquality } from "./type-utils";
 
 /**

--- a/typescript/tsconfig.template.json
+++ b/typescript/tsconfig.template.json
@@ -30,7 +30,7 @@
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {                                           /* Specify a set of entries that re-map imports to additional lookup locations. */
-      "uniffi-bindgen-react-native/*": ["{{repository_root}}/typescript/src/*"],
+      "uniffi-bindgen-react-native": ["{{repository_root}}/typescript/src/index"],
       "@/*": ["{{repository_root}}/typescript/testing/*"],
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Fixes #13.

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

