### PR TITLE
Rename RecordFactory to Record

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -1,5 +1,4 @@
 {{- self.import_infra("UniffiError", "errors") }}
-{%- let decl_type_name = e|decl_type_name(ci) %}
 {%- let instance_of = "instanceOf" %}
 {%- let flat = e.is_flat() %}
 {%- if flat %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/RecordTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/RecordTemplate.ts
@@ -14,7 +14,7 @@ export type {{ type_name }} = {
 /**
  * Generated factory for {@link {{ type_name }}} record objects.
  */
-export const {{ type_name }}Factory = (() => {
+export const {{ decl_type_name }} = (() => {
     const defaults = () => ({
         {%- for field in rec.fields() %}
         {%- match field.default_value() %}
@@ -25,14 +25,21 @@ export const {{ type_name }}Factory = (() => {
         {%- endmatch -%}
         {%- endfor %}
     });
+    const create = (() => {
+        return uniffiCreateRecord<{{ type_name }}, ReturnType<typeof defaults>>(defaults);
+    })();
     return Object.freeze({
         /**
          * Create a frozen instance of {@link {{ type_name }}}, with defaults specified
          * in Rust, in the {@link {{ ci.namespace() }}} crate.
          */
-        create: (() => {
-            return uniffiCreateRecord<{{ type_name }}, ReturnType<typeof defaults>>(defaults);
-        })(),
+        create,
+
+        /**
+         * Create a frozen instance of {@link {{ type_name }}}, with defaults specified
+         * in Rust, in the {@link {{ ci.namespace() }}} crate.
+         */
+        new: create,
 
         /**
          * Defaults specified in the {@link {{ ci.namespace() }}} crate.

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/Types.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/Types.ts
@@ -8,6 +8,7 @@
 
 {%- for type_ in ci.iter_sorted_types() %}
 {%- let type_name = type_|type_name(ci) %}
+{%- let decl_type_name = type_|decl_type_name(ci) %}
 {%- let ffi_converter_name = type_|ffi_converter_name %}
 {%- let canonical_type_name = type_|canonical_name %}
 {%- let contains_object_references = ci.item_contains_object_references(type_) %}

--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -24,7 +24,7 @@ import myModule, {
   ParserError,
   sayAfter,
   sayAfterWithTokio,
-  SharedResourceOptionsFactory,
+  SharedResourceOptions,
   sleep,
   tryDelayUsingTrait,
   tryFromStringUsingTrait,
@@ -363,19 +363,19 @@ asyncTest("fallible method… which does throw, part II", async (t) => {
 
 asyncTest("a future that uses a lock and that is not cancelled", async (t) => {
   await useSharedResource(
-    SharedResourceOptionsFactory.create({
+    SharedResourceOptions.create({
       releaseAfterMs: 100,
       timeoutMs: 1000,
     }),
   );
   await useSharedResource(
-    SharedResourceOptionsFactory.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
+    SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
   );
   t.end();
 });
 
 asyncTest("a future that uses a lock and that is cancelled", async (t) => {
-  const options = SharedResourceOptionsFactory.create({
+  const options = SharedResourceOptions.create({
     releaseAfterMs: 100,
     timeoutMs: 1000,
   });
@@ -388,7 +388,7 @@ asyncTest("a future that uses a lock and that is cancelled", async (t) => {
   // Try accessing the shared resource again.  The initial task should release the shared resource
   // before the timeout expires.
   await useSharedResource(
-    SharedResourceOptionsFactory.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
+    SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
   );
   t.end();
 });

--- a/fixtures/rondpoint/tests/bindings/test_rondpoint.ts
+++ b/fixtures/rondpoint/tests/bindings/test_rondpoint.ts
@@ -13,9 +13,8 @@ import {
   Enumeration,
   EnumerationAvecDonnees,
   Optionneur,
-  DictionnaireFactory,
+  Dictionnaire,
   OptionneurDictionnaire,
-  OptionneurDictionnaireFactory,
   Retourneur,
   Stringifier,
   copieCarte,
@@ -39,7 +38,7 @@ test("Round trip a list of enum", (t) => {
 });
 
 test("Round trip an object literal, without strings", (t) => {
-  const input = DictionnaireFactory.create({
+  const input: Dictionnaire = Dictionnaire.create({
     un: Enumeration.Deux,
     deux: true,
     petitNombre: 0,
@@ -152,9 +151,8 @@ test("Using an object to roundtrip primitives", (t) => {
 
 test("Testing defaulting properties in record types", (t) => {
   const rt = new Retourneur();
-  const defaulted: OptionneurDictionnaire =
-    OptionneurDictionnaireFactory.create({});
-  const explicit = OptionneurDictionnaireFactory.create({
+  const defaulted: OptionneurDictionnaire = OptionneurDictionnaire.create({});
+  const explicit = OptionneurDictionnaire.create({
     i8Var: -8,
     u8Var: 8,
     i16Var: -16,
@@ -173,7 +171,7 @@ test("Testing defaulting properties in record types", (t) => {
   });
   t.assertEqual(explicit, defaulted);
 
-  const actualDefaults = OptionneurDictionnaireFactory.defaults();
+  const actualDefaults = OptionneurDictionnaire.defaults();
   t.assertEqual(defaulted, actualDefaults);
 
   affirmAllerRetour(


### PR DESCRIPTION
We've been able to declare a type and a utility object of the same name.

Before this change, we could do:

```typescript
const v: MyRecord = MyRecordFactory.create({ foo: 1 });
```

Now we can do:

```typescript
const v: MyRecord = MyRecord.create({ foo: 1 });
```

This reduces the number of specially generated names which are really implementation details of uniffi.