### PR TITLE
Tighten up futures testing

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/macros.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/macros.cpp
@@ -33,7 +33,7 @@ jsi::Value {{ module_name }}::{% call cpp_func_name(func) %}(jsi::Runtime& rt, c
 
 {%- macro cpp_fn_rust_caller_body_with_func_name(func, func_name) %}
         {%- if func.has_rust_call_status_arg() %}
-        RustCallStatus status = { 0 };
+        RustCallStatus status = {{ ci.cpp_namespace() }}::Bridging<RustCallStatus>::rustSuccess(rt);
         {%- endif %}
 
         {#- Before the call, make variables out of the args that will need cleanup after the call. #}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -19,13 +19,10 @@ const {{ trait_impl }}: { vtable: {{ vtable|ffi_type_name }}; register: () => vo
             const uniffiMakeCall = {# space #}
             {%- call ts::async(meth) -%}
             (): {% call ts::return_type(meth) %} => {
-                const uniffiObj = {{ ffi_converter_name }}.lift(uniffiHandle);
-                if (uniffiObj === undefined) {
-                    throw new UniffiInternalError.UnexpectedStaleHandle()
-                }
-                return {% call ts::await(meth) %}uniffiObj.{{ meth.name()|fn_name }}(
+                const jsCallback = {{ ffi_converter_name }}.lift(uniffiHandle);
+                return {% call ts::await(meth) %}jsCallback.{{ meth.name()|fn_name }}(
                     {%- for arg in meth.arguments() %}
-                    {{ arg|ffi_converter_name }}.lift({{ arg.name()|var_name }}){% if !loop.last %},{% endif %}
+                    {{ arg|ffi_converter_name }}.lift({{ arg.name()|var_name }}){% if !loop.last %}, {% endif %}
                     {%- endfor %}
                 )
             }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -129,6 +129,7 @@ import { decl_type_name } from "./EnumTemplate"
                 );
             },
             /*pollFunc:*/ nativeModule().{{ callable.ffi_rust_future_poll(ci) }},
+            /*cancelFunc:*/ nativeModule().{{ callable.ffi_rust_future_cancel(ci) }},
             /*completeFunc:*/ nativeModule().{{ callable.ffi_rust_future_complete(ci) }},
             /*freeFunc:*/ nativeModule().{{ callable.ffi_rust_future_free(ci) }},
             {%- match callable.return_type() %}

--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -31,122 +31,16 @@ import myModule, {
   useSharedResource,
   void_,
 } from "../../generated/futures";
-import { asyncTest, xasyncTest } from "@/asserts";
+import { asyncTest, xasyncTest, Asserts, test } from "@/asserts";
+import {
+  uniffiRustFutureHandleCount,
+  uniffiForeignFutureHandleCount,
+} from "uniffi-bindgen-react-native";
 import { console } from "@/hermes";
 
 // Initialize the callbacks for the module.
 // This will be hidden in the installation process.
 myModule.initialize();
-
-asyncTest("alwaysReady", async (t) => {
-  const result = await alwaysReady();
-  t.assertTrue(result);
-  t.end();
-});
-
-asyncTest("newMyRecord", async (t) => {
-  const record = await newMyRecord("my string", 42);
-  t.assertEqual(record.a, "my string");
-  t.assertEqual(record.b, 42);
-  t.end();
-});
-
-asyncTest("void", async (t) => {
-  await t.asyncMeasure(void_, 0, 500);
-  t.end();
-});
-
-asyncTest("sleep", async (t) => {
-  await t.asyncMeasure(() => sleep(2000), 2000, 50);
-  t.end();
-});
-
-asyncTest("sync greet", async (t) => {
-  await t.measure(() => greet("Hello"), 0, 10);
-  t.end();
-});
-
-asyncTest("Sequential futures", async (t) => {
-  t.asyncMeasure(
-    async () => {
-      t.assertEqual("Hello, Alice!", await sayAfter(1000, "Alice"));
-      t.assertEqual("Hello, Bob!", await sayAfter(2000, "Bob"));
-    },
-    3000,
-    20,
-  );
-  t.end();
-});
-
-asyncTest("Concurrent futures", async (t) => {
-  t.asyncMeasure(
-    async () => {
-      const alice = sayAfter(1000, "Alice");
-      const bob = sayAfter(2000, "Bob");
-      const [helloAlice, helloBob] = await Promise.all([alice, bob]);
-      t.assertEqual("Hello, Alice!", helloAlice);
-      t.assertEqual("Hello, Bob!", helloBob);
-    },
-    2000,
-    20,
-  );
-  t.end();
-});
-
-asyncTest("Async methods", async (t) => {
-  const megaphone = newMegaphone();
-  let helloAlice = await t.asyncMeasure(
-    async () => megaphone.sayAfter(2000, "Alice"),
-    2000,
-    20,
-  );
-  t.assertEqual("HELLO, ALICE!", helloAlice);
-  t.end();
-});
-
-asyncTest("Async trait interface methods", async (t) => {
-  const traits = getSayAfterTraits();
-
-  t.asyncMeasure(
-    async () => {
-      let result1 = await traits[0].sayAfter(1000, "Alice");
-      let result2 = await traits[1].sayAfter(1000, "Bob");
-
-      t.assertEqual(result1, "Hello, Alice!");
-      t.assertEqual(result2, "Hello, Bob!");
-    },
-    2000,
-    20,
-  );
-  t.end();
-});
-
-asyncTest("UDL-defined async trait interface methods", async (t) => {
-  const traits = getSayAfterUdlTraits();
-
-  t.asyncMeasure(
-    async () => {
-      let result1 = await traits[0].sayAfter(1000, "Alice");
-      let result2 = await traits[1].sayAfter(1000, "Bob");
-
-      t.assertEqual(result1, "Hello, Alice!");
-      t.assertEqual(result2, "Hello, Bob!");
-    },
-    2000,
-    20,
-  );
-  t.end();
-});
-
-asyncTest("Object with a fallible async ctor.", async (t) => {
-  try {
-    await FallibleMegaphone.create();
-    t.fail("Expected an error");
-  } catch (e: any) {
-    // OK
-  }
-  t.end();
-});
 
 function delayPromise(delayMs: number): Promise<void> {
   return new Promise((resolve) => {
@@ -154,243 +48,449 @@ function delayPromise(delayMs: number): Promise<void> {
   });
 }
 
-// AsyncParser.
-class TsAsyncParser implements AsyncParser {
-  constructor(public completedDelays: number = 0) {}
-  async asString(delayMs: number, value: number): Promise<string> {
-    await this.doDelay(delayMs);
-    return value.toString();
-  }
-  async tryFromString(delayMs: number, value: string): Promise<number> {
-    if (value == "force-panic") {
-      throw new Error("force-panic");
-    }
-    if (value == "force-unexpected-exception") {
-      throw new ParserError.UnexpectedError();
-    }
-    const v = this.parseInt(value);
-    await this.doDelay(delayMs);
-    return v;
-  }
-  async delay(delayMs: number): Promise<void> {
-    await this.doDelay(delayMs);
-  }
-  async tryDelay(delayMs: string): Promise<void> {
-    await this.doDelay(this.parseInt(delayMs));
-  }
-
-  toString(): string {
-    return "TsAsyncParser";
-  }
-
-  private async doDelay(ms: number): Promise<void> {
-    await delayPromise(ms);
-    this.completedDelays += 1;
-  }
-
-  private parseInt(value: string): number {
-    const num = Number.parseInt(value);
-    if (Number.isNaN(num)) {
-      throw new ParserError.NotAnInt();
-    }
-    return num;
-  }
+function checkRemainingFutures(t: Asserts) {
+  t.assertEqual(
+    0,
+    uniffiRustFutureHandleCount(),
+    "Number of remaining futures should be zero",
+  );
+  t.assertEqual(
+    0,
+    uniffiForeignFutureHandleCount(),
+    "Number of remaining foreign futures should be zero",
+  );
 }
 
-asyncTest("Async callbacks", async (t) => {
-  const traitObj = new TsAsyncParser();
-
-  const result = await asStringUsingTrait(traitObj, 1, 42);
-  t.assertEqual(result, "42");
-
-  const result2 = await tryFromStringUsingTrait(traitObj, 1, "42");
-  t.assertEqual(result2, 42);
-
-  await delayUsingTrait(traitObj, 1);
-  await tryDelayUsingTrait(traitObj, "1");
-
-  t.end();
-});
-
-asyncTest("Async callbacks with errors", async (t) => {
-  const traitObj = new TsAsyncParser();
-
-  try {
-    await tryFromStringUsingTrait(traitObj, 1, "force-panic");
-    t.fail("No error detected");
-  } catch (e: any) {
-    // OK
-  }
-
-  try {
-    await tryFromStringUsingTrait(traitObj, 1, "fourty-two");
-    t.fail("No error detected");
-  } catch (e: any) {
-    // OK
-  }
-
-  await t.assertThrowsAsync(
-    ParserError.NotAnInt.instanceOf,
-    async () => await tryFromStringUsingTrait(traitObj, 1, "fourty-two"),
-  );
-  await t.assertThrowsAsync(
-    ParserError.UnexpectedError.instanceOf,
-    async () =>
-      await tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception"),
-  );
-
-  try {
-    await tryDelayUsingTrait(traitObj, "one");
-    t.fail("Expected previous statement to throw");
-  } catch (/*ParserError.NotAnInt*/ e: any) {
-    // Expected
-  }
-
-  t.end();
-});
-
-xasyncTest("Async callbacks cancellation", async (t) => {
-  const traitObj = new TsAsyncParser();
-
-  const completedDelaysBefore = traitObj.completedDelays;
-  await cancelDelayUsingTrait(traitObj, 100);
-  // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-  await delayPromise(1000);
-  // If the task was cancelled, then completedDelays won't have increased
-  t.assertEqual(traitObj.completedDelays, completedDelaysBefore);
-
-  // Test that all handles here cleaned up
-  // assert(uniffiForeignFutureHandleCountFutures() == 0)
-
-  t.end();
-});
-
-asyncTest("async function returning an object", async (t) => {
-  const megaphone = await asyncNewMegaphone();
-  const result = await megaphone.fallibleMe(false);
-  t.assertEqual(result, 42);
-  t.end();
-});
-
-asyncTest(
-  "async function returning an object with primary async connstructor",
-  async (t) => {
-    const megaphone = await Megaphone.create();
-    const result = await megaphone.fallibleMe(false);
-    t.assertEqual(result, 42);
+(async () => {
+  await asyncTest("alwaysReady", async (t) => {
+    const result = await alwaysReady();
+    t.assertTrue(result);
+    checkRemainingFutures(t);
     t.end();
-  },
-);
-
-asyncTest(
-  "async function returning an object with secondary async connstructor",
-  async (t) => {
-    const megaphone = await Megaphone.secondary();
-
-    const result = await megaphone.fallibleMe(false);
-    t.assertEqual(result, 42);
-
-    t.end();
-  },
-);
-
-asyncTest("With the Tokio runtime", async (t) => {
-  const helloAlice = await t.asyncMeasure(
-    async () => sayAfterWithTokio(2000, "Alice"),
-    2000,
-    20,
-  );
-  t.assertEqual("Hello, Alice (with Tokio)!", helloAlice);
-  t.end();
-});
-
-asyncTest("fallible function… which doesn't throw", async (t) => {
-  const result = await t.asyncMeasure(async () => fallibleMe(false), 0, 100);
-  t.assertEqual(42, result);
-  t.end();
-});
-
-asyncTest("fallible method… which doesn't throw", async (t) => {
-  const m = await fallibleStruct(false);
-  const result = await m.fallibleMe(false);
-  t.assertEqual(42, result);
-  t.end();
-});
-
-asyncTest("fallible method… which doesn't throw, part II", async (t) => {
-  const megaphone = newMegaphone();
-  const result = await t.asyncMeasure(
-    async () => megaphone.fallibleMe(false),
-    0,
-    100,
-  );
-  t.assertEqual(42, result);
-
-  t.end();
-});
-
-asyncTest("fallible function… which does throw", async (t) => {
-  await t.asyncMeasure(
-    async () =>
-      await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
-        fallibleMe(true),
-      ),
-    0,
-    100,
-  );
-  t.end();
-});
-
-asyncTest("fallible method… which does throw", async (t) => {
-  await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
-    fallibleStruct(true),
-  );
-  t.end();
-});
-
-asyncTest("fallible method… which does throw, part II", async (t) => {
-  const megaphone = newMegaphone();
-  await t.asyncMeasure(
-    async () =>
-      await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
-        megaphone.fallibleMe(true),
-      ),
-    0,
-    100,
-  );
-  t.end();
-});
-
-asyncTest("a future that uses a lock and that is not cancelled", async (t) => {
-  await useSharedResource(
-    SharedResourceOptions.create({
-      releaseAfterMs: 100,
-      timeoutMs: 1000,
-    }),
-  );
-  await useSharedResource(
-    SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
-  );
-  t.end();
-});
-
-asyncTest("a future that uses a lock and that is cancelled", async (t) => {
-  const options = SharedResourceOptions.create({
-    releaseAfterMs: 100,
-    timeoutMs: 1000,
   });
-  const task = useSharedResource(options);
-  await delayPromise(100);
-  // Cancel the task
-  // Unsure what this means in a Javascript context.
-  await task;
 
-  // Try accessing the shared resource again.  The initial task should release the shared resource
-  // before the timeout expires.
-  await useSharedResource(
-    SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
+  await asyncTest("newMyRecord", async (t) => {
+    const record = await newMyRecord("my string", 42);
+    t.assertEqual(record.a, "my string");
+    t.assertEqual(record.b, 42);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("void", async (t) => {
+    await t.asyncMeasure(void_, 0, 500);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("sleep", async (t) => {
+    await t.asyncMeasure(async () => sleep(500), 500, 50);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  test("sync greet", (t) => {
+    t.measure(() => greet("Hello"), 0, 10);
+  });
+
+  await asyncTest("Sequential futures", async (t) => {
+    await t.asyncMeasure(
+      async () => {
+        t.assertEqual("Hello, Alice!", await sayAfter(500, "Alice"));
+        t.assertEqual("Hello, Bob!", await sayAfter(500, "Bob"));
+      },
+      1000,
+      50,
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("Concurrent futures", async (t) => {
+    await t.asyncMeasure(
+      async () => {
+        const alice = sayAfter(400, "Alice");
+        const bob = sayAfter(600, "Bob");
+        const [helloAlice, helloBob] = await Promise.all([alice, bob]);
+        t.assertEqual("Hello, Alice!", helloAlice);
+        t.assertEqual("Hello, Bob!", helloBob);
+      },
+      600,
+      50,
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("Async methods", async (t) => {
+    const megaphone = newMegaphone();
+    let helloAlice = await t.asyncMeasure(
+      async () => megaphone.sayAfter(500, "Alice"),
+      500,
+      20,
+    );
+    t.assertEqual("HELLO, ALICE!", helloAlice);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("Async trait interface methods", async (t) => {
+    const traits = getSayAfterTraits();
+
+    await t.asyncMeasure(
+      async () => {
+        let result1 = await traits[0].sayAfter(300, "Alice");
+        let result2 = await traits[1].sayAfter(200, "Bob");
+
+        t.assertEqual(result1, "Hello, Alice!");
+        t.assertEqual(result2, "Hello, Bob!");
+      },
+      500,
+      50,
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("UDL-defined async trait interface methods", async (t) => {
+    const traits = getSayAfterUdlTraits();
+
+    await t.asyncMeasure(
+      async () => {
+        let result1 = await traits[0].sayAfter(300, "Alice");
+        let result2 = await traits[1].sayAfter(200, "Bob");
+
+        t.assertEqual(result1, "Hello, Alice!");
+        t.assertEqual(result2, "Hello, Bob!");
+      },
+      500,
+      50,
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("Object with a fallible async ctor.", async (t) => {
+    try {
+      await FallibleMegaphone.create();
+      t.fail("Expected an error");
+    } catch (e: any) {
+      // OK
+    }
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  // AsyncParser.
+  class TsAsyncParser implements AsyncParser {
+    constructor(public completedDelays: number = 0) {}
+    async asString(delayMs: number, value: number): Promise<string> {
+      await this.doDelay(delayMs);
+      return value.toString();
+    }
+    async tryFromString(delayMs: number, value: string): Promise<number> {
+      if (value == "force-panic") {
+        throw new Error("force-panic");
+      }
+      if (value == "force-unexpected-exception") {
+        throw new ParserError.UnexpectedError();
+      }
+      const v = this.parseInt(value);
+      await this.doDelay(delayMs);
+      return v;
+    }
+    async delay(delayMs: number): Promise<void> {
+      await this.doDelay(delayMs);
+    }
+    async tryDelay(delayMs: string): Promise<void> {
+      await this.doDelay(this.parseInt(delayMs));
+    }
+
+    toString(): string {
+      return "TsAsyncParser";
+    }
+
+    private async doDelay(ms: number): Promise<void> {
+      await delayPromise(ms);
+      this.completedDelays += 1;
+    }
+
+    private parseInt(value: string): number {
+      const num = Number.parseInt(value);
+      if (Number.isNaN(num)) {
+        throw new ParserError.NotAnInt();
+      }
+      return num;
+    }
+  }
+
+  await asyncTest("Async callbacks", async (t) => {
+    const traitObj = new TsAsyncParser();
+
+    const result = await asStringUsingTrait(traitObj, 1, 42);
+    t.assertEqual(result, "42");
+
+    const result2 = await tryFromStringUsingTrait(traitObj, 1, "42");
+    t.assertEqual(result2, 42);
+
+    await delayUsingTrait(traitObj, 1);
+    await tryDelayUsingTrait(traitObj, "1");
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("Async callbacks with errors", async (t) => {
+    const traitObj = new TsAsyncParser();
+
+    try {
+      await tryFromStringUsingTrait(traitObj, 1, "force-panic");
+      t.fail("No error detected");
+    } catch (e: any) {
+      // OK
+      t.assertTrue(ParserError.UnexpectedError.instanceOf(e));
+    }
+
+    try {
+      await tryFromStringUsingTrait(traitObj, 1, "fourty-two");
+      t.fail("No error detected");
+    } catch (e: any) {
+      t.assertTrue(ParserError.NotAnInt.instanceOf(e));
+    }
+
+    await t.assertThrowsAsync(
+      ParserError.NotAnInt.instanceOf,
+      async () => await tryFromStringUsingTrait(traitObj, 1, "fourty-two"),
+    );
+    await t.assertThrowsAsync(
+      ParserError.UnexpectedError.instanceOf,
+      async () =>
+        await tryFromStringUsingTrait(
+          traitObj,
+          1,
+          "force-unexpected-exception",
+        ),
+    );
+
+    try {
+      await tryDelayUsingTrait(traitObj, "one");
+      t.fail("Expected previous statement to throw");
+    } catch (e: any) {
+      // Expected
+    }
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  /**
+   * Skipping this test as it is testing an abort being propogated to Javascript.
+   *
+   * Cancellable promises aren't a standard in JS, so there is nothing to cancel.
+   *
+   * Even then, the single threaded-ness of JS means that this test would rely on client
+   * code, i.e. `doDelay` checking if the Promise had been cancelled before incrementing
+   * the `completedDelays` count.
+   */
+  await xasyncTest("cancellation of async JS callbacks", async (t) => {
+    const traitObj = new TsAsyncParser();
+
+    // #JS_TASK_CANCELLATION
+    const completedDelaysBefore = traitObj.completedDelays;
+    const promise = cancelDelayUsingTrait(traitObj, 100);
+    // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+    await delayPromise(1000);
+    await promise;
+    // If the task was cancelled, then completedDelays won't have increased
+    // however, this is cancelling the async callback, which doesn't really make any sense
+    // in Javascript.
+    t.assertEqual(
+      traitObj.completedDelays,
+      completedDelaysBefore,
+      "Delay should have been cancelled",
+    );
+
+    // Test that all handles here cleaned up
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("async function returning an object", async (t) => {
+    const megaphone = await asyncNewMegaphone();
+    const result = await megaphone.fallibleMe(false);
+    t.assertEqual(result, 42);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest(
+    "async function returning an object with primary async connstructor",
+    async (t) => {
+      const megaphone = await Megaphone.create();
+      const result = await megaphone.fallibleMe(false);
+      t.assertEqual(result, 42);
+      checkRemainingFutures(t);
+      t.end();
+    },
   );
-  t.end();
-});
 
-//
+  await asyncTest(
+    "async function returning an object with secondary async connstructor",
+    async (t) => {
+      const megaphone = await Megaphone.secondary();
+
+      const result = await megaphone.fallibleMe(false);
+      t.assertEqual(result, 42);
+      checkRemainingFutures(t);
+      t.end();
+    },
+  );
+
+  await asyncTest("With the Tokio runtime", async (t) => {
+    const helloAlice = await t.asyncMeasure(
+      async () => sayAfterWithTokio(500, "Alice"),
+      500,
+      20,
+    );
+    t.assertEqual("Hello, Alice (with Tokio)!", helloAlice);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("fallible function… which doesn't throw", async (t) => {
+    const result = await t.asyncMeasure(async () => fallibleMe(false), 0, 100);
+    t.assertEqual(42, result);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("fallible method… which doesn't throw", async (t) => {
+    const m = await fallibleStruct(false);
+    const result = await m.fallibleMe(false);
+    t.assertEqual(42, result);
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest(
+    "fallible method… which doesn't throw, part II",
+    async (t) => {
+      const megaphone = newMegaphone();
+      const result = await t.asyncMeasure(
+        async () => megaphone.fallibleMe(false),
+        0,
+        100,
+      );
+      t.assertEqual(42, result);
+      checkRemainingFutures(t);
+      t.end();
+    },
+  );
+
+  await asyncTest("fallible function… which does throw", async (t) => {
+    await t.asyncMeasure(
+      async () =>
+        await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
+          fallibleMe(true),
+        ),
+      0,
+      100,
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("fallible method… which does throw", async (t) => {
+    await t.assertThrowsAsync(
+      MyError.Foo.instanceOf,
+      async () => await fallibleStruct(true),
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest("fallible method… which does throw, part II", async (t) => {
+    const megaphone = newMegaphone();
+    await t.asyncMeasure(
+      async () =>
+        await t.assertThrowsAsync(MyError.Foo.instanceOf, async () =>
+          megaphone.fallibleMe(true),
+        ),
+      0,
+      100,
+    );
+    checkRemainingFutures(t);
+    t.end();
+  });
+
+  await asyncTest(
+    "a future that uses a lock and that is not cancelled",
+    async (t) => {
+      const task1 = useSharedResource(
+        SharedResourceOptions.create({
+          releaseAfterMs: 100,
+          timeoutMs: 1000,
+        }),
+      );
+      const task2 = useSharedResource(
+        SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
+      );
+      await Promise.all([task1, task2]);
+
+      checkRemainingFutures(t);
+      t.end();
+    },
+  );
+
+  await xasyncTest(
+    "a future that uses a lock and that is cancelled from JS",
+    async (t) => {
+      const task1 = useSharedResource(
+        SharedResourceOptions.create({
+          releaseAfterMs: 5000,
+          timeoutMs: 100,
+        }),
+      );
+      // #RUST_TASK_CANCELLATION
+      //
+      // Again this test is not really applicable for JS, as it has no standard way of
+      // cancelling a task.
+      // task1.cancel()
+
+      // Try accessing the shared resource again.  The initial task should release the shared resource
+      // before the timeout expires.
+      const task2 = useSharedResource(
+        SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
+      );
+
+      await Promise.allSettled([task1, task2]);
+      checkRemainingFutures(t);
+      t.end();
+    },
+  );
+
+  await xasyncTest(
+    "a future that uses a lock and that is cancelled by Rust",
+    async (t) => {
+      // #RUST_TASK_CANCELLATION
+      //
+      // We should be able to see this test pass if Rust is calling a
+      // timeout a cancellation.
+      //
+      await t.assertThrowsAsync(
+        (err) => {
+          t.assertEqual(err.message, "cancelled");
+          return true;
+        },
+        async () => {
+          await useSharedResource(
+            SharedResourceOptions.create({
+              releaseAfterMs: 1000,
+              timeoutMs: 100,
+            }),
+          );
+        },
+      );
+      checkRemainingFutures(t);
+      t.end();
+    },
+  );
+})();

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -39,10 +39,11 @@ export class UniffiError extends Error {
     variantName: string,
     message: string | undefined,
   ): string {
+    const prefix = `${typeName}.${variantName}`;
     if (message) {
-      return `${typeName}.${variantName}: ${message}`;
+      return `${prefix}: ${message}`;
     } else {
-      return `${typeName}.${variantName}`;
+      return prefix;
     }
   }
 }

--- a/typescript/src/handle-map.ts
+++ b/typescript/src/handle-map.ts
@@ -33,4 +33,8 @@ export class UniffiHandleMap<T> {
     this.map.delete(handle);
     return obj;
   }
+
+  get size(): number {
+    return this.map.size;
+  }
 }

--- a/typescript/src/rust-call.ts
+++ b/typescript/src/rust-call.ts
@@ -4,7 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 import { UniffiInternalError } from "./errors";
-import type { UnsafeMutableRawPointer } from "./objects";
 
 export const CALL_SUCCESS = 0;
 export const CALL_ERROR = 1;
@@ -86,6 +85,18 @@ function uniffiCheckCallStatus(
     }
 
     case CALL_CANCELLED:
+      // #RUST_TASK_CANCELLATION:
+      //
+      // This error code is expected when a Rust Future is cancelled or aborted, either
+      // from the foreign side, or from within Rust itself.
+      //
+      // It's expected that this would be encountered when the `completeFunc` is called
+      // from `uniffiRustCallAsync`.
+      //
+      // Currently, there is no generated API of cancelling a promise from JS.
+      //
+      // As of uniffi-rs v0.28.0, call cancellation is only checked for in the Swift bindings,
+      // and has a similar Unimplemeneted error.
       throw new UniffiInternalError.Unimplemented(
         "Cancellation not supported yet",
       );


### PR DESCRIPTION
This PR makes the `test_futures.ts` tests run in series.

This makes it easier to test/demonstrate that:

- the `async-callbacks` are cleaned up (so we can use this to keep the promise in memory, and have a future place for an AbortController to live)
- the `async-rust-call` are cleaned up.

Additional tests/documentation is also put in place for a future implementation of task cancellation, both Rust cancelling JS and the other way round.

This hasn't been implemented here: 

- for Rust cancelling JS: `AbortController` exists, but doesn't seem to be widely adopted. It is not yet implemented by Hermes.
- for JS cancelling Rust: an FFI method can be easily exposed, but it is not clear what the most JS-ergonomic way to do this might be. 
- for Rust cancelling Rust, and it propagating to JS: I'm not 100% sure, but I don't think it is currently supported by uniffi-rs.
  - There seems to be missing tests for this case: [Swift test](https://github.com/mozilla/uniffi-rs/blob/main/fixtures/futures/tests/bindings/test_futures.swift#L401-L429), [Kotlin test](https://github.com/mozilla/uniffi-rs/blob/main/fixtures/futures/tests/bindings/test_futures.kts#L325-L352). Missing is the case where `timeoutMs` < `releaseAfterMs`, such that the Rust aborts after the timeout.
  - Only the Swift implementation makes mention of [`CALL_CANCELLED`, and `fatalError`s on detection](https://github.com/mozilla/uniffi-rs/blob/7ff7584ce06a2d5160d598b319689d0f691c9ddf/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift#L104-L105).

