### PR TITLE
Add arraybuffer test-fixture

### DIFF
--- a/fixtures/coverall2/Cargo.toml
+++ b/fixtures/coverall2/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "uniffi-coverall2"
+edition = "2021"
+version = "0.22.0"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+async-std = "1.12.0"
+thiserror = "1.0"
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/coverall2/src/lib.rs
+++ b/fixtures/coverall2/src/lib.rs
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+#[uniffi::export]
+/// This makes the byte array in rust, and the test in JS will compare it there.
+///
+/// This eliminates the possibility of two symmetrical bugs in each of the lift and
+/// lower for the roundtrip tests– this just uses the Rust lower, and the Typescript
+/// lift.
+pub fn well_known_array_buffer() -> Vec<u8> {
+    Default::default()
+}
+
+#[uniffi::export]
+/// This uses a byte array to pass an argument and return, so it uses lift/lower methods.
+pub fn identity_array_buffer(bytes: Vec<u8>) -> Vec<u8> {
+    bytes
+}
+
+#[uniffi::export]
+/// This uses an option to force the lift/lower machinery to use read and write
+/// directly from the Option lift and lower, not from the byte array lift and lower.
+pub fn identity_array_buffer_forced_read(bytes: Option<Vec<u8>>) -> Option<Vec<u8>> {
+    bytes
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/coverall2/tests/bindings/test_coverall2.ts
+++ b/fixtures/coverall2/tests/bindings/test_coverall2.ts
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import {
+  identityArrayBuffer,
+  identityArrayBufferForcedRead,
+  wellKnownArrayBuffer,
+} from "../../generated/uniffi_coverall2";
+import { test } from "@/asserts";
+import { console } from "@/hermes";
+
+test("well known array buffer returned", (t) => {
+  const wellKnown = wellKnownArrayBuffer();
+  t.assertEqual(0, wellKnown.byteLength);
+});
+
+test("array buffer equals", (t) => {
+  t.assertEqual(arrayBuffer(16).byteLength, 16);
+  t.assertEqual(arrayBuffer(16), arrayBuffer(16), undefined, abEquals);
+
+  const mutated = new Uint32Array(arrayBuffer(32), 0).reverse().buffer;
+  t.assertNotEqual(mutated, arrayBuffer(32), undefined, abEquals);
+});
+
+test("array buffer roundtrip using lift/lower", (t) => {
+  function rt(ab: ArrayBuffer) {
+    t.assertEqual(ab, identityArrayBuffer(ab), undefined, abEquals);
+  }
+  for (let i = 0; i < 64; i++) {
+    rt(arrayBuffer(i));
+  }
+});
+
+test("array buffer roundtrip using read/write", (t) => {
+  function rt(ab: ArrayBuffer) {
+    t.assertEqual(ab, identityArrayBufferForcedRead(ab)!, undefined, abEquals);
+  }
+  for (let i = 0; i < 64; i++) {
+    rt(arrayBuffer(i));
+  }
+});
+
+function abEquals(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+
+  const len = a.byteLength;
+  const aArray = new Uint8Array(a);
+  const bArray = new Uint8Array(b);
+
+  for (let i = 0; i < len; i++) {
+    if (aArray.at(i) !== bArray.at(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function arrayBuffer(numBytes: number): ArrayBuffer {
+  const array = Uint8Array.from({ length: numBytes }, (_v, i) => i);
+  return array.buffer;
+}

--- a/fixtures/coverall2/tests/test_generated_bindings.rs
+++ b/fixtures/coverall2/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -323,7 +323,7 @@ export class FfiConverterMap<K, V> extends AbstractFfiConverterArrayBuffer<
 
 export const FfiConverterArrayBuffer = (() => {
   const lengthConverter = FfiConverterInt32;
-  class FFIConverter extends FfiConverterPrimitive<ArrayBuffer> {
+  class FFIConverter extends AbstractFfiConverterArrayBuffer<ArrayBuffer> {
     read(from: RustBuffer): ArrayBuffer {
       const length = lengthConverter.read(from);
       return from.readBytes(length);


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR adds a test for roundtripping an `ArrayBuffer`s.

Coincidentally, it fixes a bug with roundtripping `ArrayBuffer`s.