### PR TITLE
Add type to importing of Object interfaces

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/mod.rs
@@ -204,11 +204,11 @@ impl<'a> TypeRenderer<'a> {
                 let type_ = self.as_type(external);
                 let name = type_name(&type_, self).expect("External types should have type names");
                 match &type_ {
+                    Type::Enum { .. } => self.import_ext(&name, &namespace),
                     Type::CallbackInterface { .. }
-                    | Type::Object { .. }
                     | Type::Custom { .. }
-                    | Type::Enum { .. } => self.import_ext(&name, &namespace),
-                    Type::Record { .. } => self.import_ext_type(&name, &namespace),
+                    | Type::Object { .. }
+                    | Type::Record { .. } => self.import_ext_type(&name, &namespace),
                     _ => unreachable!(),
                 };
                 let ffi_converter_name = ffi_converter_name(&type_, self)

--- a/typescript/tests/exported.ts
+++ b/typescript/tests/exported.ts
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+export type MyCustomString = string;
+
+export const MyEnum = (() => {
+  return {
+    Variant1: class {},
+    Variant2: class {},
+    instanceOf: (obj: any): boolean => true,
+  };
+})();
+export type MyEnum = InstanceType<
+  (typeof MyEnum)[keyof Omit<typeof MyEnum, "instanceOf">]
+>;
+
+export type MyRecord = {
+  prop1: string;
+  prop2: number;
+};
+
+export interface MyCallbackInterface {
+  myMethod(): void;
+}
+
+export interface MyObjectInterface {
+  myForeignMethod(): void;
+}
+export class MyObject implements MyObjectInterface {
+  myForeignMethod(): void {}
+}

--- a/typescript/tests/importing.test.ts
+++ b/typescript/tests/importing.test.ts
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+import {
+  type MyCallbackInterface,
+  type MyCustomString,
+  MyEnum,
+  MyObject,
+  type MyObjectInterface,
+  type MyRecord,
+} from "./exported";
+
+import { test } from "../testing/asserts";
+
+test("Records imported as type", (t) => {
+  const record: MyRecord = {
+    prop1: "string",
+    prop2: 42,
+  };
+});
+
+test("Enums imported as objects", (t) => {
+  const enum_: MyEnum = new MyEnum.Variant1();
+});
+
+test("Objects interfaces imported as types", (t) => {
+  // In our generated code, `MyObject` would not be imported into this
+  // file because all creation happens via the `FfiConverterTypeMyObject`.
+  const obj: MyObjectInterface = new MyObject();
+});
+
+test("Callback interfaces imported as types", (t) => {
+  class Impl implements MyCallbackInterface {
+    myMethod(): void {}
+  }
+
+  const cb = new Impl();
+});
+
+test("Custom types imported as types", (t) => {
+  const s: MyCustomString = "string";
+});


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Fixes #81.

This PR adds `type` to the imports of types between crates, and reviews what uniffi types should be imported as consts and which as types.

Before: 

```typescript
import { 
  MyObjectInterface, 
  MyCallbackInterface, 
  MyEnum, 
  type MyRecord 
} from "./other-crate"
```

Now:

```typescript
import { 
  type MyObjectInterface, 
  type MyCallbackInterface, 
  MyEnum, 
  type MyRecord 
} from "./other-crate"
```

It also adds a playground test in the `testing` directory.