### PR TITLE
Mark fields as non private

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -9,7 +9,15 @@ export const {{ decl_type_name }} = (() => {
     {%-   call ts::docstring(variant, 4) %}
     {%-   let variant_name = variant.name()|class_name(ci) %}
     class {{ variant_name }} extends UniffiError {
+        /**
+         * @private
+         * This field is private and should not be used.
+         */
         readonly __uniffiTypeName = "{{ type_name }}";
+        /**
+         * @private
+         * This field is private and should not be used.
+         */
         readonly __variant = {{ loop.index }};
         constructor(message: string) {
             super("{{ type_name }}", "{{ variant_name }}", message);

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/ErrorTemplate.ts
@@ -9,8 +9,8 @@ export const {{ decl_type_name }} = (() => {
     {%-   call ts::docstring(variant, 4) %}
     {%-   let variant_name = variant.name()|class_name(ci) %}
     class {{ variant_name }} extends UniffiError {
-        private readonly __uniffiTypeName = "{{ type_name }}";
-        private readonly __variant = {{ loop.index }};
+        readonly __uniffiTypeName = "{{ type_name }}";
+        readonly __variant = {{ loop.index }};
         constructor(message: string) {
             super("{{ type_name }}", "{{ variant_name }}", message);
         }

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -56,6 +56,10 @@ export const {{ decl_type_name }} = (() => {
 
     {% call ts::docstring(variant, 4) %}
     class {{ variant_name }} extends {{ superclass }} implements {{ variant_interface }} {
+        /**
+         * @private
+         * This field is private and should not be used, use `tag` instead.
+         */
         readonly __uniffiTypeName = "{{ type_name }}";
         readonly tag = {{ variant_tag }};
         {%- if has_fields %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -56,7 +56,7 @@ export const {{ decl_type_name }} = (() => {
 
     {% call ts::docstring(variant, 4) %}
     class {{ variant_name }} extends {{ superclass }} implements {{ variant_interface }} {
-        private readonly __uniffiTypeName = "{{ type_name }}";
+        readonly __uniffiTypeName = "{{ type_name }}";
         readonly tag = {{ variant_tag }};
         {%- if has_fields %}
         readonly inner: {% call variant_data_type(variant) %};

--- a/typescript/tests/playground/enums.ts
+++ b/typescript/tests/playground/enums.ts
@@ -12,7 +12,7 @@ export const MyEnum = (() => {
     inner: Readonly<{ myValue: string }>;
   };
   class Variant1_ extends UniffiEnum implements Variant1__interface {
-    private readonly __uniffiTypeName = typeName;
+    readonly __uniffiTypeName = typeName;
     readonly tag = "Variant1";
     readonly inner: Readonly<{ myValue: string }>;
     constructor(inner: { myValue: string }) {
@@ -29,7 +29,7 @@ export const MyEnum = (() => {
     inner: Readonly<[number, string]>;
   };
   class Variant2_ extends UniffiEnum implements Variant2__interface {
-    private readonly __uniffiTypeName = typeName;
+    readonly __uniffiTypeName = typeName;
     readonly tag = "Variant2";
     readonly inner: Readonly<[number, string]>;
     constructor(p1: number, p2: string) {


### PR DESCRIPTION
So my previous fix did not work, my verification technique must have been flawed.  The private designation was still breaking us.

Unfortunately, it seems like Typescript does not have a way to restrict access to the fields while still letting them be accessed.  We can either tell people to ignore the errors, or just leave them exposed.  I think leaving them exposed is probably better.

