### PR TITLE
Use DataView instead of TypedArrays in RustBuffer

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/StringHelper.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/StringHelper.ts
@@ -24,13 +24,14 @@ const FfiConverterString = (() => {
         }
         read(from: RustBuffer): TypeName {
             const length = lengthConverter.read(from);
-            return from.read(length, arrayBufferToString);
+            const bytes = from.readBytes(length);
+            return arrayBufferToString(bytes);
         }
         write(value: TypeName, into: RustBuffer): void {
             const buffer = stringToArrayBuffer(value);
             const numBytes = buffer.byteLength;
             lengthConverter.write(numBytes, into);
-            into.write(numBytes, () => stringToArrayBuffer(value));
+            into.writeBytes(buffer);
         }
         allocationSize(value: TypeName): number {
             return lengthConverter.allocationSize(0) + stringByteLength(value);

--- a/fixtures/coverall/tests/bindings/test_coverall.ts
+++ b/fixtures/coverall/tests/bindings/test_coverall.ts
@@ -38,20 +38,22 @@ test("test create_some_dict() with default values", (t) => {
   const d = createSomeDict();
   t.assertEqual(d.text, "text");
   t.assertEqual(d.maybeText, "maybe_text");
-  // Hermes doesn't support string --> ArrayBuffer
-  // t.assertEqual(d.someBytes.contentEquals("some_bytes".toByteArray(Charsets.UTF_8)))
-  // t.assertEqual(d.maybeSomeBytes.contentEquals("maybe_some_bytes".toByteArray(Charsets.UTF_8)))
+  // Hermes doesn't support string --> ArrayBuffer, so we just check the length.
+  // The string is all alphanumeric, so the length is the same in chars as they are in bytes.
+  // This is not the case for all strings, however.
+  t.assertEqual(d.someBytes.byteLength, "some_bytes".length);
+  t.assertEqual(d.maybeSomeBytes?.byteLength, "maybe_some_bytes".length);
   t.assertTrue(d.aBool);
   t.assertEqual(d.maybeABool, false);
   t.assertEqual(d.unsigned8, 1);
   t.assertEqual(d.maybeUnsigned8, 2);
   t.assertEqual(d.unsigned16, 3);
   t.assertEqual(d.maybeUnsigned16, 4);
-  t.assertEqual(d.unsigned64, BigInt("0x10000000000000000"));
+  t.assertEqual(d.unsigned64, BigInt("0xffffffffffffffff"));
   t.assertEqual(d.maybeUnsigned64, BigInt("0"));
   t.assertEqual(d.signed8, 8);
   t.assertEqual(d.maybeSigned8, 0);
-  t.assertEqual(d.signed64, BigInt("0x8000000000000000"));
+  t.assertEqual(d.signed64, BigInt("0x7fffffffffffffff"));
   t.assertEqual(d.maybeSigned64, BigInt("0"));
 
   t.assertEqual(d.float32, 1.2345, undefined, almostEquals);
@@ -66,20 +68,22 @@ test("test create_none_dict() with default values", (t) => {
   const d = createNoneDict();
   t.assertEqual(d.text, "text");
   t.assertEqual(d.maybeText, undefined);
-  // Hermes doesn't support string --> ArrayBuffer
-  // t.assertEqual(d.someBytes.contentEquals("some_bytes".toByteArray(Charsets.UTF_8)))
-  // t.assertEqual(d.maybeSomeBytes.contentEquals("maybe_some_bytes".toByteArray(Charsets.UTF_8)))
+  // Hermes doesn't support string --> ArrayBuffer, so we just check the length.
+  // The string is all alphanumeric, so the length is the same in chars as they are in bytes.
+  // This is not the case for all strings, however.
+  t.assertEqual(d.someBytes.byteLength, "some_bytes".length);
+  t.assertEqual(d.maybeSomeBytes, undefined);
   t.assertTrue(d.aBool);
   t.assertEqual(d.maybeABool, undefined);
   t.assertEqual(d.unsigned8, 1);
   t.assertEqual(d.maybeUnsigned8, undefined);
   t.assertEqual(d.unsigned16, 3);
   t.assertEqual(d.maybeUnsigned16, undefined);
-  t.assertEqual(d.unsigned64, BigInt("0x10000000000000000"));
+  t.assertEqual(d.unsigned64, BigInt("0xffffffffffffffff"));
   t.assertEqual(d.maybeUnsigned64, undefined);
   t.assertEqual(d.signed8, 8);
   t.assertEqual(d.maybeSigned8, undefined);
-  t.assertEqual(d.signed64, BigInt("0x8000000000000000"));
+  t.assertEqual(d.signed64, BigInt("0x7fffffffffffffff"));
   t.assertEqual(d.maybeSigned64, undefined);
 
   t.assertEqual(d.float32, 1.2345, undefined, almostEquals);


### PR DESCRIPTION
Using typed arrays had a number of disadvantages, most notably:

- Handling endian-ness was a manual process which was non-obvious.
- The offset rules, i.e. you can't write to the underlying array buffer at offsets that were not multiples of the element byte length.

This resulted in lots of copying. For example, when writing a `BigInt` to the byte offset 11 a destination `ArrayBuffer`:

1. an transitional `ArrayBuffer` of 8 bytes was created
2. a `Uint64Array` typed array was created to view that transitional ArrayBuffer.
3. the `BigInt` was written into the `Uint64Array`, i.e. the transitional array.
4. the transitional array was reversed, because of endian-ness differences between Rust and Hermes.
5. a `Uint8Array` view was created for each of the transitional array and the destination array.
6. the transitional array was copied into the destination array.

This was a lot of work for a single write: steps 1, 3, 4 and 6 involve `O(n)` work.

This PR replaces the typed arrays with a `DataView` which is a lot simpler:

1. a `DataView` of the destination array is created
2. the `BigInt` is written into the `DataView`, of the correct endianness.

Only step 2 involves `O(n)` work.

The work allowed us to simplify the `RustBuffer`: the `read` and `write` method are both replaced by two simpler methods:

- `readWithView` and `readBytes`.
- `writeWithView` and `writeBytes`.