### PR TITLE
Fixup C++ compile time warnings

### DIFF
--- a/cpp/hermes-rust-extension/CMakeLists.txt
+++ b/cpp/hermes-rust-extension/CMakeLists.txt
@@ -56,5 +56,8 @@ link_directories("${HERMES_BUILD_DIR}/jsi")
 link_libraries(jsi)
 link_directories("${RUST_TARGET_DIR}")
 
+# Set C++ compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -frtti -fexceptions -Wall -fstack-protector-all -Werror")
+
 add_library(${HERMES_EXTENSION_NAME} SHARED ${HERMES_EXTENSION_CPP})
 target_link_libraries(${HERMES_EXTENSION_NAME} ${RUST_LIB_NAME})

--- a/cpp/includes/ForeignBytes.h
+++ b/cpp/includes/ForeignBytes.h
@@ -20,11 +20,10 @@ template <> struct Bridging<ForeignBytes> {
   static ForeignBytes fromJs(jsi::Runtime &rt, const jsi::Value &value) {
     try {
       auto buffer = value.asObject(rt).getArrayBuffer(rt);
-      auto bytes = ForeignBytes{
+      return ForeignBytes{
           .len = static_cast<int32_t>(buffer.length(rt)),
           .data = buffer.data(rt),
       };
-      return std::move(bytes);
     } catch (const std::logic_error &e) {
       throw jsi::JSError(rt, e.what());
     }

--- a/cpp/includes/RustArcPtr.h
+++ b/cpp/includes/RustArcPtr.h
@@ -51,16 +51,14 @@ template <> struct Bridging<void *> {
 /// unlikely to get better.
 class DestructibleObject : public jsi::HostObject {
 private:
-  jsi::Runtime &rt;
   std::mutex destructorMutex;
   bool isDestroyed = false;
   uint64_t pointer;
   std::function<void(uint64_t)> destructor;
 
 public:
-  DestructibleObject(jsi::Runtime &rt, uint64_t pointer,
-                     std::function<void(uint64_t)> destructor)
-      : jsi::HostObject(), rt(rt), pointer(pointer), destructor(destructor) {}
+  DestructibleObject(uint64_t pointer, std::function<void(uint64_t)> destructor)
+      : jsi::HostObject(), pointer(pointer), destructor(destructor) {}
 
   ~DestructibleObject() {
     /// You can use uniffiDestroy() from JS instead of relying on GC.

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/CallbackFunction.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/CallbackFunction.cpp
@@ -145,7 +145,8 @@ namespace {{ ns }} {
     }
 
     static {{ name }}
-    makeCallbackFunction(jsi::Runtime &rt,
+    makeCallbackFunction( // {{ ns }}
+                    jsi::Runtime &rt,
                      std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
                      const jsi::Value &value) {
         auto callbackFunction = value.asObject(rt).asFunction(rt);

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/ObjectHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/ObjectHelper.cpp
@@ -11,7 +11,7 @@
         RustCallStatus status = {0};
         {{ free.name() }}(pointer, &status);
     };
-    auto ptrObj = std::make_shared<{{ ci.cpp_namespace_includes() }}::DestructibleObject>(rt, pointer, destructor);
+    auto ptrObj = std::make_shared<{{ ci.cpp_namespace_includes() }}::DestructibleObject>(pointer, destructor);
     auto obj = jsi::Object::createFromHostObject(rt, ptrObj);
     return jsi::Value(rt, obj);
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/RustBufferHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/RustBufferHelper.cpp
@@ -25,7 +25,7 @@ template <> struct Bridging<RustBuffer> {
       // Once it leaves this function, the buffer is immediately passed back
       // into Rust, where it's used to deserialize into the Rust versions of the
       // arguments. At that point, the copy is destroyed.
-      return std::move(buf);
+      return buf;
     } catch (const std::logic_error &e) {
       throw jsi::JSError(rt, e.what());
     }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/entrypoint.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/entrypoint.cpp
@@ -11,7 +11,7 @@
 #include "registerNatives.h"
 
 {%- for m in modules %}
-#include "{{ m.hpp_filename() }}";
+#include "{{ m.hpp_filename() }}"
 {%- endfor %}
 
 extern "C" void registerNatives(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> callInvoker) {

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/macros.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/macros.cpp
@@ -119,7 +119,7 @@ jsi::Value {{ module_name }}::{% call cpp_func_name(func) %}(jsi::Runtime& rt, c
 // It should match the value rendered by the callback_fn_namespace macro.
 #}
 {%- macro callback_fn_free_impl(callback) %}
-{%- for st in self.ci.iter_ffi_structs() %}
+{%- for st in self.ci.iter_ffi_structs_for_free() %}
 {%- let ns = st.cpp_namespace_free(ci) %}
 {%- include "CallbackFunction.cpp" %}
 {%- endfor %}
@@ -139,7 +139,7 @@ jsi::Value {{ module_name }}::{% call cpp_func_name(func) %}(jsi::Runtime& rt, c
 // It should match the value rendered by the callback_fn_namespace macro.
 #}
 {%- macro callback_fn_free_cleanup(callback) %}
-{%- for st in self.ci.iter_ffi_structs() %}
+{%- for st in self.ci.iter_ffi_structs_for_free() %}
 {%- let ns = st.cpp_namespace_free(ci) %}
 {{- ns }}::cleanup();
 {%- endfor %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -92,7 +92,7 @@ jsi::Value {{ module_name }}::get(jsi::Runtime& rt, const jsi::PropNameID& name)
     try {
         return jsi::Value(rt, props.at(name.utf8(rt)));
     }
-    catch (std::out_of_range e) {
+    catch (std::out_of_range &e) {
         return jsi::Value::undefined();
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -63,7 +63,7 @@ extern "C" {
 {{ module_name }}::{{ module_name }}(
     jsi::Runtime &rt,
     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> invoker
-) : props(), callInvoker(invoker) {
+) : callInvoker(invoker), props() {
     // Map from Javascript names to the cpp names
     {%- for func in ci.iter_ffi_functions_js_to_cpp() %}
     {%- let name = func.name() %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_cpp/templates/wrapper.cpp
@@ -41,8 +41,7 @@ extern "C" {
 {%-       if callback.is_rust_calling_js() %}
 {%-         if callback.is_free_callback() %}
     // Implementation of free callback function {{ callback.name() }}
-{%-           call cpp::callback_fn_impl(callback) %}
-{%-           call cpp::callback_fn_free_impl(callback) %}
+{%            call cpp::callback_fn_free_impl(callback) %}
 {%-         else %}
     // Implementation of callback function calling from Rust to JS {{ callback.name() }}
 {%-           call cpp::callback_fn_impl(callback) %}
@@ -117,7 +116,6 @@ void {{ module_name }}::set(jsi::Runtime& rt, const jsi::PropNameID& name, const
 {%-       if callback.is_rust_calling_js() %}
 {%-         if callback.is_free_callback() %}
     // Cleanup for "free" callback function {{ callback.name() }}
-{%            call cpp::callback_fn_cleanup(callback) %}
 {%            call cpp::callback_fn_free_cleanup(callback) %}
 {%-         else %}
     // Cleanup for callback function {{ callback.name() }}

--- a/crates/ubrn_bindgen/src/bindings/react_native/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/mod.rs
@@ -237,6 +237,11 @@ impl ComponentInterface {
         })
     }
 
+    fn iter_ffi_structs_for_free(&self) -> impl Iterator<Item = FfiStruct> {
+        self.iter_ffi_structs()
+            .filter(|s| !s.is_future() || s.name() == "ForeignFuture")
+    }
+
     fn iter_ffi_definitions_exported_by_ts(&self) -> impl Iterator<Item = FfiDefinition> {
         self.ffi_definitions().filter(|d| d.is_exported())
     }
@@ -520,7 +525,11 @@ impl FfiStruct {
     }
 
     fn is_exported(&self) -> bool {
-        self.is_vtable() || self.name() == "ForeignFuture"
+        self.is_vtable() || self.is_future()
+    }
+
+    fn is_future(&self) -> bool {
+        self.name().starts_with("ForeignFuture")
     }
 
     fn is_vtable(&self) -> bool {

--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -39,6 +39,14 @@ add_library(
     cpp-adapter.cpp
 )
 
+# Set C++ compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+
 {%- let dir = self.config.project.android.jni_libs(root) %}
 {%- let jni_libs_dir = self.relative_to(root, dir) %}
 

--- a/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.java
+++ b/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.java
@@ -28,18 +28,11 @@ public class {{ module_class_name }} extends {{ self.config.project.tm.spec_name
     System.loadLibrary("{{ self.config.project.cpp_filename() }}");
   }
 
-  // TODO Remove `multiply` after seeing this work on iOS and Android.
-  private static native double nativeMultiply(double a, double b);
   private static native boolean nativeInstallRustCrate(long rtPtr, CallInvokerHolder callInvoker);
-  private static native boolean nativeCleanupRustCrate(long rtPtr, boolean a);
+  private static native boolean nativeCleanupRustCrate(long rtPtr);
 
   @Override
-  public double multiply(double a, double b) {
-    return nativeMultiply(a, b);
-  }
-
-  @Override
-  public boolean installRustCrate(boolean rt) {
+  public boolean installRustCrate() {
     ReactApplicationContext context = getReactApplicationContext();
     return nativeInstallRustCrate(
       context.getJavaScriptContextHolder().get(),
@@ -48,10 +41,9 @@ public class {{ module_class_name }} extends {{ self.config.project.tm.spec_name
   }
 
   @Override
-  public boolean cleanupRustCrate(boolean rt) {
+  public boolean cleanupRustCrate() {
     return nativeCleanupRustCrate(
-      this.getReactApplicationContext().getJavaScriptContextHolder().get(),
-      rt
+      this.getReactApplicationContext().getJavaScriptContextHolder().get()
     );
   }
 }

--- a/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.mm
+++ b/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.mm
@@ -17,10 +17,6 @@ namespace {{ uniffi_ns }} {
         std::shared_ptr<CallInvoker> callInvoker;
     };
 
-    // TODO Remove `multiply` after seeing this work on iOS and Android.
-    static facebook::jsi::Value {{ fn_prefix }}_multiply(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, NumberKind, "multiply", @selector(multiply:b:), args, count);
-    }
     static facebook::jsi::Value {{ fn_prefix }}_installRustCrate(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
         auto& tm = static_cast<{{ spec_jsi }}&>(turboModule);
         auto jsInvoker = tm.callInvoker;
@@ -28,15 +24,12 @@ namespace {{ uniffi_ns }} {
         return facebook::jsi::Value(rt, result);
     }
     static facebook::jsi::Value {{ fn_prefix }}_cleanupRustCrate(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-        uint8_t a = 0;
-        uint8_t result = {{ ns }}::cleanupRustCrate(rt, a);
+        uint8_t result = {{ ns }}::cleanupRustCrate(rt);
         return facebook::jsi::Value(rt, result);
     }
 
     {{ spec_jsi }}::{{ spec_jsi }}(const ObjCTurboModule::InitParams &params)
         : ObjCTurboModule(params), callInvoker(params.jsInvoker) {
-            // TODO Remove `multiply` after seeing this work on iOS and Android.
-            this->methodMap_["multiply"] = MethodMetadata {2, {{ fn_prefix }}_multiply};
             this->methodMap_["installRustCrate"] = MethodMetadata {1, {{ fn_prefix }}_installRustCrate};
             this->methodMap_["cleanupRustCrate"] = MethodMetadata {1, {{ fn_prefix }}_cleanupRustCrate};
     }
@@ -47,20 +40,13 @@ RCT_EXPORT_MODULE()
 
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
-// TODO Remove `multiply` after seeing this work on iOS and Android.
-- (NSNumber *)multiply:(double)a b:(double)b {
-    NSNumber *result = @({{ ns }}::multiply(a, b));
-
-    return result;
-}
-
-- (NSNumber *)installRustCrate:(bool)a {
+- (NSNumber *)installRustCrate {
     @throw [NSException exceptionWithName:@"UnreachableException"
                         reason:@"This method should never be called."
                         userInfo:nil];
 }
 
-- (NSNumber *)cleanupRustCrate:(bool)a {
+- (NSNumber *)cleanupRustCrate {
     @throw [NSException exceptionWithName:@"UnreachableException"
                         reason:@"This method should never be called."
                         userInfo:nil];

--- a/crates/ubrn_cli/src/codegen/templates/NativeCodegenTemplate.ts
+++ b/crates/ubrn_cli/src/codegen/templates/NativeCodegenTemplate.ts
@@ -3,10 +3,8 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
-  // TODO Remove `multiply` after seeing this work on iOS and Android.
-  multiply(a: number, b: number): number;
-  installRustCrate(runtime: boolean): boolean;
-  cleanupRustCrate(runtime: boolean): boolean;
+  installRustCrate(): boolean;
+  cleanupRustCrate(): boolean;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('{{ self.config.project.name_upper_camel() }}');

--- a/crates/ubrn_cli/src/codegen/templates/TurboModuleTemplate.cpp
+++ b/crates/ubrn_cli/src/codegen/templates/TurboModuleTemplate.cpp
@@ -10,11 +10,6 @@
 namespace {{ self.config.project.cpp_namespace() }} {
 	using namespace facebook;
 
-	// TODO Remove `multiply` after seeing this work on iOS and Android.
-	double multiply(double a, double b) {
-		return a * b;
-	}
-
 	uint8_t installRustCrate(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker) {
         {%- for m in self.config.modules %}
 		{{ m.cpp_module() }}::registerModule(runtime, callInvoker);
@@ -22,7 +17,7 @@ namespace {{ self.config.project.cpp_namespace() }} {
 		return false;
 	}
 
-	uint8_t cleanupRustCrate(jsi::Runtime &runtime, uint8_t b) {
+	uint8_t cleanupRustCrate(jsi::Runtime &runtime) {
 		return false;
 	}
 }

--- a/crates/ubrn_cli/src/codegen/templates/TurboModuleTemplate.h
+++ b/crates/ubrn_cli/src/codegen/templates/TurboModuleTemplate.h
@@ -10,11 +10,8 @@
 namespace {{ ns }} {
   using namespace facebook;
 
-  // TODO Remove `multiply` after seeing this work on iOS and Android.
-  double multiply(double a, double b);
-
   uint8_t installRustCrate(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker);
-  uint8_t cleanupRustCrate(jsi::Runtime &runtime, uint8_t b);
+  uint8_t cleanupRustCrate(jsi::Runtime &runtime);
 }
 
 #endif /* {{ marker }} */

--- a/crates/ubrn_cli/src/codegen/templates/build.gradle
+++ b/crates/ubrn_cli/src/codegen/templates/build.gradle
@@ -64,7 +64,6 @@ android {
     }
     externalNativeBuild {
       cmake {
-        cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
         arguments '-DANDROID_STL=c++_shared'
       }
     }

--- a/crates/ubrn_cli/src/codegen/templates/cpp-adapter.cpp
+++ b/crates/ubrn_cli/src/codegen/templates/cpp-adapter.cpp
@@ -12,13 +12,6 @@
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
-// TODO Remove `multiply` after seeing this work on iOS and Android.
-extern "C"
-JNIEXPORT jdouble JNICALL
-{{ prefix }}_nativeMultiply(JNIEnv *env, jclass type, jdouble a, jdouble b) {
-    return {{ ns }}::multiply(a, b);
-}
-
 // Installer coming from {{ module_class_name }}
 extern "C"
 JNIEXPORT jboolean JNICALL
@@ -61,7 +54,7 @@ JNIEXPORT jboolean JNICALL
 
 extern "C"
 JNIEXPORT jboolean JNICALL
-{{ prefix }}_nativeCleanupRustCrate(JNIEnv *env, jclass type, jlong rtPtr, jboolean a) {
+{{ prefix }}_nativeCleanupRustCrate(JNIEnv *env, jclass type, jlong rtPtr) {
     auto runtime = reinterpret_cast<jsi::Runtime *>(rtPtr);
-    return {{ ns }}::cleanupRustCrate(*runtime, a);
+    return {{ ns }}::cleanupRustCrate(*runtime);
 }

--- a/crates/ubrn_cli/src/codegen/templates/index.ts
+++ b/crates/ubrn_cli/src/codegen/templates/index.ts
@@ -2,12 +2,7 @@
 import installer from './{{ self.config.project.codegen_filename() }}';
 
 // Register the rust crate with Hermes
-installer.installRustCrate(true);
-
-// TODO Remove `multiply` after seeing this work on iOS and Android.
-export function multiply(a: number, b: number): number {
-  return installer.multiply(a, b);
-}
+installer.installRustCrate();
 
 // Export the generated bindings to the app.
 {%- let root = self.project_root() %}

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -105,6 +105,9 @@ impl Default for RustGetters {
 #[allow(clippy::wrong_self_convention)]
 trait StoredForeignStringifier: Send + Sync + std::fmt::Debug {
     fn from_simple_type(&self, value: i32) -> String;
+    // We are not expecting to run this, but we would like to see the resulting
+    // bindings compile.
+    #[allow(dead_code)]
     fn from_complex_type(&self, values: Option<Vec<Option<f64>>>) -> String;
 }
 

--- a/fixtures/custom-types-example/src/lib.rs
+++ b/fixtures/custom-types-example/src/lib.rs
@@ -130,7 +130,7 @@ pub fn identity_enum_wrapper(v: EnumWrapper) -> EnumWrapper {
 }
 
 #[uniffi::export]
-pub fn unwap_enum_wrapper(v: EnumWrapper) -> MyEnum {
+pub fn unwrap_enum_wrapper(v: EnumWrapper) -> MyEnum {
     v.0
 }
 

--- a/fixtures/custom-types-example/tests/bindings/test_custom_types_example.ts
+++ b/fixtures/custom-types-example/tests/bindings/test_custom_types_example.ts
@@ -9,7 +9,7 @@ import {
   Handle,
   identityEnumWrapper,
   MyEnum_Tags,
-  unwapEnumWrapper,
+  unwrapEnumWrapper,
 } from "../../generated/custom_types";
 import { URL } from "@/hermes";
 import { secondsToDate } from "@/converters";
@@ -60,7 +60,7 @@ test("Rust EnumWrapper structs --> via MyEnum --> string", (t) => {
   const strings = ["A", "dAtA", "Alice", "Bob", "Charlie"];
   for (const s of strings) {
     t.assertEqual(s, identityEnumWrapper(s));
-    const enumValue = unwapEnumWrapper(s);
+    const enumValue = unwrapEnumWrapper(s);
     switch (enumValue.tag) {
       case MyEnum_Tags.A: {
         const value = enumValue.inner[0];


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_m * n_) change.

This has a multiple small cleanup changes, predominantly touching C++ compilation.

Fixes the compile time warnings for C++:

- remove a couple of redundant `std::move` when returning.
- remove a redundant `jsi::Runtime` property for `DestribleObject`.
- re-order property initialization in the `NativeModule`.
- remove a stray `;` at the end of `#include` statements in the `Entrypoint.h`
- removed spurious `free::makeCallbackFunction` method declarations. Fixes #65 
- moved compiler flags from `build.gradle` to `CMakeLists.txt`, and added `-Werror`.

Additionally:

- Corrected a typo in `unwap_enum_wrapper` imported from uniffi.
- Removed now redundant `multiply` function in installer introduced by builder-bob.