### PR TITLE
Enums with associated values and named associated values

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/oracle.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use uniffi_bindgen::{
     backend::{Literal, Type},
     interface::{AsType, FfiType},
@@ -40,7 +40,7 @@ impl CodeOracle {
 
     /// Get the idiomatic Typescript rendering of an individual enum variant.
     pub(crate) fn enum_variant_name(&self, nm: &str) -> String {
-        nm.to_string().to_shouty_snake_case()
+        nm.to_string().to_upper_camel_case()
     }
 
     /// Get the idiomatic Typescript rendering of an FFI callback function name

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/EnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/EnumTemplate.ts
@@ -44,7 +44,8 @@ const {{ ffi_converter_name }} = (() => {
 {% else %}
 
 // Enum: {{ type_name }}
-{%- let kind_type_name = format!("{type_name}Kind") %}
+{%- let decl_type_name = e|decl_type_name(ci) %}
+{%- let kind_type_name = format!("{type_name}_Tags") %}
 export enum {{ kind_type_name }} {
     {%- for variant in e.variants() %}
     {{ variant|variant_name }} = "{{ variant.name() }}"
@@ -53,18 +54,90 @@ export enum {{ kind_type_name }} {
 }
 
 {%- call ts::docstring(e, 0) %}
-export type {{ type_name }} = {# space #}
-{%- for variant in e.variants() %}
-{%-   call ts::docstring(variant, 4) %}
-    { kind: {{ kind_type_name }}.{{ variant|variant_name }}
-    {%- if !variant.fields().is_empty() %}; value: { {# space #}
-        {%- for field in variant.fields() %}
-        {%- call ts::field_name(field, loop.index) %}: {{ field|type_name(ci) }}
-        {%- if !loop.last %}; {% endif -%}
-        {%- endfor %} }
-    {%- endif %} }
-    {%- if !loop.last %} |{% endif %}
-{%- endfor %};
+export const {{ decl_type_name }} = (() => {
+  {%- for variant in e.variants() %}
+    {%- let variant_name = variant.name()|class_name(ci) %}
+    {%- let variant_data = variant_name|fmt("{}_data") %}
+    {%- let variant_interface = variant_name|fmt("{}_interface") %}
+    {%- let variant_tag = format!("{kind_type_name}.{variant_name}") %}
+    {%- let has_fields = !variant.fields().is_empty() %}
+    {%- let is_tuple = variant.has_nameless_fields() %}
+    {%- if has_fields %}
+    type {{ variant_data }} = {# space #}
+    {%-   if !is_tuple %}{
+    {%-     for field in variant.fields() %}
+    {{-       field.name()|var_name }}: {{ field|type_name(ci) }}
+    {%-       if !loop.last %}; {% endif -%}
+    {%-     endfor %}}
+    {%-   else %}[
+    {%-     for field in variant.fields() %}
+    {{-       field|type_name(ci) }}
+    {%-       if !loop.last %}, {% endif -%}
+    {%-     endfor %}]
+    {%-   endif %};
+    {%- endif %}
+    type {{ variant_interface }} = { tag: {{ variant_tag }} {%- if has_fields %}; data: Readonly<{{ variant_data }}> {%- endif %}};
+
+    {% call ts::docstring(variant, 4) %}
+    class {{ variant_name }} implements {{ variant_interface }} {
+        readonly tag = {{ variant_tag }};
+        {%- if has_fields %}
+        readonly data: Readonly<{{ variant_data }}>;
+        {%-   if !is_tuple %}
+        constructor(data: { {% call ts::field_list_decl(variant, false) %} }) {
+            this.data = Object.freeze(data);
+        }
+
+        static new(data: { {% call ts::field_list_decl(variant, false) %} }): {{ variant_interface }} {
+            return new {{ variant_name }}(data);
+        }
+        {%-   else %}
+        constructor({%- call ts::field_list_decl(variant, true) -%}) {
+            this.data = Object.freeze([{%- call ts::field_list(variant, true) -%}]);
+        }
+
+        static new({%- call ts::field_list_decl(variant, true) -%}): {{ variant_name }} {
+            return new {{ variant_name }}({%- call ts::field_list(variant, true) -%});
+        }
+        {%-   endif %}
+        {%- else %}
+        constructor() {
+            // NOOP
+        }
+
+        static new(): {{ variant_name }} {
+            return new {{ variant_name }}();
+        }
+        {%- endif %}
+
+        static instanceOf(obj: any): obj is {{ variant_interface }} {
+            return obj.tag === {{ variant_tag }};
+        }
+    }
+
+
+  {%- endfor %}
+
+    function instanceOf(obj: any): obj is {# space #}
+  {%- for variant in e.variants() %}
+  {{-  variant.name()|class_name(ci)|fmt("{}_interface") }}
+  {%-  if !loop.last %}| {% endif -%}
+  {%- endfor %} {
+        return obj.tag !== undefined && {{ kind_type_name }}.hasOwnProperty(obj.tag);
+    }
+
+    return {
+        instanceOf,
+  {%- for variant in e.variants() %}
+  {{    variant.name()|class_name(ci) }}
+  {%-   if !loop.last %}, {% endif -%}
+  {%- endfor %}
+    };
+
+})();
+
+{% call ts::docstring(e, 0) %}
+{% call ts::type_omit_instanceof(type_name, decl_type_name) %}
 
 // FfiConverter for enum {{ type_name }}
 const {{ ffi_converter_name }} = (() => {
@@ -73,26 +146,34 @@ const {{ ffi_converter_name }} = (() => {
     class FFIConverter extends AbstractFfiConverterArrayBuffer<TypeName> {
         read(from: RustBuffer): TypeName {
             switch (ordinalConverter.read(from)) {
-                {%- for variant in e.variants() %}
-                case {{ loop.index }}: return { kind: {{ kind_type_name }}.{{ variant|variant_name }}
-                {%- if !variant.fields().is_empty() %}, value: {
-                    {%- for field in variant.fields() %}
-                    {% call ts::field_name(field, loop.index) %}: {{ field|read_fn }}(from)
-                    {%- if !loop.last -%}, {% endif -%}{% endfor %} }
-                {%- endif %} };
-                {%- endfor %}
+            {%- for variant in e.variants() %}
+                case {{ loop.index }}: return new {{ type_name }}.{{ variant|variant_name }}(
+            {%-   if !variant.fields().is_empty() %}
+            {%-     if !variant.has_nameless_fields() %}{
+            {%-     for field in variant.fields() %}
+            {{-       field.name()|var_name }}: {{ field|read_fn }}(from)
+            {%-       if !loop.last -%}, {% endif %}
+            {%-     endfor %} }
+            {%-     else %}
+            {%-       for field in variant.fields() %}
+            {{-         field|read_fn }}(from)
+            {%-         if !loop.last -%}, {% endif %}
+            {%-       endfor %}
+            {%-     endif %}
+            {%-   endif %});
+            {%- endfor %}
                 default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
         }
         write(value: TypeName, into: RustBuffer): void {
-            switch (value.kind) {
+            switch (value.tag) {
                 {%- for variant in e.variants() %}
                 case {{ kind_type_name }}.{{ variant|variant_name }}: {
                     ordinalConverter.write({{ loop.index }}, into);
                     {%- if !variant.fields().is_empty() %}
-                    const inner = value.value;
+                    const inner = value.data;
                     {%-   for field in variant.fields() %}
-                    {{ field|write_fn }}(inner.{% call ts::field_name(field, loop.index) %}, into);
+                    {{ field|write_fn }}({% call ts::field_name("inner", field, loop.index0) %}, into);
                     {%-   endfor %}
                     {%- endif %}
                     return;
@@ -104,14 +185,14 @@ const {{ ffi_converter_name }} = (() => {
             }
         }
         allocationSize(value: TypeName): number {
-            switch (value.kind) {
+            switch (value.tag) {
                 {%- for variant in e.variants() %}
                 case {{ kind_type_name }}.{{ variant|variant_name }}: {
                     {%- if !variant.fields().is_empty() %}
-                    const inner = value.value;
+                    const inner = value.data;
                     let size = ordinalConverter.allocationSize({{ loop.index }});
                     {%- for field in variant.fields() %}
-                    size += {{ field|allocation_size_fn }}(inner.{% call ts::field_name(field, loop.index) %});
+                    size += {{ field|allocation_size_fn }}({% call ts::field_name("inner", field, loop.index0) %});
                     {%- endfor %}
                     return size;
                     {%- else %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -65,9 +65,8 @@ export const {{ decl_type_name }} = (() => {
 })();
 
 // Union type for {{ type_name }} error type.
-export type {{ type_name }} = InstanceType<
-    typeof {{ decl_type_name }}[keyof Omit<typeof {{ decl_type_name }}, '{{ instance_of }}'>]
->;
+{% call ts::docstring(e, 0) %}
+{% call ts::type_omit_instanceof(type_name, decl_type_name) %}
 
 const {{ ffi_converter_name }} = (() => {
     const intConverter = FfiConverterInt32;

--- a/fixtures/coverall/tests/bindings/test_coverall.ts
+++ b/fixtures/coverall/tests/bindings/test_coverall.ts
@@ -183,7 +183,7 @@ test("Error Values", (t) => {
 
   const e = getRootError();
   t.assertTrue(RootError.Other.instanceOf(e));
-  t.assertEqual(e.error, OtherError.UNEXPECTED);
+  t.assertEqual(e.error, OtherError.Unexpected);
 
   const ce = getComplexError(undefined);
   t.assertTrue(ComplexError.PermissionDenied.instanceOf(ce));

--- a/fixtures/enum-types/Cargo.toml
+++ b/fixtures/enum-types/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uniffi-fixture-enum-types"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "enum_types"
+
+[dependencies]
+uniffi = { workspace = true }
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/enum-types/build.rs
+++ b/fixtures/enum-types/build.rs
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+fn main() {
+    uniffi::generate_scaffolding("src/enum_types.udl").unwrap();
+}

--- a/fixtures/enum-types/src/enum_types.udl
+++ b/fixtures/enum-types/src/enum_types.udl
@@ -1,0 +1,5 @@
+namespace enum_types {};
+enum Animal {
+  "Dog",
+  "Cat"
+};

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -1,0 +1,112 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+pub enum Animal {
+    Dog,
+    Cat,
+}
+
+// Though it has the proc-macro, we drop the variant
+// literals if there is not a repr type defined
+#[derive(uniffi::Enum)]
+pub enum AnimalNoReprInt {
+    Dog = 3,
+    Cat = 4,
+}
+
+#[repr(u8)]
+#[derive(uniffi::Enum)]
+pub enum AnimalUInt {
+    Dog = 3,
+    Cat = 4,
+}
+
+#[repr(u64)]
+#[derive(uniffi::Enum)]
+pub enum AnimalLargeUInt {
+    Dog = 4294967298, // u32::MAX as u64 + 3
+    Cat = 4294967299, // u32::MAX as u64 + 4
+}
+
+#[repr(i8)]
+#[derive(Debug, uniffi::Enum)]
+pub enum AnimalSignedInt {
+    Dog = -3,
+    Cat = -2,
+    Koala,   // -1
+    Wallaby, // 0
+    Wombat,  // 1
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct AnimalRecord {
+    value: u8,
+}
+
+#[derive(uniffi::Object)]
+pub struct AnimalObject {
+    pub value: AnimalRecord,
+}
+
+#[uniffi::export]
+impl AnimalObject {
+    #[uniffi::constructor]
+    fn new(value: u8) -> Arc<Self> {
+        Arc::new(Self {
+            value: AnimalRecord { value },
+        })
+    }
+
+    pub fn record(&self) -> AnimalRecord {
+        self.value.clone()
+    }
+}
+
+use std::sync::Arc;
+// Adding an enum with a Associated Type that is a exported Arc<Object> with a exported Record field.
+// This is done to check for compilation errors.
+#[derive(uniffi::Enum)]
+pub(crate) enum AnimalAssociatedType {
+    Dog(Arc<AnimalObject>),
+    Cat,
+}
+
+#[uniffi::export]
+fn identity_enum_with_associated_type(value: AnimalAssociatedType) -> AnimalAssociatedType {
+    value
+}
+
+#[uniffi::export]
+fn identity_enum_with_named_associated_type(
+    value: AnimalNamedAssociatedType,
+) -> AnimalNamedAssociatedType {
+    value
+}
+
+#[derive(uniffi::Enum)]
+pub(crate) enum AnimalNamedAssociatedType {
+    Dog { value: Arc<AnimalObject> },
+    Cat,
+}
+
+#[uniffi::export]
+fn get_animal(a: Option<Animal>) -> Animal {
+    a.unwrap_or(Animal::Dog)
+}
+
+uniffi::include_scaffolding!("enum_types");
+
+#[cfg(test)]
+mod test {
+    use crate::AnimalSignedInt;
+
+    #[test]
+    fn check_signed() {
+        assert_eq!(AnimalSignedInt::Koala as i8, -1);
+        assert_eq!(AnimalSignedInt::Wallaby as i8, 0);
+        assert_eq!(AnimalSignedInt::Wombat as i8, 1);
+    }
+}

--- a/fixtures/enum-types/tests/bindings/test_enum_types.ts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.ts
@@ -1,0 +1,102 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "@/asserts";
+import {
+  Animal,
+  AnimalAssociatedType,
+  AnimalAssociatedType_Tags,
+  AnimalLargeUInt,
+  AnimalNamedAssociatedType,
+  AnimalNamedAssociatedType_Tags,
+  AnimalNoReprInt,
+  AnimalObject,
+  AnimalSignedInt,
+  AnimalUInt,
+  getAnimal,
+  identityEnumWithAssociatedType,
+  identityEnumWithNamedAssociatedType,
+} from "../../generated/enum_types";
+
+test("Enum disriminant", (t) => {
+  t.assertEqual(Animal.Dog, 0);
+  t.assertEqual(Animal.Cat, 1);
+  t.assertEqual(getAnimal(undefined), Animal.Dog);
+  t.assertEqual(AnimalNoReprInt.Dog, 0);
+  t.assertEqual(AnimalNoReprInt.Cat, 1);
+  t.assertEqual(AnimalUInt.Dog, 3);
+  t.assertEqual(AnimalUInt.Cat, 4);
+  t.assertEqual(
+    AnimalLargeUInt.Dog,
+    (BigInt("4294967295") + BigInt("3")).toString(),
+  );
+  t.assertEqual(
+    AnimalLargeUInt.Cat,
+    (BigInt("4294967295") + BigInt("4")).toString(),
+  );
+  t.assertEqual(AnimalSignedInt.Dog, -3);
+  t.assertEqual(AnimalSignedInt.Cat, -2);
+  t.assertEqual(AnimalSignedInt.Koala, -1);
+  t.assertEqual(AnimalSignedInt.Wallaby, 0);
+  t.assertEqual(AnimalSignedInt.Wombat, 1);
+});
+
+test("Roundtripping enums with values", (t) => {
+  function assertEqual(
+    left: AnimalAssociatedType,
+    right: AnimalAssociatedType,
+  ): void {
+    t.assertEqual(left.tag, right.tag);
+    switch (left.tag) {
+      case AnimalAssociatedType_Tags.Cat:
+        return;
+      case AnimalAssociatedType_Tags.Dog:
+        if (AnimalAssociatedType.Dog.instanceOf(right)) {
+          t.assertEqual(left.data[0].record(), right.data[0].record());
+        } else {
+          t.fail(`${right} is not a Dog`);
+        }
+    }
+  }
+  const values = [
+    AnimalAssociatedType.Cat.new(),
+    AnimalAssociatedType.Dog.new(new AnimalObject(1)),
+    AnimalAssociatedType.Dog.new(new AnimalObject(2)),
+  ];
+
+  for (const v of values) {
+    t.assertTrue(AnimalAssociatedType.instanceOf(v as any));
+    assertEqual(v, identityEnumWithAssociatedType(v));
+  }
+});
+
+test("Roundtripping enums with name values", (t) => {
+  function assertEqual(
+    left: AnimalNamedAssociatedType,
+    right: AnimalNamedAssociatedType,
+  ): void {
+    t.assertEqual(left.tag, right.tag);
+    switch (left.tag) {
+      case AnimalNamedAssociatedType_Tags.Cat:
+        return;
+      case AnimalNamedAssociatedType_Tags.Dog:
+        if (AnimalNamedAssociatedType.Dog.instanceOf(right)) {
+          t.assertEqual(left.data.value.record(), right.data.value.record());
+        } else {
+          t.fail(`${right} is not a Dog`);
+        }
+    }
+  }
+  const values = [
+    AnimalNamedAssociatedType.Cat.new(),
+    AnimalNamedAssociatedType.Dog.new({ value: new AnimalObject(1) }),
+    AnimalNamedAssociatedType.Dog.new({ value: new AnimalObject(2) }),
+  ];
+
+  for (const v of values) {
+    t.assertTrue(AnimalNamedAssociatedType.instanceOf(v as any));
+    assertEqual(v, identityEnumWithNamedAssociatedType(v));
+  }
+});

--- a/fixtures/enum-types/tests/test_generated_bindings.rs
+++ b/fixtures/enum-types/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/fixtures/enum-types/uniffi.toml
+++ b/fixtures/enum-types/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "uniffi.enum_types"

--- a/fixtures/rondpoint/tests/bindings/test_rondpoint.ts
+++ b/fixtures/rondpoint/tests/bindings/test_rondpoint.ts
@@ -11,8 +11,7 @@
 import { Asserts, test } from "@/asserts";
 import {
   Enumeration,
-  type EnumerationAvecDonnees,
-  EnumerationAvecDonneesKind,
+  EnumerationAvecDonnees,
   Optionneur,
   DictionnaireFactory,
   OptionneurDictionnaire,
@@ -28,20 +27,20 @@ import {
 import { numberToString } from "@/simulated";
 
 test("Round trip a single enum", (t) => {
-  const input = Enumeration.DEUX;
+  const input = Enumeration.Deux;
   const output = copieEnumeration(input);
   t.assertEqual(input, output);
 });
 
 test("Round trip a list of enum", (t) => {
-  const input = [Enumeration.UN, Enumeration.DEUX];
+  const input = [Enumeration.Un, Enumeration.Deux];
   const output = copieEnumerations(input);
   t.assertEqual(input, output);
 });
 
 test("Round trip an object literal, without strings", (t) => {
   const input = DictionnaireFactory.create({
-    un: Enumeration.DEUX,
+    un: Enumeration.Deux,
     deux: true,
     petitNombre: 0,
     grosNombre: BigInt("123456789"),
@@ -52,15 +51,9 @@ test("Round trip an object literal, without strings", (t) => {
 
 test("Round trip a map<string, *> of strings to enums with values", (t) => {
   const input = new Map<string, EnumerationAvecDonnees>([
-    ["0", { kind: EnumerationAvecDonneesKind.ZERO }],
-    ["1", { kind: EnumerationAvecDonneesKind.UN, value: { premier: 1 } }],
-    [
-      "2",
-      {
-        kind: EnumerationAvecDonneesKind.DEUX,
-        value: { premier: 2, second: "deux" },
-      },
-    ],
+    ["0", new EnumerationAvecDonnees.Zero()],
+    ["1", new EnumerationAvecDonnees.Un({ premier: 1 })],
+    ["2", new EnumerationAvecDonnees.Deux({ premier: 2, second: "deux" })],
   ]);
   const output = copieCarte(input);
   t.assertEqual(input, output);
@@ -100,7 +93,7 @@ const inputData = {
   u64: [BigInt("0"), BigInt("0xffffffffffffffff")],
   f32: [3.5, 27, -113.75, 0.0078125, 0.5, 0, -1],
   f64: [Number.MIN_VALUE, Number.MAX_VALUE],
-  enums: [Enumeration.UN, Enumeration.DEUX, Enumeration.TROIS],
+  enums: [Enumeration.Un, Enumeration.Deux, Enumeration.Trois],
   string: [
     "",
     "abc",
@@ -175,7 +168,7 @@ test("Testing defaulting properties in record types", (t) => {
     booleanVar: true,
     stringVar: "default",
     listVar: [],
-    enumerationVar: Enumeration.DEUX,
+    enumerationVar: Enumeration.Deux,
     dictionnaireVar: undefined,
   });
   t.assertEqual(explicit, defaulted);
@@ -313,7 +306,7 @@ test("Default arguments are defaulting", (t) => {
   t.assertEqual(op.sinonF64(), 42.1);
 
   // enums
-  t.assertEqual(op.sinonEnum(), Enumeration.TROIS);
+  t.assertEqual(op.sinonEnum(), Enumeration.Trois);
 
   op.uniffiDestroy();
 });


### PR DESCRIPTION
This changes the way enums with associated values (a.k.a. tagged unions) are represented in typescript.

Previously, they were raw objects, now they are classes.

This allows us to add extra methods, including handy constructors and `instanceOf` methods.

The interface for the `MyEnum` type is approximately `{ tag: MyEnum_tags, data: MyEnum_interface }`, where `MyEnum_tags` is exported.

The tag allows us to to interesting pattern matching like switch statements.

e.g. consider an enum for `Sheep`, `Goat(String, u32)`, `Cat { owner: Option<String>, name: String }`

The values are constructed like so:

```typescript
const sheep = new Animal.Sheep();
const jeff = new Animal.Goat("Jeff", 17);
const roberta = new Animal.Cat({ name: "Roberta", owner: undefined });
```

For pattern matching, a simple tag enum is generated and exposed:

```typscript
enum Animal_tags {
    Sheep, Goat, Cat
}
```

Typescript will infer the correct types of the `value.data` property:

```typescript
function name(animal: Animal): string {
    switch (animal.tag) {
        case Animal_tags.Sheep:
            return "mah";
        case Animal_tags.Goat: {
            const [name, age] = animal.data;
            return name;
        }
        case Animal_tags.Cat: {
            const {name, owner} = animal.data;
            return name;
        }
        default:
            throw new Error("Unreachable");
    }
}
````

For convenience, a `new` method is also generated:

```typscript
const berry = Animal.Cat.new({ name: "Berry", owner: undefined });
````

Having `new` as a method means that changing `Animal` from a flat enum (i.e. one without associated types) to one that does means only changing one side of the literal.

Also: `instanceOf` methods:

```typscript
const ermintrude: any = Animal.Goat.new("Ermintrude", 18);

if (Animal.instanceOf(ermintrude)) {
    // ermintrude is an animal
}
if (Animal.Goat.instanceOf(ermintrude)) {
    // ermintrude is goat.
}
```