### PR TITLE
Use node to resolve path to ubrn module.

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -5,16 +5,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 #
 set -e
-script_dir="$(dirname "${BASH_SOURCE[0]}")"
-if [[ "$script_dir" == *".bin" ]] ; then
-    root_dir="$(cd "$script_dir/../uniffi-bindgen-react-native" && pwd)"
-elif [[ "$script_dir" == *"bin" ]] ; then
-    root_dir="$(cd "$script_dir/.." && pwd)"
-else
-    echo "Unable to locate the uniffi-bindgen-react-native directory" 2>/dev/null
-    exit 1
-fi
 
+# Use Node to resolve the path to the module. The require.resolve
+# function returns a thing like:
+#
+# PATH_TO/node_modules/uniffi-bindgen-react-native/typescript/src/index.ts
+#
+# So we drop the /typescript/src/index.ts.
+resolved_path=$(node --print "require.resolve('uniffi-bindgen-react-native')")
+root_dir=${resolved_path/\/typescript\/src\/index.ts*/}
 manifest_path="${root_dir}/crates/ubrn_cli/Cargo.toml"
 
 cargo run --quiet --manifest-path "${manifest_path}" -- "$@"


### PR DESCRIPTION
This is a similar change to what we had to do in the CMakeList generation.