### PR TITLE
Rename `data` property to `inner` in enums and errors

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ObjectTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ObjectTemplate.ts
@@ -121,11 +121,11 @@ export class {{ impl_class_name }} extends AbstractUniffiObject implements {{ pr
     {% if is_error %}
     {{- self.import_infra("UniffiThrownObject", "objects") }}
     static hasInner(obj: any): obj is UniffiThrownObject<{{ impl_class_name }}> {
-        return UniffiThrownObject.instanceOf(obj) && {{ impl_class_name }}.instanceOf(obj.data);
+        return UniffiThrownObject.instanceOf(obj) && {{ impl_class_name }}.instanceOf(obj.inner);
     }
 
     static getInner(err: UniffiThrownObject<{{ impl_class_name }}>): {{ impl_class_name }} {
-        return err.data;
+        return err.inner;
     }
     {%- endif %}
 }

--- a/fixtures/callbacks/tests/bindings/test_callbacks.ts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.ts
@@ -133,7 +133,7 @@ test("Non-flat errors are propagated correctly", (t) => {
       const isError = ComplexError.ReallyBadArgument.instanceOf(err);
       if (isError) {
         // set in TypesSriptGetters.getOption
-        t.assertEqual(err.data.code, 20);
+        t.assertEqual(err.inner.code, 20);
       }
       return isError;
     },
@@ -143,7 +143,7 @@ test("Non-flat errors are propagated correctly", (t) => {
     (err) => {
       const isError = ComplexError.UnexpectedErrorWithReason.instanceOf(err);
       if (isError) {
-        t.assertEqual(err.data.reason, `Error: ${SOMETHING_FAILED}`);
+        t.assertEqual(err.inner.reason, `Error: ${SOMETHING_FAILED}`);
       }
       return isError;
     },

--- a/fixtures/coverall/tests/bindings/test_coverall.ts
+++ b/fixtures/coverall/tests/bindings/test_coverall.ts
@@ -175,7 +175,7 @@ test("Error Values", (t) => {
     throwRootError();
   });
   t.assertThrows(
-    (e) => ComplexError.instanceOf(e.data.error),
+    (e) => ComplexError.instanceOf(e.inner.error),
     () => {
       throwRootError();
     },
@@ -183,7 +183,7 @@ test("Error Values", (t) => {
 
   const e = getRootError();
   t.assertTrue(RootError.Other.instanceOf(e));
-  t.assertEqual(e.data.error, OtherError.Unexpected);
+  t.assertEqual(e.inner.error, OtherError.Unexpected);
 
   const ce = getComplexError(undefined);
   t.assertTrue(ComplexError.PermissionDenied.instanceOf(ce));

--- a/fixtures/custom-types-example/tests/bindings/test_custom_types_example.ts
+++ b/fixtures/custom-types-example/tests/bindings/test_custom_types_example.ts
@@ -62,13 +62,13 @@ test("Rust EnumWrapper structs --> via MyEnum --> string", (t) => {
     const enumValue = unwapEnumWrapper(s);
     switch (enumValue.tag) {
       case MyEnum_Tags.A: {
-        const value = enumValue.data[0];
+        const value = enumValue.inner[0];
         t.assertEqual(value, s);
         t.assertTrue(value.indexOf("A") >= 0);
         break;
       }
       case MyEnum_Tags.B: {
-        const value = enumValue.data[0];
+        const value = enumValue.inner[0];
         t.assertEqual(value, s);
         t.assertFalse(value.indexOf("A") >= 0);
         break;

--- a/fixtures/custom-types-example/uniffi.toml
+++ b/fixtures/custom-types-example/uniffi.toml
@@ -46,9 +46,9 @@ fromCustom = "{}.indexOf('A') >= 0 ? new MyEnum.A({}) : new MyEnum.B({})"
 intoCustom = """((v: MyEnum) => {
     switch (v.tag) {
         case MyEnum_Tags.A:
-            return v.data[0];
+            return v.inner[0];
         case MyEnum_Tags.B:
-            return v.data[0];
+            return v.inner[0];
     }
 })({})
 """

--- a/fixtures/enum-types/tests/bindings/test_enum_types.ts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.ts
@@ -54,7 +54,7 @@ test("Roundtripping enums with values", (t) => {
         return;
       case AnimalAssociatedType_Tags.Dog:
         if (AnimalAssociatedType.Dog.instanceOf(right)) {
-          t.assertEqual(left.data[0].record(), right.data[0].record());
+          t.assertEqual(left.inner[0].record(), right.inner[0].record());
         } else {
           t.fail(`${right} is not a Dog`);
         }
@@ -83,7 +83,7 @@ test("Roundtripping enums with name values", (t) => {
         return;
       case AnimalNamedAssociatedType_Tags.Dog:
         if (AnimalNamedAssociatedType.Dog.instanceOf(right)) {
-          t.assertEqual(left.data.value.record(), right.data.value.record());
+          t.assertEqual(left.inner.value.record(), right.inner.value.record());
         } else {
           t.fail(`${right} is not a Dog`);
         }

--- a/fixtures/error-types/tests/bindings/test_error_types.ts
+++ b/fixtures/error-types/tests/bindings/test_error_types.ts
@@ -82,7 +82,7 @@ test("oopsEnum 2", (t) => {
   t.assertThrows(
     (error) => {
       if (Exception.IntValue.instanceOf(error)) {
-        t.assertEqual(error.data.value, 2);
+        t.assertEqual(error.inner.value, 2);
         // assert(String(describing: error) == "IntValue(value: 2)")
         // assert(String(reflecting: error) == "error_types.Error.IntValue(value: 2)")
         // assert(error.localizedDescription == "error_types.Error.IntValue(value: 2)")
@@ -99,9 +99,9 @@ test("oopsEnum 3", (t) => {
     (error) => {
       if (Exception.FlatInnerError.instanceOf(error)) {
         t.assertEqual(error.toString(), "Error: Exception.FlatInnerError");
-        t.assertTrue(FlatInner.CaseA.instanceOf(error.data.error));
+        t.assertTrue(FlatInner.CaseA.instanceOf(error.inner.error));
         t.assertEqual(
-          error.data.error.toString(),
+          error.inner.error.toString(),
           "Error: FlatInner.CaseA: inner",
         );
         // assert(String(describing: e) == "FlatInnerError(error: error_types.FlatInner.CaseA(message: \"inner\"))")
@@ -160,7 +160,7 @@ test("oopsTuple 0 - throws enum variants containing tuples", (t) => {
     (error) => {
       t.assertEqual("Error: TupleError.Oops", error.toString());
       if (TupleError.Oops.instanceOf(error)) {
-        t.assertEqual("oops", error.data[0]);
+        t.assertEqual("oops", error.inner[0]);
         return true;
       }
       return false;
@@ -174,7 +174,7 @@ test("oopsTuple 1  - throws enum variants containing tuples", (t) => {
     (error) => {
       t.assertEqual("Error: TupleError.Value", error.toString());
       if (TupleError.Value.instanceOf(error)) {
-        t.assertEqual(1, error.data[0]);
+        t.assertEqual(1, error.inner[0]);
         return true;
       }
       return false;

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -53,19 +53,19 @@ export class UniffiThrownObject<T> extends Error {
   private readonly __baseTypeName: string = UniffiThrownObject.__baseTypeName;
   constructor(
     private readonly __uniffiTypeName: string,
-    public readonly data: T,
+    public readonly inner: T,
     message?: string,
   ) {
     // We append the error type and variant to the message because we cannot override `toString()`—
     // in errors.test.ts, we see that the overridden `toString()` method is not called.
-    super(UniffiThrownObject.createMessage(__uniffiTypeName, data, message));
+    super(UniffiThrownObject.createMessage(__uniffiTypeName, inner, message));
   }
 
   // Current implementations of hermes errors do not repect instance methods or calculated properties.
   toString(): string {
     return UniffiThrownObject.createMessage(
       this.__uniffiTypeName,
-      this.data,
+      this.inner,
       this.message,
     );
   }

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -134,10 +134,10 @@ export class FfiConverterObjectAsError<
     return new UniffiThrownObject(this.typeName, obj);
   }
   write(value: UniffiThrownObject<T>, into: RustBuffer): void {
-    const obj = value.data;
+    const obj = value.inner;
     this.innerConverter.write(obj, into);
   }
   allocationSize(value: UniffiThrownObject<T>): number {
-    return this.innerConverter.allocationSize(value.data);
+    return this.innerConverter.allocationSize(value.inner);
   }
 }


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This mechanical rename changes the type of enums and errors from:

```ts
type MyEnum = {
  tag: MyEnum_Tags,
  data: MyEnum_data,
};
```
to:
```ts
type MyEnum = {
  tag: MyEnum_Tags,
  inner: MyEnum_data,
};
```

This is to match the `getInner` and `hasInner` static methods for errors.