### PR TITLE
Break up the ubrn command line build commands

### DIFF
--- a/crates/ubrn_cli/src/android.rs
+++ b/crates/ubrn_cli/src/android.rs
@@ -262,6 +262,10 @@ impl AndroidArgs {
     pub(crate) fn project_config(&self) -> Result<ProjectConfig> {
         self.config.clone().try_into()
     }
+
+    pub(crate) fn config(&self) -> Utf8PathBuf {
+        self.config.clone()
+    }
 }
 
 #[derive(Debug, Deserialize, Default, Clone, Hash, PartialEq, Eq)]

--- a/crates/ubrn_cli/src/android.rs
+++ b/crates/ubrn_cli/src/android.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use serde::Deserialize;
-use std::{fmt::Display, fs, process::Command, str::FromStr};
+use std::{collections::HashMap, fmt::Display, fs, process::Command, str::FromStr};
 
 use clap::Args;
 
@@ -15,6 +15,7 @@ use ubrn_common::{mk_dir, rm_dir, run_cmd, CrateMetadata};
 use crate::{
     building::{CommonBuildArgs, ExtraArgs},
     config::ProjectConfig,
+    rust::CrateConfig,
     workspace,
 };
 
@@ -122,53 +123,111 @@ impl AndroidArgs {
         let config: ProjectConfig = self.project_config()?;
         let project_root = config.project_root();
         let crate_ = &config.crate_;
-        let rust_dir = crate_.directory()?;
-        let manifest_path = crate_.manifest_path()?;
 
         let android = &config.android;
 
+        let cargo_extras = &android.cargo_extras;
+        let api_level = android.api_level;
+        let target_files = if self.common_args.no_cargo {
+            let files = self.find_existing(&crate_.metadata()?, &android.targets);
+            if !files.is_empty() {
+                files
+            } else {
+                self.cargo_build_all(crate_, &android.targets, cargo_extras, api_level)?
+            }
+        } else {
+            self.cargo_build_all(crate_, &android.targets, cargo_extras, api_level)?
+        };
+
+        let metadata = crate_.metadata()?;
         let jni_libs = android.jni_libs(project_root);
         rm_dir(&jni_libs)?;
-
-        let mut target_files: Vec<_> = Vec::new();
-        for target in &android.targets {
-            let target = target.parse::<Target>()?;
-            let mut cmd = Command::new("cargo");
-            cmd.arg("ndk")
-                .arg("--manifest-path")
-                .arg(&manifest_path)
-                .arg("--target")
-                .arg(target.to_string())
-                .arg("--platform")
-                .arg(format!("{}", android.api_level));
-
-            if !self.common_args.release {
-                cmd.arg("--no-strip");
-            }
-
-            cmd.arg("--").arg("build");
-            if self.common_args.release {
-                cmd.arg("--release");
-            }
-
-            cmd.args(android.cargo_extras.clone());
-
-            run_cmd(cmd.current_dir(&rust_dir))?;
-            let metadata = crate_.metadata()?;
-            let src_lib = metadata.library_path(
-                Some(target.triple()),
-                CrateMetadata::profile(self.common_args.release),
-            )?;
+        for (target, library) in &target_files {
             let dst_dir = jni_libs.join(target.to_string());
             mk_dir(&dst_dir)?;
 
             let dst_lib = dst_dir.join(metadata.library_file(Some(target.triple())));
-            fs::copy(&src_lib, &dst_lib)?;
-
-            target_files.push(src_lib);
+            fs::copy(library, &dst_lib)?;
         }
 
+        Ok(target_files.into_values().collect())
+    }
+
+    fn cargo_build_all(
+        &self,
+        crate_: &CrateConfig,
+        targets: &[String],
+        cargo_extras: &ExtraArgs,
+        api_level: usize,
+    ) -> Result<HashMap<Target, Utf8PathBuf>> {
+        let rust_dir = crate_.directory()?;
+        let manifest_path = crate_.manifest_path()?;
+        let metadata = crate_.metadata()?;
+        let mut target_files = HashMap::new();
+        let profile = self.common_args.profile();
+        for target in targets {
+            let target =
+                self.cargo_build(target, &manifest_path, cargo_extras, api_level, &rust_dir)?;
+            let library = metadata.library_path(Some(target.triple()), profile);
+            metadata.library_path_exists(&library)?;
+            target_files.insert(target, library);
+        }
         Ok(target_files)
+    }
+
+    fn cargo_build(
+        &self,
+        target: &str,
+        manifest_path: &Utf8PathBuf,
+        cargo_extras: &ExtraArgs,
+        api_level: usize,
+        rust_dir: &Utf8PathBuf,
+    ) -> Result<Target> {
+        let target = target.parse::<Target>()?;
+        let mut cmd = Command::new("cargo");
+        cmd.arg("ndk")
+            .arg("--manifest-path")
+            .arg(manifest_path)
+            .arg("--target")
+            .arg(target.to_string())
+            .arg("--platform")
+            .arg(format!("{}", api_level));
+        if !self.common_args.release {
+            cmd.arg("--no-strip");
+        }
+        cmd.arg("--").arg("build");
+        if self.common_args.release {
+            cmd.arg("--release");
+        }
+        cmd.args(cargo_extras.clone());
+        run_cmd(cmd.current_dir(rust_dir))?;
+        Ok(target)
+    }
+
+    fn find_existing(
+        &self,
+        metadata: &CrateMetadata,
+        targets: &[String],
+    ) -> HashMap<Target, Utf8PathBuf> {
+        let profile = self.common_args.profile();
+        targets
+            .iter()
+            .filter_map(|target| {
+                let target = target.parse::<Target>();
+                match target {
+                    Ok(target) => Some(target),
+                    Err(_) => None,
+                }
+            })
+            .filter_map(|target| {
+                let library = metadata.library_path(Some(target.triple()), profile);
+                if library.exists() {
+                    Some((target, library))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     pub(crate) fn project_config(&self) -> Result<ProjectConfig> {
@@ -176,7 +235,7 @@ impl AndroidArgs {
     }
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Default, Clone, Hash, PartialEq, Eq)]
 pub enum Target {
     #[serde(rename = "armeabi-v7a")]
     ArmeabiV7a,

--- a/crates/ubrn_cli/src/building.rs
+++ b/crates/ubrn_cli/src/building.rs
@@ -109,6 +109,14 @@ pub(crate) struct CommonBuildArgs {
     #[clap(long, short, default_value = "false")]
     pub(crate) release: bool,
 
+    /// If the Rust library has been built for at least one target, then
+    /// don't re-run cargo build.
+    ///
+    /// This may be useful if you are using a pre-built library or are
+    /// managing the build process yourself.
+    #[clap(long)]
+    pub(crate) no_cargo: bool,
+
     /// Optionally generate the bindings and turbo-module code for the crate
     #[clap(long = "and-generate", short = 'g')]
     pub(crate) and_generate: bool,

--- a/crates/ubrn_cli/src/generate.rs
+++ b/crates/ubrn_cli/src/generate.rs
@@ -4,10 +4,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use anyhow::Result;
+use camino::Utf8PathBuf;
 use clap::{Args, Subcommand};
-use ubrn_bindgen::BindingsArgs;
+use ubrn_bindgen::{BindingsArgs, OutputArgs, SourceArgs};
 
-use crate::codegen::TurboModuleArgs;
+use crate::{codegen::TurboModuleArgs, config::ProjectConfig};
 
 #[derive(Args, Debug)]
 pub(crate) struct GenerateArgs {
@@ -27,6 +28,11 @@ pub(crate) enum GenerateCmd {
     Bindings(BindingsArgs),
     /// Generate the TurboModule code to plug the bindings into the app
     TurboModule(TurboModuleArgs),
+    /// Generate the Bindings and TurboModule code from a library
+    /// file and a YAML config file.
+    ///
+    /// This is the second step of the `--and-generate` option of the build command.
+    All(GenerateAllArgs),
 }
 
 impl GenerateCmd {
@@ -40,6 +46,59 @@ impl GenerateCmd {
                 t.run()?;
                 Ok(())
             }
+            Self::All(t) => {
+                t.run()?;
+                Ok(())
+            }
         }
+    }
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct GenerateAllArgs {
+    /// The configuration file for this project
+    #[clap(long)]
+    config: Utf8PathBuf,
+
+    /// A path to staticlib file.
+    lib_file: Utf8PathBuf,
+}
+
+impl GenerateAllArgs {
+    pub(crate) fn new(lib_file: Utf8PathBuf, config: Utf8PathBuf) -> Self {
+        Self { lib_file, config }
+    }
+
+    pub(crate) fn run(&self) -> Result<()> {
+        let project = self.project_config()?;
+        let root = project.project_root();
+        let pwd = ubrn_common::pwd()?;
+        let lib_file = pwd.join(&self.lib_file);
+        let modules = {
+            let dir = project.crate_.directory()?;
+            ubrn_common::cd(&dir)?;
+            let ts_dir = project.bindings.ts_path(root);
+            let cpp_dir = project.bindings.cpp_path(root);
+            let config = project.bindings.uniffi_toml_path(root);
+            if let Some(ref file) = config {
+                if !file.exists() {
+                    anyhow::bail!("uniffi.toml file {:?} does not exist. Either delete the uniffiToml property or supply a file", file)
+                }
+            }
+            let bindings = BindingsArgs::new(
+                SourceArgs::library(&lib_file).with_config(config),
+                OutputArgs::new(&ts_dir, &cpp_dir, false),
+            );
+
+            bindings.run()?
+        };
+        ubrn_common::cd(&pwd)?;
+        let rust_crate = project.crate_.metadata()?;
+        crate::codegen::render_files(project, rust_crate, modules)?;
+        Ok(())
+    }
+
+    fn project_config(&self) -> Result<ProjectConfig> {
+        self.config.clone().try_into()
     }
 }

--- a/crates/ubrn_cli/src/ios.rs
+++ b/crates/ubrn_cli/src/ios.rs
@@ -236,4 +236,8 @@ impl IOsArgs {
     pub(crate) fn project_config(&self) -> Result<ProjectConfig> {
         self.config.clone().try_into()
     }
+
+    pub(crate) fn config(&self) -> Utf8PathBuf {
+        self.config.clone()
+    }
 }

--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -28,12 +28,12 @@ impl CrateMetadata {
         }
     }
 
-    pub fn library_path(&self, target: Option<&str>, profile: &str) -> Result<Utf8PathBuf> {
+    pub fn library_path(&self, target: Option<&str>, profile: &str) -> Utf8PathBuf {
         let library_name = self.library_file(target);
-        Ok(match target {
+        match target {
             Some(t) => self.target_dir.join(t).join(profile).join(library_name),
             None => self.target_dir.join(profile).join(library_name),
-        })
+        }
     }
 
     pub fn library_path_exists(&self, path: &Utf8Path) -> Result<()> {

--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -36,6 +36,13 @@ impl CrateMetadata {
         })
     }
 
+    pub fn library_path_exists(&self, path: &Utf8Path) -> Result<()> {
+        if !path.exists() {
+            anyhow::bail!("Library doesn't exist. This may be because `staticlib` is not in the `crate-type` list in the [lib] entry of Cargo.toml: {}", self.manifest_path());
+        }
+        Ok(())
+    }
+
     pub fn library_file(&self, target: Option<&str>) -> String {
         let ext = so_extension(target);
         format!("lib{}.{ext}", &self.library_name)

--- a/xtask/src/run/mod.rs
+++ b/xtask/src/run/mod.rs
@@ -74,7 +74,7 @@ impl RunCmd {
                 Ok(Some(so_file))
             }
             (Some(crate_), None, Some(bindings)) => {
-                let crate_lib = crate_.library_path(None, release)?;
+                let crate_lib = crate_.library_path(None, release);
                 let target_dir = crate_.target_dir();
                 let lib_name = crate_.library_name();
                 let cpp_files = bindings.generate(&crate_lib)?;

--- a/xtask/src/run/rust_crate.rs
+++ b/xtask/src/run/rust_crate.rs
@@ -32,7 +32,7 @@ impl CrateArg {
     pub(crate) fn cargo_build(&self, clean: bool) -> Result<CrateMetadata> {
         let metadata = CrateMetadata::try_from(self.crate_dir.clone().expect("crate has no path"))?;
         let profile = CrateMetadata::profile(self.release);
-        let lib_path = metadata.library_path(None, profile)?;
+        let lib_path = metadata.library_path(None, profile);
         if lib_path.exists() && clean {
             metadata.cargo_clean()?;
         }


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This adds a number of suppression flags to the command line. This is to make it:

- easier to generate code using your own build process
- easier to customize parts of the build process
- cache as much as possible of the previous build

For `build ios`:

- `--no-xcodebuild` suppress the creation of an xcframework. The xcframework is expected, but with this flag, you are expected to provide it; perhaps after generating swift from a library file. (future work idea: add an arg to generate Swift from uniffi).
- `--no-cargo` detects if any targets are already built, and uses that to generate library files. If no targets are built, then build all, re-using the  library files next time.

For `build android`

- `--no-jniLibs`, this is Android reflection of `--no-xcodebuild`. I'm not sure what this would be used for.
- `--no-cargo` detects if any targets are already built, and uses that to generate library files. If no targets are built, then build all, re-using the  library files next time.

A new command: `generate all --config config.yaml lib.a`:

- This combines `generate bindings` and `generate turbo-module` into a higher level command which accepts a config file and a pre-built library file.