### PR TITLE
Simplify React name trimming function.

### DIFF
--- a/cpp/includes/UniffiCallInvoker.h
+++ b/cpp/includes/UniffiCallInvoker.h
@@ -80,5 +80,16 @@ public:
       cv.wait(lock, [&done] { return done; });
     }
   }
+
+  void invokeAsync(jsi::Runtime &rt, UniffiCallFunc &func) {
+    if (std::this_thread::get_id() == threadId_) {
+      func(rt);
+    } else {
+      std::function<void()> wrapper = [&func, &rt]() {
+        func(rt);
+      };
+      callInvoker_->invokeAsync(std::move(wrapper));
+    }
+  }
 };
 } // namespace uniffi_runtime

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/Future.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/Future.cpp
@@ -14,7 +14,8 @@ template <> struct Bridging<UniffiRustFutureContinuationCallback> {
       static auto callback = {{ cb_type.borrow()|cpp_namespace(ci) }}::makeCallbackFunction(
         rt,
         callInvoker,
-        value
+        value,
+        true
       );
       return callback;
     } catch (const std::logic_error &e) {

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -9,7 +9,15 @@ export const {{ decl_type_name }} = (() => {
     {%-   call ts::docstring(variant, 4) %}
     {%-   let variant_name = variant.name()|class_name(ci) %}
     class {{ variant_name }} extends UniffiError {
+        /**
+         * @private
+         * This field is private and should not be used.
+         */
         readonly __uniffiTypeName = "{{ type_name }}";
+        /**
+         * @private
+         * This field is private and should not be used.
+         */
         readonly __variant = {{ loop.index }};
         constructor(message: string) {
             super("{{ type_name }}", "{{ variant_name }}", message);

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -9,8 +9,8 @@ export const {{ decl_type_name }} = (() => {
     {%-   call ts::docstring(variant, 4) %}
     {%-   let variant_name = variant.name()|class_name(ci) %}
     class {{ variant_name }} extends UniffiError {
-        private readonly __uniffiTypeName = "{{ type_name }}";
-        private readonly __variant = {{ loop.index }};
+        readonly __uniffiTypeName = "{{ type_name }}";
+        readonly __variant = {{ loop.index }};
         constructor(message: string) {
             super("{{ type_name }}", "{{ variant_name }}", message);
         }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -56,6 +56,10 @@ export const {{ decl_type_name }} = (() => {
 
     {% call ts::docstring(variant, 4) %}
     class {{ variant_name }} extends {{ superclass }} implements {{ variant_interface }} {
+        /**
+         * @private
+         * This field is private and should not be used, use `tag` instead.
+         */
         readonly __uniffiTypeName = "{{ type_name }}";
         readonly tag = {{ variant_tag }};
         {%- if has_fields %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -56,7 +56,7 @@ export const {{ decl_type_name }} = (() => {
 
     {% call ts::docstring(variant, 4) %}
     class {{ variant_name }} extends {{ superclass }} implements {{ variant_interface }} {
-        private readonly __uniffiTypeName = "{{ type_name }}";
+        readonly __uniffiTypeName = "{{ type_name }}";
         readonly tag = {{ variant_tag }};
         {%- if has_fields %}
         readonly inner: {% call variant_data_type(variant) %};

--- a/crates/ubrn_cli/src/config/mod.rs
+++ b/crates/ubrn_cli/src/config/mod.rs
@@ -56,11 +56,7 @@ impl ProjectConfig {
 }
 
 fn trim_react_native(name: &str) -> String {
-    name.strip_prefix("RN")
-        .unwrap_or(name)
-        .replace("ReactNative", "")
-        .replace("react-native", "")
-        .trim_matches('-')
+    name.trim_matches('-')
         .trim_matches('_')
         .to_string()
 }
@@ -181,7 +177,7 @@ impl TurboModulesConfig {
     fn default_spec_name() -> String {
         let package_json = workspace::package_json();
         let codegen_name = &package_json.codegen().name;
-        format!("Native{}", trim_react_native(codegen_name))
+        trim_react_native(codegen_name)
     }
 }
 

--- a/typescript/src/async-rust-call.ts
+++ b/typescript/src/async-rust-call.ts
@@ -33,6 +33,12 @@ type PollFunc = (
   handle: UniffiHandle,
 ) => void;
 
+// Calls setTimeout and then resolves the promise.
+// This may be used as a simple yield.
+export async function delayPromise(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
 /**
  * This method calls an asynchronous method on the Rust side.
  *
@@ -71,7 +77,7 @@ export async function uniffiRustCallAsync<F, T>(
       pollResult = await pollRust((handle) => {
         pollFunc(rustFuture, uniffiFutureContinuationCallback, handle);
       });
-    } while (pollResult != UNIFFI_RUST_FUTURE_POLL_READY);
+    } while (pollResult !== UNIFFI_RUST_FUTURE_POLL_READY);
 
     // Now it's ready, all we need to do is pick up the result (and error).
     return liftFunc(
@@ -85,7 +91,7 @@ export async function uniffiRustCallAsync<F, T>(
     // #RUST_TASK_CANCELLATION: the unused `cancelFunc` function should be exposed
     // to client code in order for clients to be able to cancel the running Rust task.
   } finally {
-    freeFunc(rustFuture);
+    setTimeout(() => freeFunc(rustFuture), 0);
   }
 }
 
@@ -110,7 +116,24 @@ const uniffiFutureContinuationCallback: UniffiRustFutureContinuationCallback = (
   pollResult: number,
 ) => {
   const resolve = UNIFFI_RUST_FUTURE_RESOLVER_MAP.remove(handle);
-  resolve(pollResult);
+  if (pollResult === UNIFFI_RUST_FUTURE_POLL_READY) {
+    resolve(pollResult);
+  } else {
+    // From https://github.com/mozilla/uniffi-rs/pull/1837/files#diff-8a28c9cf1245b4f714d406ea4044d68e1000099928eaca1afb504ccbc008fe9fR35-R37
+    //
+    // > WARNING: the call to [rust_future_poll] must be scheduled to happen soon after the callback is
+    // > called, but not inside the callback itself.  If [rust_future_poll] is called inside the
+    // > callback, some futures will deadlock and our scheduler code might as well.
+    //
+    // This delay is to ensure that `uniffiFutureContinuationCallback` returns before the next poll, i.e.
+    // so that the next poll is outside of this callback.
+    //
+    // The length of the delay seems to be significant (at least in tests which hammer a network).
+    // I would like to understand this more: I am still seeing deadlocks when this drops below its current
+    // delay, but these maybe related to a different issue, as alluded to in
+    // https://github.com/mozilla/uniffi-rs/pull/1901
+    setTimeout(() => resolve(pollResult), 20);
+  }
 };
 
 // For testing only.

--- a/typescript/tests/playground/enums.ts
+++ b/typescript/tests/playground/enums.ts
@@ -12,7 +12,7 @@ export const MyEnum = (() => {
     inner: Readonly<{ myValue: string }>;
   };
   class Variant1_ extends UniffiEnum implements Variant1__interface {
-    private readonly __uniffiTypeName = typeName;
+    readonly __uniffiTypeName = typeName;
     readonly tag = "Variant1";
     readonly inner: Readonly<{ myValue: string }>;
     constructor(inner: { myValue: string }) {
@@ -29,7 +29,7 @@ export const MyEnum = (() => {
     inner: Readonly<[number, string]>;
   };
   class Variant2_ extends UniffiEnum implements Variant2__interface {
-    private readonly __uniffiTypeName = typeName;
+    readonly __uniffiTypeName = typeName;
     readonly tag = "Variant2";
     readonly inner: Readonly<[number, string]>;
     constructor(p1: number, p2: string) {


### PR DESCRIPTION
This simplifies the way in which we create a trimmed react name, which has downstream implications in a few places. For example, this function is used in generating the `Native___` names, spec names, and namespace. Previously, if you named your package RNFoo vs Foo then you would get FooSpec in both cases, as well as placement in the foo namespace.  This is specialized knowledge a user of the ubrn would need to know. Whereas now, RNFoo results in RnFooSpec and rnfoo, and Foo results in FooSpec and foo.

It's possible I've misunderstood what the point of this was.. just I was having difficulty understanding in what cases I could drop RN, and in what cases Native got prefixed. I'm open to doing something different here, I just want to minimize the surprise from the user's perspective.