### PR TITLE
Prefer interface types to concrete class names

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/callback_interface.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/callback_interface.rs
@@ -19,6 +19,10 @@ impl CallbackInterfaceCodeType {
 }
 
 impl CodeType for CallbackInterfaceCodeType {
+    fn decl_type_label(&self, ci: &ComponentInterface) -> String {
+        format!("{}Impl", CodeOracle.class_name(ci, &self.id))
+    }
+
     fn type_label(&self, ci: &ComponentInterface) -> String {
         CodeOracle.class_name(ci, &self.id)
     }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/filters.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/filters.rs
@@ -7,7 +7,7 @@ use super::oracle::{AsCodeType, CodeOracle};
 pub(crate) use uniffi_bindgen::backend::filters::*;
 use uniffi_bindgen::{
     backend::{filters::UniFFIError, Literal, Type},
-    interface::{AsType, Enum, FfiType, Object, Variant},
+    interface::{AsType, Enum, FfiType, Variant},
     ComponentInterface,
 };
 
@@ -100,14 +100,6 @@ fn int_literal(t: &Option<Type>, base10: String) -> Result<String, askama::Error
             "Enum hasn't defined a repr".to_string(),
         ))))
     }
-}
-
-/// Get the idiomatic Python rendering of an individual enum variant.
-pub fn object_names(
-    obj: &Object,
-    ci: &ComponentInterface,
-) -> Result<(String, String), askama::Error> {
-    Ok(CodeOracle.object_names(ci, obj))
 }
 
 pub fn variant_discr_literal(

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/object.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/object.rs
@@ -19,8 +19,34 @@ impl ObjectCodeType {
 }
 
 impl CodeType for ObjectCodeType {
+    // This is the name of the type/interface.
+    //
+    // In Kotlin, this is `{class_name}Interface`, and for callback
+    // interfaces (when `self.imp.has_callback_interface()`) `{class_name}`.
+    //
     fn type_label(&self, ci: &ComponentInterface) -> String {
-        CodeOracle.class_name(ci, &self.name)
+        if !self.imp.has_callback_interface() {
+            format!("{}Interface", CodeOracle.class_name(ci, &self.name))
+        } else {
+            CodeOracle.class_name(ci, &self.name)
+        }
+    }
+
+    // This is the name of the implementation class, that implements the interface
+    // above.
+    //
+    // In Kotlin, this is `{class_name}`, and for callback
+    // interfaces (when `self.imp.has_callback_interface()`) `{class_name}Impl`.
+    //
+    // Unlike other languages, in Typescript it is legal to have the interface/type called the same thing
+    // as the implementation class. This is very useful so as avoid extra cognitive burden,
+    // and naming collisions.
+    fn decl_type_label(&self, ci: &ComponentInterface) -> String {
+        if self.imp.has_callback_interface() {
+            format!("{}Impl", CodeOracle.class_name(ci, &self.name))
+        } else {
+            CodeOracle.class_name(ci, &self.name)
+        }
     }
 
     fn canonical_name(&self) -> String {

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
@@ -6,7 +6,7 @@
 use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use uniffi_bindgen::{
     backend::{Literal, Type},
-    interface::{AsType, FfiType, Object},
+    interface::{AsType, FfiType},
     ComponentInterface,
 };
 
@@ -152,24 +152,6 @@ impl CodeOracle {
             FfiType::Struct(name) => self.ffi_struct_name(name),
             FfiType::Reference(inner) => self.ffi_type_label_by_reference(inner),
             FfiType::VoidPointer => "/*pointer*/ bigint".to_string(),
-        }
-    }
-
-    /// Get the name of the interface and class name for an object.
-    ///
-    /// If we support callback interfaces, the interface name is the object name, and the class name is derived from that.
-    /// Otherwise, the class name is the object name and the interface name is derived from that.
-    ///
-    /// This split determines what types `FfiConverter.lower()` inputs.  If we support callback
-    /// interfaces, `lower` must lower anything that implements the interface.  If not, then lower
-    /// only lowers the concrete class.
-    pub(crate) fn object_names(&self, ci: &ComponentInterface, obj: &Object) -> (String, String) {
-        let class_name = self.class_name(ci, obj.name());
-        if obj.has_callback_interface() {
-            let impl_name = format!("{class_name}Impl");
-            (class_name, impl_name)
-        } else {
-            (format!("{class_name}Interface"), class_name)
         }
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -93,7 +93,7 @@
         super();
         const pointer =
             {% call to_ffi_method_call(obj_factory, callable) %};
-        this._rustArcPtr = {{ obj_factory }}.bless(pointer);
+        this.__rustArcPtr = {{ obj_factory }}.bless(pointer);
     }
 {%- endmacro %}
 

--- a/fixtures/coverall/tests/bindings/test_coverall.ts
+++ b/fixtures/coverall/tests/bindings/test_coverall.ts
@@ -11,6 +11,7 @@
 import {
   CoverallError,
   ComplexError,
+  CoverallsInterface,
   Coveralls,
   createNoneDict,
   createSomeDict,
@@ -21,6 +22,10 @@ import {
   OtherError,
   getComplexError,
   getErrorDict,
+  EmptyStruct,
+  Patch,
+  Repair,
+  PatchInterface,
 } from "../../generated/coverall";
 import { test } from "@/asserts";
 import { console } from "@/hermes";
@@ -165,4 +170,82 @@ test("Error Values", (t) => {
   t.assertNull(getErrorDict(undefined).complexError);
 
   coveralls.uniffiDestroy();
+});
+
+test("Dummy coveralls implement the Coveralls interface", (t) => {
+  // We're testing only whether this is compilable.
+  class DummyCoveralls implements CoverallsInterface {
+    addPatch(patch: PatchInterface): void {
+      throw new Error("Method not implemented.");
+    }
+    addRepair(repair: Repair): void {
+      throw new Error("Method not implemented.");
+    }
+    cloneMe(): CoverallsInterface {
+      throw new Error("Method not implemented.");
+    }
+    falliblePanic(message: string): void {
+      throw new Error("Method not implemented.");
+    }
+    getDict(key: string, value: bigint): Map<string, bigint> {
+      throw new Error("Method not implemented.");
+    }
+    getDict2(key: string, value: bigint): Map<string, bigint> {
+      throw new Error("Method not implemented.");
+    }
+    getDict3(key: number, value: bigint): Map<number, bigint> {
+      throw new Error("Method not implemented.");
+    }
+    getName(): string {
+      throw new Error("Method not implemented.");
+    }
+    getOther(): CoverallsInterface | undefined {
+      throw new Error("Method not implemented.");
+    }
+    getRepairs(): Array<Repair> {
+      throw new Error("Method not implemented.");
+    }
+    getStatus(status: string): string {
+      throw new Error("Method not implemented.");
+    }
+    maybeThrow(shouldThrow: boolean): boolean {
+      throw new Error("Method not implemented.");
+    }
+    maybeThrowComplex(input: number): boolean {
+      throw new Error("Method not implemented.");
+    }
+    maybeThrowInto(shouldThrow: boolean): boolean {
+      throw new Error("Method not implemented.");
+    }
+    panic(message: string): void {
+      throw new Error("Method not implemented.");
+    }
+    reverse(value: ArrayBuffer): ArrayBuffer {
+      throw new Error("Method not implemented.");
+    }
+    setAndGetEmptyStruct(emptyStruct: EmptyStruct): EmptyStruct {
+      throw new Error("Method not implemented.");
+    }
+    strongCount(): bigint {
+      throw new Error("Method not implemented.");
+    }
+    takeOther(other: CoverallsInterface | undefined): void {
+      throw new Error("Method not implemented.");
+    }
+    takeOtherFallible(): void {
+      throw new Error("Method not implemented.");
+    }
+    takeOtherPanic(message: string): void {
+      throw new Error("Method not implemented.");
+    }
+  }
+
+  // reimplementing the CoverallsInterface interface.
+  const dummyCoveralls = new DummyCoveralls();
+  t.assertFalse(Coveralls.instanceOf(dummyCoveralls));
+
+  // subclassing the Coveralls object.
+  class ExtendedCoveralls extends Coveralls {}
+  const extendedCoveralls = new ExtendedCoveralls("Extended coveralls");
+  t.assertTrue(Coveralls.instanceOf(extendedCoveralls));
 });

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -53,6 +53,7 @@ export interface UniffiObjectFactory<T> {
   pointer(obj: T): UnsafeMutableRawPointer;
   clonePointer(obj: T): UnsafeMutableRawPointer;
   freePointer(pointer: UnsafeMutableRawPointer): void;
+  isConcreteType(obj: any): obj is T;
 }
 
 const pointerConverter: FfiConverter<any, UnsafeMutableRawPointer> =
@@ -71,7 +72,11 @@ export class FfiConverterObject<T>
     return this.factory.create(value);
   }
   lower(value: T): UnsafeMutableRawPointer {
-    return this.factory.clonePointer(value);
+    if (this.factory.isConcreteType(value)) {
+      return this.factory.clonePointer(value);
+    } else {
+      throw new Error("Cannot lower this object to a pointer");
+    }
   }
   read(from: RustBuffer): T {
     return this.lift(pointerConverter.read(from));


### PR DESCRIPTION
When defining a new class, uniffi-bindgen-react-native routinely generates an interface.

By convention, we're calling this `FooInterface`.

```ts
interface FooInterface {
    method(obj: Bar): Baz
}

class Foo implements FooInterface {
    method(obj: Bar): Baz
}
```

When a method on a `FooInterface` returns another object, or accepts an object as an argument— say `Bar`— prior to this commit, both the `FooInterface` and the concrete `Foo` type would use the concrete `Bar`.

```ts
interface FooInterface {
    method(obj: Bar): Baz
}

class Foo implements FooInterface {
    method(obj: Bar): Baz {
        // …
    }
}
```

This changes this, to use the interface name.

```ts
interface FooInterface {
    method(obj: BarInterface): BazInterface
}

class Foo implements FooInterface {
    method(obj: BarInterface): BazInterface {
        // …
    }
}
```

This makes it easy for creating mocks and dummy interfaces.

Question:

I notice that the `type` and the `class` namespaces seem to be disjoint, so this is valid:

```ts
interface Foo {
  method(bool: boolean): void;
}

class Foo implements Foo {
  method(bool: boolean): void {}
}

class Bar implements Foo {
  method(bool: boolean): void {}
}

const foo: Foo = new Bar();
```

Should I make these the same names? If keeping them different, what should they be?

If they are different, and we want to keep this commit, then other questions need to be thought about:

- what should the behaviour of alternate constructors be? (currently, they return the interface, not the concrete type)
- how should we protect the object `FfiConverter` which now accepts an interface, but can only handle a concrete type? Does it really matter, given that it will only cause a failing test?

/cc @zzorba WDYT?