### PR TITLE
Changed __ prefixed private fields to symbols

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -1,3 +1,4 @@
+{{- self.import_infra("uniffiTypeNameSymbol", "symbols") -}}
 
 // Enum: {{ type_name }}
 {%- let type_name__Tags = format!("{type_name}_Tags") %}
@@ -56,7 +57,11 @@ export const {{ decl_type_name }} = (() => {
 
     {% call ts::docstring(variant, 4) %}
     class {{ variant_name }} extends {{ superclass }} implements {{ variant_interface }} {
-        private readonly __uniffiTypeName = "{{ type_name }}";
+        /**
+         * @private
+         * This field is private and should not be used, use `tag` instead.
+         */
+        readonly [uniffiTypeNameSymbol] = "{{ type_name }}";
         readonly tag = {{ variant_tag }};
         {%- if has_fields %}
         readonly inner: {% call variant_data_type(variant) %};
@@ -113,7 +118,7 @@ export const {{ decl_type_name }} = (() => {
   {%- endfor %}
 
     function instanceOf(obj: any): obj is {{ type_name }} {
-        return obj.__uniffiTypeName === "{{ type_name }}";
+        return obj[uniffiTypeNameSymbol] === "{{ type_name }}";
     }
 
     return Object.freeze({

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -1,5 +1,3 @@
-import { decl_type_name } from "./EnumTemplate"
-
 {#
     // Template to defining types. This may endup using codegen,
     // but may not.
@@ -95,8 +93,8 @@ import { decl_type_name } from "./EnumTemplate"
         super();
         const pointer =
             {% call to_ffi_method_call(obj_factory, callable) %};
-        this.__rustPointer = pointer;
-        this.__rustArcPtr = {{ obj_factory }}.bless(pointer);
+        this[pointerLiteralSymbol] = pointer;
+        this[destructorGuardSymbol] = {{ obj_factory }}.bless(pointer);
     }
 {%- endmacro %}
 

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+import { uniffiTypeNameSymbol } from "./symbols";
+
 // The top level error class for all uniffi-wrapped errors.
 //
 // The readonly fields are used to implement both the instanceOf checks which are used
@@ -17,7 +19,7 @@ export class UniffiError extends Error {
   }
 
   static instanceOf(obj: any): obj is UniffiError {
-    return obj.__uniffiTypeName !== undefined && obj instanceof Error;
+    return obj[uniffiTypeNameSymbol] !== undefined && obj instanceof Error;
   }
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -17,4 +17,5 @@ export * from "./handle-map";
 export * from "./objects";
 export * from "./records";
 export * from "./rust-call";
+export * from "./symbols";
 export * from "./type-utils";

--- a/typescript/src/symbols.ts
+++ b/typescript/src/symbols.ts
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+// Symbols for semi-private properties. These properties should
+// not be visible to users.
+//
+// The documentation refers to the property itself, of
+// which these symbols are the property name.
+
+/**
+ * A destructor guard object is created for every
+ * `interface` object.
+ *
+ * It corresponds to the `DestructibleObject` in C++, which
+ * uses a C++ destructor to simulate the JS garbage collector.
+ *
+ * The implementation is in {@link RustArcPtr.h}.
+ */
+export const destructorGuardSymbol = Symbol.for("destructor");
+
+/**
+ * The `bigint` pointer corresponding to the Rust memory address
+ * of the native peer.
+ */
+export const pointerLiteralSymbol = Symbol.for("pointer");
+
+/**
+ * The `string` name of the object, enum or error class.
+ *
+ * This drives the `instanceOf` method implementations.
+ */
+export const uniffiTypeNameSymbol = Symbol.for("typeName");
+
+/**
+ * The ordinal of the variant in an enum.
+ *
+ * This is the number that is passed over the FFI.
+ */
+export const variantOrdinalSymbol = Symbol.for("variant");

--- a/typescript/tests/playground/enums.ts
+++ b/typescript/tests/playground/enums.ts
@@ -5,6 +5,7 @@
  */
 import { UniffiEnum } from "../../src/enums";
 
+const uniffiTypeNameSymbol = Symbol("uniffiTypeName");
 export const MyEnum = (() => {
   const typeName = "MyEnum";
   type Variant1__interface = {
@@ -12,7 +13,7 @@ export const MyEnum = (() => {
     inner: Readonly<{ myValue: string }>;
   };
   class Variant1_ extends UniffiEnum implements Variant1__interface {
-    private readonly __uniffiTypeName = typeName;
+    readonly [uniffiTypeNameSymbol]: string = typeName;
     readonly tag = "Variant1";
     readonly inner: Readonly<{ myValue: string }>;
     constructor(inner: { myValue: string }) {
@@ -29,7 +30,7 @@ export const MyEnum = (() => {
     inner: Readonly<[number, string]>;
   };
   class Variant2_ extends UniffiEnum implements Variant2__interface {
-    private readonly __uniffiTypeName = typeName;
+    readonly [uniffiTypeNameSymbol]: string = typeName;
     readonly tag = "Variant2";
     readonly inner: Readonly<[number, string]>;
     constructor(p1: number, p2: string) {
@@ -42,7 +43,7 @@ export const MyEnum = (() => {
   }
 
   function instanceOf(obj: any): obj is MyEnum {
-    return obj.__uniffiTypeName === "MyEnum";
+    return obj[uniffiTypeNameSymbol] === "MyEnum";
   }
 
   return Object.freeze({


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This supersedes #94 to hide properties that are only used internally within the generated code.

It introduces a `symbols.ts` file and replaces all references to `__uniffiTypeName`, `__variant`, `__rustPointer` and `__rustArcPtr`.

The private accessors have also been removed.

The tests all continue to work, and the properties do not show up in the autocomplete/content assist of VS Code.