### PR TITLE
Detect if ArrayBuffer is really a typed array

### DIFF
--- a/fixtures/coverall2/tests/bindings/test_coverall2.ts
+++ b/fixtures/coverall2/tests/bindings/test_coverall2.ts
@@ -42,6 +42,52 @@ test("array buffer roundtrip using read/write", (t) => {
   }
 });
 
+test("array buffer roundtrip with ArrayBufferView", (t) => {
+  function rt(ab: ArrayBuffer) {
+    t.assertEqual(
+      ab,
+      identityArrayBuffer(new Uint32Array(ab)),
+      undefined,
+      abEquals,
+    );
+  }
+  for (let i = 0; i < 64; i += 4) {
+    rt(arrayBuffer(i));
+  }
+});
+
+test("array buffer roundtrip with ArrayBufferView of different sizes", (t) => {
+  function rt(ta: ArrayBuffer, slice: ArrayBuffer) {
+    t.assertEqual(slice, identityArrayBuffer(ta), undefined, abEquals);
+  }
+  const base = arrayBuffer(64);
+  for (const TypedArray of [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    BigUint64Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    BigInt64Array,
+    Float32Array,
+    Float64Array,
+  ]) {
+    const width = TypedArray.BYTES_PER_ELEMENT;
+    for (let length = width; length < base.byteLength; length += width) {
+      for (
+        let offset = 0;
+        offset + length < base.byteLength;
+        offset += length
+      ) {
+        const typedArray = new TypedArray(base, offset, length / width);
+        const slice = base.slice(offset, offset + length);
+        rt(typedArray, slice);
+      }
+    }
+  }
+});
+
 function abEquals(a: ArrayBuffer, b: ArrayBuffer): boolean {
   if (a.byteLength !== b.byteLength) {
     return false;

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -328,6 +328,21 @@ export class FfiConverterMap<K, V> extends AbstractFfiConverterArrayBuffer<
 }
 
 export const FfiConverterArrayBuffer = (() => {
+  function unwrapBuffer(value: ArrayBuffer): ArrayBuffer {
+    // Typed arrays are accepted by TS as array buffers,
+    // even though they are really ArrayBufferViews.
+    if (ArrayBuffer.isView(value)) {
+      const ab = value.buffer;
+      const start = value.byteOffset;
+      const length = value.byteLength;
+      if (start === 0 && ab.byteLength === length) {
+        return ab;
+      }
+      const end = start + length;
+      return ab.slice(start, end);
+    }
+    return value;
+  }
   const lengthConverter = FfiConverterInt32;
   class FFIConverter extends AbstractFfiConverterArrayBuffer<ArrayBuffer> {
     read(from: RustBuffer): ArrayBuffer {
@@ -337,7 +352,7 @@ export const FfiConverterArrayBuffer = (() => {
     write(value: ArrayBuffer, into: RustBuffer): void {
       const length = value.byteLength;
       lengthConverter.write(length, into);
-      into.writeBytes(value);
+      into.writeBytes(unwrapBuffer(value));
     }
     allocationSize(value: ArrayBuffer): number {
       return lengthConverter.allocationSize(0) + value.byteLength;


### PR DESCRIPTION
Fixes #91.

Typescript accepts a typed array (`Uint32Array`, and friends) where it expects an `ArrayBuffer`.

This could mean passing an `Uint32Array` slice where a `Vec<u8>` is expected.

This commit ensures the `FfiConverterArrayBuffer` handles this correctly: it now sends the slice of the underlying buffer that the typed array represents.

Unfortunately, it is not possible to detect pathological cases:

```ts
const ab = new ArrayBuffer(256);
const ta8 = new Uint8Array(ab, 0, 64); // view of `ab`.
const ta32 = new Uint32Array(ta8, 0, 16); // nested view of view of `ab`.
````

I would like the `ffi-converter` to detect this case, but it can't.

This is because the constructor of `Uint32Array` treats the value of `ta8` as an `ArrayLike` iterable, rather than an `ArrayBufferView` or `ArrayBuffer`.

This should likely be documented.