### PR TITLE
Upgrade uniffi-rs to 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ heck = "0.5.0"
 paste = "1.0.14"
 pathdiff = { version = "0.2.1", features = ["camino"] }
 serde = { version = "1", features = ["derive"] }
-uniffi = "0.27.1"
-uniffi_bindgen = "0.27.1"
-uniffi_meta = "0.27.1"
+uniffi = "0.28"
+uniffi_bindgen = "0.28"
+uniffi_meta = "0.28"

--- a/crates/ubrn_bindgen/Cargo.toml
+++ b/crates/ubrn_bindgen/Cargo.toml
@@ -19,3 +19,4 @@ uniffi_bindgen = { workspace = true }
 uniffi_meta = { workspace = true }
 extend = "1.2.0"
 topological-sort = "0.2.2"
+toml = "0.5"

--- a/crates/ubrn_bindgen/src/bindings/metadata.rs
+++ b/crates/ubrn_bindgen/src/bindings/metadata.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use heck::ToUpperCamelCase;
+use uniffi_bindgen::Component;
 
 #[derive(Default)]
 pub struct ModuleMetadata {
@@ -43,5 +44,12 @@ impl ModuleMetadata {
 
     pub fn ts_ffi_filename(&self) -> String {
         format!("{}.ts", self.ts_ffi())
+    }
+}
+
+impl<T> From<&Component<T>> for ModuleMetadata {
+    fn from(value: &Component<T>) -> Self {
+        let namespace = value.ci.namespace().to_string();
+        Self { namespace }
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/mod.rs
@@ -114,16 +114,16 @@ impl BindingsArgs {
         let try_format_code = !out.no_format;
 
         let configs: Vec<ModuleMetadata> = if input.library_mode {
-            uniffi_bindgen::library_mode::generate_external_bindings(
-                &generator,
+            uniffi_bindgen::library_mode::generate_bindings(
                 &input.source,
                 input.crate_name.clone(),
+                &generator,
                 input.config.as_deref(),
                 &dummy_dir,
                 try_format_code,
             )?
             .iter()
-            .map(|s| (&s.config).into())
+            .map(|s| s.into())
             .collect()
         } else {
             uniffi_bindgen::generate_external_bindings(
@@ -137,10 +137,6 @@ impl BindingsArgs {
             )?;
             Default::default()
         };
-
-        if try_format_code {
-            let _ = generator.format_code();
-        }
 
         Ok(configs)
     }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/mod.rs
@@ -51,12 +51,11 @@ impl<'a> HppWrapper<'a> {
 #[template(syntax = "cpp", escape = "none", path = "wrapper.cpp")]
 struct CppWrapper<'a> {
     ci: &'a ComponentInterface,
-    #[allow(unused)]
-    config: &'a ModuleMetadata,
+    module: &'a ModuleMetadata,
 }
 
 impl<'a> CppWrapper<'a> {
-    fn new(ci: &'a ComponentInterface, config: &'a ModuleMetadata) -> Self {
-        Self { ci, config }
+    fn new(ci: &'a ComponentInterface, module: &'a ModuleMetadata) -> Self {
+        Self { ci, module }
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -1,5 +1,5 @@
 {%- let namespace = ci.namespace() %}
-{%- let module_name = config.cpp_module() %}
+{%- let module_name = module.cpp_module() %}
 #ifndef UNIFFI_EXPORT
 #if defined(_WIN32) || defined(_WIN64)
 #define UNIFFI_EXPORT __declspec(dllexport)
@@ -8,7 +8,7 @@
 #endif
 #endif
 
-#include "{{ namespace }}.hpp"
+#include "{{ module.hpp_filename() }}"
 
 #include "UniffiJsiTypes.h"
 #include <stdexcept>

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
@@ -18,12 +18,12 @@ mod record;
 
 use anyhow::{Context, Result};
 use askama::Template;
+use filters::ffi_converter_name;
 use heck::ToUpperCamelCase;
 use oracle::CodeOracle;
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use uniffi_bindgen::bindings::swift::gen_swift::filters::ffi_converter_name;
 use uniffi_bindgen::interface::{Callable, FfiDefinition, FfiType, Type, UniffiTrait};
 use uniffi_bindgen::ComponentInterface;
 use uniffi_meta::{AsType, ExternalKind};


### PR DESCRIPTION
This PR updates uniffi-rs to 0.28. 

The changelog for that is [here](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md#v0280-backend-crates-v0280---2024-06-11).