### PR TITLE
Add fixture for timestamp and duration

### DIFF
--- a/fixtures/chronological/Cargo.toml
+++ b/fixtures/chronological/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-time"
+edition = "2021"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_chronological"
+
+[dependencies]
+uniffi = { workspace = true }
+thiserror = "1.0"
+chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std"] }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/chronological/README.md
+++ b/fixtures/chronological/README.md
@@ -1,0 +1,4 @@
+# Test for time types
+
+This directory contains tests for Timestamp and Duration types. It is intended
+to exercise these types and their edge cases.

--- a/fixtures/chronological/build.rs
+++ b/fixtures/chronological/build.rs
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+fn main() {
+    uniffi::generate_scaffolding("src/chronological.udl").unwrap();
+}

--- a/fixtures/chronological/src/chronological.udl
+++ b/fixtures/chronological/src/chronological.udl
@@ -1,0 +1,35 @@
+[Error]
+enum ChronologicalError {
+  "TimeOverflow",
+  "TimeDiffError",
+};
+
+namespace chronological {
+  [Throws=ChronologicalError]
+  timestamp return_timestamp(timestamp a);
+
+  [Throws=ChronologicalError]
+  duration return_duration(duration a);
+
+  string to_string_timestamp(timestamp a);
+
+  timestamp get_pre_epoch_timestamp();
+
+  [Throws=ChronologicalError]
+  timestamp add(timestamp a, duration b);
+
+  [Throws=ChronologicalError]
+  duration diff(timestamp a, timestamp b);
+
+  timestamp now();
+
+  boolean equal(timestamp a, timestamp b);
+
+  boolean optional(timestamp? a, duration? b);
+
+  [Throws=ChronologicalError]
+  u64 get_seconds_before_unix_epoch(timestamp a);
+
+  [Throws=ChronologicalError]
+  timestamp set_seconds_before_unix_epoch(u64 seconds);
+};

--- a/fixtures/chronological/src/lib.rs
+++ b/fixtures/chronological/src/lib.rs
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use std::time::{Duration, SystemTime};
+
+use chrono::offset::Utc;
+use chrono::DateTime;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChronologicalError {
+    #[error("Time overflow on an operation with {a:?} and {b:?}")]
+    TimeOverflow { a: SystemTime, b: Duration },
+    #[error("Time difference error {a:?} is before {b:?}")]
+    TimeDiffError { a: SystemTime, b: SystemTime },
+}
+
+fn return_timestamp(a: SystemTime) -> Result<SystemTime> {
+    Ok(a)
+}
+
+fn return_duration(a: Duration) -> Result<Duration> {
+    Ok(a)
+}
+
+fn to_string_timestamp(a: SystemTime) -> String {
+    let datetime: DateTime<Utc> = a.into();
+    datetime.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+}
+
+fn get_pre_epoch_timestamp() -> SystemTime {
+    std::time::SystemTime::UNIX_EPOCH
+        .checked_sub(std::time::Duration::new(1, 1_000_000))
+        .unwrap()
+}
+
+fn add(a: SystemTime, b: Duration) -> Result<SystemTime> {
+    a.checked_add(b)
+        .ok_or(ChronologicalError::TimeOverflow { a, b })
+}
+
+fn diff(a: SystemTime, b: SystemTime) -> Result<Duration> {
+    a.duration_since(b)
+        .map_err(|_| ChronologicalError::TimeDiffError { a, b })
+}
+
+fn now() -> SystemTime {
+    SystemTime::now()
+}
+
+fn equal(a: SystemTime, b: SystemTime) -> bool {
+    a == b
+}
+
+fn optional(a: Option<SystemTime>, b: Option<Duration>) -> bool {
+    a.is_some() && b.is_some()
+}
+
+fn get_seconds_before_unix_epoch(b: SystemTime) -> Result<u64> {
+    diff(SystemTime::UNIX_EPOCH, b).map(|duration| duration.as_secs())
+}
+
+fn set_seconds_before_unix_epoch(seconds: u64) -> Result<SystemTime> {
+    let a = SystemTime::UNIX_EPOCH;
+    let b = Duration::from_secs(seconds);
+
+    a.checked_sub(b)
+        .ok_or(ChronologicalError::TimeOverflow { a, b })
+}
+
+type Result<T, E = ChronologicalError> = std::result::Result<T, E>;
+
+uniffi::include_scaffolding!("chronological");

