### PR TITLE
Add lipo support to allow multiple targets of the same platform

### DIFF
--- a/crates/ubrn_cli/src/ios.rs
+++ b/crates/ubrn_cli/src/ios.rs
@@ -4,14 +4,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-use std::process::Command;
+use std::{collections::HashMap, process::Command};
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
 use heck::ToUpperCamelCase;
 use serde::Deserialize;
-use ubrn_common::{rm_dir, run_cmd, CrateMetadata};
+use ubrn_common::{mk_dir, rm_dir, run_cmd, CrateMetadata};
 
 use crate::{
     building::{CommonBuildArgs, ExtraArgs},
@@ -118,8 +118,14 @@ impl IOsArgs {
         let targets = ios
             .targets
             .iter()
+            .map(|t| {
+                TARGETS
+                    .iter()
+                    .find(|target| target.triple == *t)
+                    .unwrap_or_else(|| panic!("Invalid target specified: {t}"))
+            })
             .filter(|target| {
-                let is_sim = target.contains("sim");
+                let is_sim = target.platform == Platform::IosSimulator;
                 if self.no_sim {
                     !is_sim
                 } else if self.sim_only {
@@ -128,7 +134,7 @@ impl IOsArgs {
                     true
                 }
             })
-            .map(String::clone)
+            .cloned()
             .collect::<Vec<_>>();
 
         let target_files = if self.common_args.no_cargo {
@@ -142,19 +148,22 @@ impl IOsArgs {
             self.cargo_build_all(crate_, &targets, &ios.cargo_extras)?
         };
 
-        if !self.no_xcodebuild {
+        Ok(if !self.no_xcodebuild {
+            let target_files = self.lipo_when_necessary(crate_, target_files)?;
             self.create_xcframework(&config, &target_files)?;
-        }
-        Ok(target_files)
+            target_files
+        } else {
+            target_files.into_values().collect()
+        })
     }
 
     fn cargo_build_all(
         &self,
         crate_: &CrateConfig,
-        targets: &[String],
+        targets: &[Target],
         cargo_extras: &ExtraArgs,
-    ) -> Result<Vec<Utf8PathBuf>> {
-        let mut target_files = Vec::new();
+    ) -> Result<HashMap<Target, Utf8PathBuf>> {
+        let mut target_files = HashMap::new();
         let metadata = crate_.metadata()?;
         let rust_dir = crate_.directory()?;
         let manifest_path = crate_.manifest_path()?;
@@ -162,9 +171,9 @@ impl IOsArgs {
             self.cargo_build(&manifest_path, target, cargo_extras, &rust_dir)?;
 
             // Now we need to get the path to the lib.a file, to feed to xcodebuild.
-            let library = metadata.library_path(Some(target), self.common_args.profile());
+            let library = metadata.library_path(Some(target.triple), self.common_args.profile());
             metadata.library_path_exists(&library)?;
-            target_files.push(library);
+            target_files.insert(target.clone(), library);
         }
         Ok(target_files)
     }
@@ -172,7 +181,7 @@ impl IOsArgs {
     fn cargo_build(
         &self,
         manifest_path: &Utf8PathBuf,
-        target: &String,
+        target: &Target,
         cargo_extras: &ExtraArgs,
         rust_dir: &Utf8PathBuf,
     ) -> Result<()> {
@@ -181,7 +190,7 @@ impl IOsArgs {
             .arg("--manifest-path")
             .arg(manifest_path)
             .arg("--target")
-            .arg(target);
+            .arg(target.triple);
         if self.common_args.release {
             cmd.arg("--release");
         }
@@ -190,10 +199,44 @@ impl IOsArgs {
         Ok(())
     }
 
+    fn lipo_when_necessary(
+        &self,
+        crate_: &CrateConfig,
+        target_files: HashMap<Target, Utf8PathBuf>,
+    ) -> Result<Vec<Utf8PathBuf>> {
+        let mut by_platform = HashMap::new();
+        for (target, file) in target_files {
+            let files = by_platform.entry(target.platform).or_insert(Vec::new());
+            files.push(file);
+        }
+        let metadata = crate_.metadata()?;
+
+        let mut sorted = Vec::new();
+        for (p, mut files) in by_platform {
+            if files.len() == 1 {
+                sorted.append(&mut files);
+            } else {
+                let dir = metadata.target_dir().join("lipo").join(p.lib_folder_name());
+                mk_dir(&dir)?;
+                let output = dir.join(metadata.library_file(Some("ios")));
+                let mut cmd = Command::new("lipo");
+                cmd.arg("-create");
+                for f in files {
+                    cmd.arg(f);
+                }
+                cmd.arg("-output").arg(&output);
+                run_cmd(&mut cmd)?;
+                sorted.push(output);
+            }
+        }
+
+        Ok(sorted)
+    }
+
     fn create_xcframework(
         &self,
         config: &ProjectConfig,
-        target_files: &Vec<Utf8PathBuf>,
+        target_files: &[Utf8PathBuf],
     ) -> Result<(), anyhow::Error> {
         let ios = &config.ios;
         let project_root = config.project_root();
@@ -218,19 +261,23 @@ impl IOsArgs {
         Ok(())
     }
 
-    fn find_existing(&self, metadata: &CrateMetadata, targets: &[String]) -> Vec<Utf8PathBuf> {
+    fn find_existing(
+        &self,
+        metadata: &CrateMetadata,
+        targets: &[Target],
+    ) -> HashMap<Target, Utf8PathBuf> {
         let profile = self.common_args.profile();
         targets
             .iter()
             .filter_map(|target| {
-                let library = metadata.library_path(Some(target), profile);
+                let library = metadata.library_path(Some(target.triple), profile);
                 if library.exists() {
-                    Some(library)
+                    Some((target.clone(), library))
                 } else {
                     None
                 }
             })
-            .collect::<Vec<_>>()
+            .collect::<HashMap<_, _>>()
     }
 
     pub(crate) fn project_config(&self) -> Result<ProjectConfig> {
@@ -241,3 +288,60 @@ impl IOsArgs {
         self.config.clone()
     }
 }
+
+/// A specific build target supported by the SDK.
+#[derive(Hash, PartialEq, Eq, Clone)]
+struct Target {
+    triple: &'static str,
+    platform: Platform,
+    description: &'static str,
+}
+
+/// The platform for which a particular target can run on.
+#[derive(Hash, PartialEq, Eq, Clone)]
+enum Platform {
+    Macos,
+    Ios,
+    IosSimulator,
+}
+
+impl Platform {
+    /// The name of the subfolder in which to place the library for the platform
+    /// once all architectures are lipo'd together.
+    fn lib_folder_name(&self) -> &str {
+        match self {
+            Platform::Macos => "macos",
+            Platform::Ios => "ios",
+            Platform::IosSimulator => "ios-simulator",
+        }
+    }
+}
+
+/// The list of targets supported by the SDK.
+const TARGETS: &[Target] = &[
+    Target {
+        triple: "aarch64-apple-ios",
+        platform: Platform::Ios,
+        description: "iOS",
+    },
+    Target {
+        triple: "aarch64-apple-darwin",
+        platform: Platform::Macos,
+        description: "macOS (Apple Silicon)",
+    },
+    Target {
+        triple: "x86_64-apple-darwin",
+        platform: Platform::Macos,
+        description: "macOS (Intel)",
+    },
+    Target {
+        triple: "aarch64-apple-ios-sim",
+        platform: Platform::IosSimulator,
+        description: "iOS Simulator (Apple Silicon)",
+    },
+    Target {
+        triple: "x86_64-apple-ios",
+        platform: Platform::IosSimulator,
+        description: "iOS Simulator (Intel) ",
+    },
+];

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -5,7 +5,7 @@
  */
 use std::fs;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 
@@ -91,11 +91,15 @@ where
     P: AsRef<Utf8Path>,
     for<'a> T: Deserialize<'a>,
 {
-    let s = std::fs::read_to_string(file.as_ref())?;
-    Ok(if is_yaml(&file) {
-        serde_yaml::from_str(&s)?
+    let file = file.as_ref();
+    let s =
+        std::fs::read_to_string(file).with_context(|| format!("Failed to read from {file:?}"))?;
+    Ok(if is_yaml(file) {
+        serde_yaml::from_str(&s)
+            .with_context(|| format!("Failed to read {file:?} as valid YAML"))?
     } else {
-        serde_json::from_str(&s)?
+        serde_json::from_str(&s)
+            .with_context(|| format!("Failed to read {file:?} as valid YAML or JSON"))?
     })
 }
 


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_m *n_) change.

This PR makes two changes to the build command:

- Adds a command line override of the targets that are being built. This list of valid targets are found by looking at `ubrn build ios --help` and its android counterpart.
- Adds lipo support. This should help in the cases where multi-architecture builds are needed. (Fixes: #77)

The lipo support is largely copied from the matrix-rust-sdk build. 