### PR TITLE
Allow enum variant names that collide with existing types

### DIFF
--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -97,6 +97,20 @@ fn get_animal(a: Option<Animal>) -> Animal {
     a.unwrap_or(Animal::Dog)
 }
 
+#[derive(uniffi::Enum)]
+pub(crate) enum CollidingVariants {
+    AnimalRecord(AnimalRecord),
+    AnimalObjectInterface(Arc<AnimalObject>),
+    AnimalObject(Arc<AnimalObject>),
+    Animal(Animal),
+    CollidingVariants,
+}
+
+#[uniffi::export]
+fn identity_colliding_variants(value: CollidingVariants) -> CollidingVariants {
+    value
+}
+
 uniffi::include_scaffolding!("enum_types");
 
 #[cfg(test)]

--- a/fixtures/enum-types/tests/bindings/test_enum_types.ts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.ts
@@ -13,11 +13,15 @@ import {
   AnimalNamedAssociatedType_Tags,
   AnimalNoReprInt,
   AnimalObject,
+  AnimalRecord,
   AnimalSignedInt,
   AnimalUInt,
   getAnimal,
   identityEnumWithAssociatedType,
   identityEnumWithNamedAssociatedType,
+  CollidingVariants,
+  CollidingVariants_Tags,
+  identityCollidingVariants,
 } from "../../generated/enum_types";
 
 test("Enum disriminant", (t) => {
@@ -98,5 +102,74 @@ test("Roundtripping enums with name values", (t) => {
   for (const v of values) {
     t.assertTrue(AnimalNamedAssociatedType.instanceOf(v as any));
     assertEqual(v, identityEnumWithNamedAssociatedType(v));
+  }
+});
+
+test("Variant naming cam collide with existing types", (t) => {
+  {
+    const record = AnimalRecord.create({ value: 5 });
+    const variant1 = CollidingVariants.AnimalRecord.new(record);
+    const variant2 = new CollidingVariants.AnimalRecord(record);
+
+    t.assertEqual(variant1.tag, CollidingVariants_Tags.AnimalRecord);
+    t.assertEqual(variant2.tag, CollidingVariants_Tags.AnimalRecord);
+    t.assertEqual(variant1, variant2);
+    t.assertEqual(identityCollidingVariants(variant1), variant2);
+
+    t.assertTrue(CollidingVariants.instanceOf(variant1));
+    t.assertTrue(CollidingVariants.AnimalRecord.instanceOf(variant1));
+  }
+  {
+    const obj = new AnimalObject(1);
+    const variant1 = CollidingVariants.AnimalObject.new(obj);
+    const variant2 = new CollidingVariants.AnimalObject(obj);
+
+    t.assertEqual(variant1.tag, CollidingVariants_Tags.AnimalObject);
+    t.assertEqual(variant2.tag, CollidingVariants_Tags.AnimalObject);
+    t.assertEqual(variant1, variant2);
+    t.assertEqual(identityCollidingVariants(variant1), variant2);
+
+    t.assertTrue(CollidingVariants.instanceOf(variant1));
+    t.assertTrue(CollidingVariants.AnimalObject.instanceOf(variant1));
+  }
+
+  {
+    const obj = new AnimalObject(1);
+    const variant1 = CollidingVariants.AnimalObjectInterface.new(obj);
+    const variant2 = new CollidingVariants.AnimalObjectInterface(obj);
+
+    t.assertEqual(variant1.tag, CollidingVariants_Tags.AnimalObjectInterface);
+    t.assertEqual(variant2.tag, CollidingVariants_Tags.AnimalObjectInterface);
+    t.assertEqual(variant1, variant2);
+    t.assertEqual(identityCollidingVariants(variant1), variant2);
+
+    t.assertTrue(CollidingVariants.instanceOf(variant1));
+    t.assertTrue(CollidingVariants.AnimalObjectInterface.instanceOf(variant1));
+  }
+  {
+    const animal = Animal.Dog;
+    const variant1 = CollidingVariants.Animal.new(animal);
+    const variant2 = new CollidingVariants.Animal(animal);
+
+    t.assertEqual(variant1.tag, CollidingVariants_Tags.Animal);
+    t.assertEqual(variant2.tag, CollidingVariants_Tags.Animal);
+    t.assertEqual(variant1, variant2);
+    t.assertEqual(identityCollidingVariants(variant1), variant2);
+
+    t.assertTrue(CollidingVariants.instanceOf(variant1));
+    t.assertTrue(CollidingVariants.Animal.instanceOf(variant1));
+  }
+
+  {
+    const variant1 = CollidingVariants.CollidingVariants.new();
+    const variant2 = new CollidingVariants.CollidingVariants();
+
+    t.assertEqual(variant1.tag, CollidingVariants_Tags.CollidingVariants);
+    t.assertEqual(variant2.tag, CollidingVariants_Tags.CollidingVariants);
+    t.assertEqual(variant1, variant2);
+    t.assertEqual(identityCollidingVariants(variant1), variant2);
+
+    t.assertTrue(CollidingVariants.instanceOf(variant1));
+    t.assertTrue(CollidingVariants.CollidingVariants.instanceOf(variant1));
   }
 });


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This small PR tweaks the Variant classes for our typescript version of Tagged Enums, to allow Variants to have names of existing types.

For example, it's not uncommon for Rust programs to have enums constructed like so:

```rs
struct Dog {}
struct Cat {}

enum Animal {
  Dog(Dog),
  Cat(Cat),
}
```

The way we've modeled tagged enums are with a frozen object containing a class for each Variant.

So this would translate to:

```typescript
type Dog = …; // Dog defined elsewhere
type Cat = …;

const Animal = (() => {
    class Dog {
        constructor(public value: Dog) {
            // This Dog value is the wrong type!
            // value is the type of the Variant class.
        }
    }
    class Cat {
        constructor(public value: Cat) {}
    }
    return Object.freeze({ Dog, Cat });
})();
```

This commit changes the naming of the Variant class:

```typescript
type Dog = …; // Dog defined elsewhere
type Cat = …;

const Animal = (() => {
    class Dog_ {
        constructor(public value: Dog) {
            // There is no variant class called Dog yet, just Dog_,
            // so value is the correct type.
        }
    }
    class Cat_ {
        constructor(public value: Cat) {}
    }
    // We rename the Dog_ variant class as Dog here,
    // so the only way to access this class is via Animal.Dog.
    return Object.freeze({ Dog: Dog_, Cat: Cat_ });
})();
```