--- a/fixtures/chronological/tests/bindings/test_chronological.ts
+++ b/fixtures/chronological/tests/bindings/test_chronological.ts
@@ -1,0 +1,163 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import {
+  now as rustNow,
+  toStringTimestamp,
+  returnDuration,
+  returnTimestamp,
+  add,
+  diff,
+  ChronologicalError,
+  optional,
+} from "../../generated/chronological";
+import { asyncTest, test, Asserts, xtest } from "@/asserts";
+
+type Duration = number;
+
+const Duration = {
+  ofSeconds(sec: number): Duration {
+    return sec * 1000;
+  },
+  ofNanos(nanos: number): Duration {
+    return nanos / 1e6;
+  },
+  ofMs(ms: number): Duration {
+    return ms;
+  },
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
+const MAX_MS_FROM_EPOCH = 8.64e15;
+const Instant = {
+  ofEpochSecond(seconds: number): Date {
+    return new Date(seconds * 1000);
+  },
+
+  parse(string: string): Date {
+    return new Date(Date.parse(string));
+  },
+
+  now(): Date {
+    return new Date();
+  },
+
+  MAX: new Date(MAX_MS_FROM_EPOCH),
+};
+
+test("One way timestamp", (t) => {
+  {
+    const now = new Date(22, 1);
+    t.assertEqual(now.toISOString(), toStringTimestamp(now));
+  }
+
+  {
+    const now = new Date();
+    t.assertEqual(now.toISOString(), toStringTimestamp(now));
+  }
+});
+
+test("Roundtripping Timestamp", (t) => {
+  const now = new Date();
+  dateEquals(t, now, returnTimestamp(now));
+});
+
+test("Roundtripping Duration", (t) => {
+  function rt(duration: Duration) {
+    t.assertEqual(duration, returnDuration(duration));
+  }
+
+  rt(Duration.ofMs(1));
+  rt(Duration.ofMs(500));
+  rt(Duration.ofMs(1500) + Duration.ofSeconds(1));
+
+  rt(Duration.ofNanos(5e5));
+});
+
+function dateEquals(t: Asserts, a: Date, b: Date) {
+  t.assertEqual(a.getTime(), b.getTime(), `${a} !== ${b}`);
+}
+
+test("Rust vs Hermes timestamp", (t) => {
+  const now = new Date();
+  now.setMilliseconds(0);
+  const rustTime = rustNow();
+  rustTime.setMilliseconds(0);
+
+  dateEquals(t, now, rustTime);
+});
+
+test("Test passing timestamp and duration while returning timestamp", (t) => {
+  const start = Instant.ofEpochSecond(1000);
+  const duration = Duration.ofSeconds(2);
+  t.assertEqual(add(start, duration), Instant.ofEpochSecond(1000 + 2));
+});
+
+test("Test passing timestamp while returning duration", (t) => {
+  const start = Instant.ofEpochSecond(1000);
+  const end = Instant.ofEpochSecond(1002);
+  t.assertEqual(diff(end, start), Duration.ofSeconds(2));
+});
+
+test("Test pre-epoch timestamps", (t) => {
+  const start = Instant.parse("1955-11-05T00:06:00.283000001Z");
+  t.assertEqual(start, add(start, 0));
+
+  const duration = Duration.ofSeconds(1) + Duration.ofNanos(1);
+  const end = Instant.parse("1955-11-05T00:06:01.283000002Z");
+  t.assertEqual(end, add(start, duration));
+});
+
+test("Test exceptions are propagated", (t) => {
+  t.assertThrows(ChronologicalError.TimeDiffError.instanceOf, () => {
+    diff(Instant.ofEpochSecond(100), Instant.ofEpochSecond(101));
+  });
+});
+
+test("Test max Instant upper bound", (t) => {
+  t.assertEqual(add(Instant.MAX, Duration.ofSeconds(0)), Instant.MAX);
+});
+
+test("Test max Instant upper bound overflow", (t) => {
+  // NB: Javascript Dates have a smaller overflow than Rust,
+  // so this error is internal to uniffi.
+  t.assertThrows(
+    (e: Error) => e.message.indexOf("Date overflow") >= 0,
+    () => {
+      add(Instant.MAX, Duration.ofSeconds(1));
+    },
+  );
+});
+
+function delayPromise(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+asyncTest(
+  "Test that rust timestamps behave like JS timestamps",
+  async (t): Promise<void> => {
+    // Unfortunately the JS clock may be lower resolution than the Rust clock.
+    // Sleep for 1ms between each call, which should ensure the JVM clock ticks
+    // forward.
+
+    const tsBefore = Instant.now();
+    await delayPromise(10);
+    const rsNow = rustNow();
+    await delayPromise(10);
+
+    const tsAfter = Instant.now();
+    t.assertTrue(tsBefore < rsNow);
+    t.assertTrue(tsAfter > rsNow);
+    t.end();
+  },
+);
+
+test("Test optional values work", (t) => {
+  t.assertTrue(optional(Instant.MAX, Duration.ofSeconds(0)));
+  t.assertFalse(optional(undefined, Duration.ofSeconds(0)));
+  t.assertFalse(optional(Instant.MAX, undefined));
+});

--- a/fixtures/chronological/tests/test_generated_bindings.rs
+++ b/fixtures/chronological/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -105,6 +105,11 @@ export const UniffiInternalError = (() => {
       super("Cannot convert a large BigInt into a number");
     }
   }
+  class DateTimeOverflow extends Error {
+    constructor() {
+      super("Date overflowed passed maximum number of ms passed the epoch");
+    }
+  }
   class BufferOverflow extends Error {
     constructor() {
       super(
@@ -169,6 +174,7 @@ export const UniffiInternalError = (() => {
   return {
     ApiChecksumMismatch,
     NumberOverflow,
+    DateTimeOverflow,
     BufferOverflow,
     ContractVersionMismatch,
     IncompleteData,


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR tests roundtripping and overflows of the `timestamp` and `duration` uniffi types.

These were added to uniffi-rs shortly before custom types were implemented, and arguably should be implemented as custom types.

| udl | Rust | Javascript | Comments |
| - | - | - | - |
| `timestamp` | `std::time::SystemTime` | `Date` | JS only supports dates up to [8.64e15 ms either side of the epoch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date). Uniffi will throw an error if the date is outside of these times  |
| `duration` | `chrono::Duration` | `number` |

Javascript represents numbers as 64 bit floating point numbers. The FFI protocol represents timestamps as `BigInt(seconds)` + `Number(nanoseconds)`. This  conversion will lead to inaccuracies at large numbers or high precision numbers.