### PR TITLE
Async task cancellation

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -22,13 +22,21 @@ const {{ trait_impl }}: { vtable: {{ vtable|ffi_type_name }}; register: () => vo
             {%- endif %}
         ) => {
             const uniffiMakeCall = {# space #}
-            {%- call ts::async(meth) -%}
-            (): {% call ts::return_type(meth) %} => {
+            {%- if meth.is_async() %}
+            async (signal: AbortSignal)
+            {%- else %}
+            ()
+            {%- endif %}
+            : {% call ts::return_type(meth) %} => {
                 const jsCallback = {{ ffi_converter_name }}.lift(uniffiHandle);
                 return {% call ts::await(meth) %}jsCallback.{{ meth.name()|fn_name }}(
                     {%- for arg in meth.arguments() %}
                     {{ arg|ffi_converter_name(self) }}.lift({{ arg.name()|var_name }}){% if !loop.last %}, {% endif %}
                     {%- endfor %}
+                    {%- if meth.is_async() -%}
+                    {%-   if !meth.arguments().is_empty() %}, {% endif -%}
+                    { signal }
+                    {%- endif %}
                 )
             }
             {%- if !meth.is_async() %}
@@ -60,7 +68,7 @@ const {{ trait_impl }}: { vtable: {{ vtable|ffi_type_name }}; register: () => vo
                 /*lowerString:*/ FfiConverterString.lower
             )
             {%- endmatch %}
-            {%- else %}
+            {%- else %} {# // is_async = true #}
 
             const uniffiHandleSuccess = (returnValue: {% call ts::raw_return_type(meth) %}) => {
                 uniffiFutureCallback(

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -215,11 +215,20 @@ import { decl_type_name } from "./EnumTemplate"
 {%- endif -%}
 {%- endmacro %}
 
+{#-
+// This macros is almost identical to `arg_list_decl`,
+// but is for interface methods, which do not allow
+// default values for arguments.
+#}
 {% macro arg_list_protocol(func) %}
     {%- for arg in func.arguments() -%}
         {{ arg.name()|var_name }}: {{ arg|type_name(self) -}}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
+    {%- if func.is_async() %}
+    {%-   if !func.arguments().is_empty() %}, {% endif -%}
+    asyncOpts_?: { signal: AbortSignal }
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro async(func) %}

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/macros.ts
@@ -138,6 +138,7 @@ import { decl_type_name } from "./EnumTemplate"
             /*liftFunc:*/ (_v) => {},
             {%- endmatch %}
             /*liftString:*/ FfiConverterString.lift,
+            /*asyncOpts:*/ asyncOpts_,
             {%- match callable.throws_type() %}
             {%- when Some with (e) %}
             /*errorHandler:*/ {{ e|lift_error_fn(self) }}
@@ -166,6 +167,11 @@ import { decl_type_name } from "./EnumTemplate"
         {%- endmatch %}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
+    {%- if func.is_async() %}
+    {%-   if !func.arguments().is_empty() %}, {% endif -%}
+    asyncOpts_?: { signal: AbortSignal }
+    {%- endif %}
+
 {%- endmacro %}
 
 {#-

--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -49,6 +49,19 @@ function delayPromise(delayMs: number): Promise<void> {
   });
 }
 
+function cancellableDelayPromise(
+  delayMs: number,
+  abortSignal: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, delayMs);
+    abortSignal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(abortSignal.reason);
+    });
+  });
+}
+
 function checkRemainingFutures(t: Asserts) {
   t.assertEqual(
     0,
@@ -282,6 +295,38 @@ function checkRemainingFutures(t: Asserts) {
     t.end();
   });
 
+  class CancellableTsAsyncParser extends TsAsyncParser {
+    /**
+     * Each async callback method has an additional optional argument
+     * `asyncOptions_`. This contains an `AbortSignal`.
+     *
+     * If the Rust task is cancelled, then this abort signal is
+     * told, which can be used to co-operatively cancel the
+     * async callback.
+     *
+     * @param delayMs
+     * @param asyncOptions_
+     */
+    async delay(
+      delayMs: number,
+      asyncOptions_?: { signal: AbortSignal },
+    ): Promise<void> {
+      await this.doCancellableDelay(delayMs, asyncOptions_?.signal);
+    }
+
+    private async doCancellableDelay(
+      ms: number,
+      signal?: AbortSignal,
+    ): Promise<void> {
+      if (signal) {
+        await cancellableDelayPromise(ms, signal);
+      } else {
+        await delayPromise(ms);
+      }
+      this.completedDelays += 1;
+    }
+  }
+
   /**
    * Rust supports task cancellation, but it's not automatic. It is rather like
    * Javascript's.
@@ -460,28 +505,61 @@ function checkRemainingFutures(t: Asserts) {
     },
   );
 
-  await xasyncTest(
+  class Counter {
+    expectedCount = 0;
+    unexpectedCount = 0;
+    ok() {
+      return () => this.expectedCount++;
+    }
+    wat() {
+      return () => this.unexpectedCount++;
+    }
+  }
+
+  await asyncTest(
     "a future that uses a lock and that is cancelled from JS",
     async (t) => {
+      const errors = new Counter();
+      const success = new Counter();
+
+      // Task 1 should hold the resource for 100 seconds.
+      // We make an abort controller and get the signal from it, and pass it to
+      // Rust.
+      // Cancellation is done by dropping the future, so the Rust should be prepared
+      // for that.
+      const abortController = new AbortController();
       const task1 = useSharedResource(
         SharedResourceOptions.create({
-          releaseAfterMs: 5000,
+          releaseAfterMs: 100000,
           timeoutMs: 100,
         }),
-      );
-      // #RUST_TASK_CANCELLATION
-      //
-      // Again this test is not really applicable for JS, as it has no standard way of
-      // cancelling a task.
-      // task1.cancel()
+        { signal: abortController.signal },
+      ).then(success.wat(), errors.ok());
 
-      // Try accessing the shared resource again.  The initial task should release the shared resource
-      // before the timeout expires.
+      // Task 2 should try to grab the resource, but timeout after 1 second.
+      // Unless we abort task 1, then task 1 will hold on, but task 2 will timeout and
+      // fail.
       const task2 = useSharedResource(
         SharedResourceOptions.create({ releaseAfterMs: 0, timeoutMs: 1000 }),
+      ).then(success.ok(), errors.wat());
+
+      // We wait for 500 ms, then call the abortController.abort().
+      const delay = delayPromise(500).then(() => abortController.abort());
+
+      await Promise.allSettled([task1, task2, delay]);
+      t.assertEqual(errors.expectedCount, 1, "only task1 should have failed");
+      t.assertEqual(
+        success.expectedCount,
+        1,
+        "only task2 should have succeeded",
       );
 
-      await Promise.allSettled([task1, task2]);
+      t.assertEqual(errors.unexpectedCount, 0, "task2 should not have failed");
+      t.assertEqual(
+        success.unexpectedCount,
+        0,
+        "task1 should not have succeeded",
+      );
       checkRemainingFutures(t);
       t.end();
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "uniffi-bindgen-react-native": "./bin/cli"
   },
   "devDependencies": {
+    "abortcontroller-polyfill": "^1.7.5",
     "metro": "^0.80.8",
     "metro-core": "^0.80.8",
     "prettier": "^3.2.5",

--- a/typescript/src/async-callbacks.ts
+++ b/typescript/src/async-callbacks.ts
@@ -6,13 +6,28 @@
 import { CALL_ERROR, CALL_UNEXPECTED_ERROR } from "./rust-call";
 import { type UniffiHandle, UniffiHandleMap } from "./handle-map";
 
-const UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = new UniffiHandleMap<Promise<any>>();
+// Some additional data we hold for each in-flight promise.
+type PromiseHelper = {
+  // The promise itself, so it doesn't get GCd by mistake.
+  promise: Promise<any>;
+  // The abort controller we will use to cancel, if necessary.
+  abortController: AbortController;
+  // A mutable object which gets set when the promise has succeeded or errored.
+  // If uniffiForeignFutureFree gets called before settled is turned to true,
+  // then we know that it is a call to cancel the task.
+  settledHolder: {
+    settled: boolean;
+  };
+};
+const UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = new UniffiHandleMap<PromiseHelper>();
 
+// Some degenerate functions used for default arguments.
 const notExpectedError = (err: any) => false;
 function emptyLowerError<E>(e: E): ArrayBuffer {
   throw new Error("Unreachable");
 }
 
+// Callbacks passed into Rust.
 export type UniffiForeignFutureFree = (handle: bigint) => void;
 
 export type UniffiForeignFuture = {
@@ -21,7 +36,7 @@ export type UniffiForeignFuture = {
 };
 
 export function uniffiTraitInterfaceCallAsync<T>(
-  makeCall: () => Promise<T>,
+  makeCall: (signal: AbortSignal) => Promise<T>,
   handleSuccess: (value: T) => void,
   handleError: (callStatus: /*i8*/ number, errorBuffer: ArrayBuffer) => void,
   lowerString: (str: string) => ArrayBuffer,
@@ -37,30 +52,39 @@ export function uniffiTraitInterfaceCallAsync<T>(
 }
 
 export function uniffiTraitInterfaceCallAsyncWithError<T, E>(
-  makeCall: () => Promise<T>,
+  makeCall: (signal: AbortSignal) => Promise<T>,
   handleSuccess: (value: T) => void,
   handleError: (callStatus: /*i8*/ number, errorBuffer: ArrayBuffer) => void,
   isErrorType: (error: any) => boolean,
   lowerError: (error: E) => ArrayBuffer,
   lowerString: (str: string) => ArrayBuffer,
 ): UniffiForeignFuture {
-  const promise = makeCall().then(handleSuccess, (error: any) => {
-    let message = error.message ? error.message : error.toString();
-    if (isErrorType(error)) {
-      try {
-        handleError(CALL_ERROR, lowerError(error as E));
-        return;
-      } catch (e: any) {
-        // Fall through to unexpected error handling below.
-        message = `Error handling error "${e}", originally: "${message}"`;
+  const settledHolder: { settled: boolean } = { settled: false };
+  const abortController = new AbortController();
+  const promise = makeCall(abortController.signal)
+    // Before doing anything else, we record that the promise has been settled.
+    // Doing this after the `then` call means we only do this once all of that has finished,
+    // which is way too late.
+    .finally(() => (settledHolder.settled = true))
+    .then(handleSuccess, (error: any) => {
+      let message = error.message ? error.message : error.toString();
+      if (isErrorType(error)) {
+        try {
+          handleError(CALL_ERROR, lowerError(error as E));
+          return;
+        } catch (e: any) {
+          // Fall through to unexpected error handling below.
+          message = `Error handling error "${e}", originally: "${message}"`;
+        }
       }
-    }
-    // This is the catch all:
-    // 1. if there was an unexpected error causing a rejection
-    // 2. if there was an unexpected error in the handleError function.
-    handleError(CALL_UNEXPECTED_ERROR, lowerString(message));
-  });
-  const handle = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert(promise);
+      // This is the catch all:
+      // 1. if there was an unexpected error causing a rejection
+      // 2. if there was an unexpected error in the handleError function.
+      handleError(CALL_UNEXPECTED_ERROR, lowerString(message));
+    });
+
+  const promiseHelper = { abortController, settledHolder, promise };
+  const handle = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert(promiseHelper);
   return /* UniffiForeignFuture */ {
     handle,
     free: uniffiForeignFutureFree,
@@ -68,20 +92,14 @@ export function uniffiTraitInterfaceCallAsyncWithError<T, E>(
 }
 
 function uniffiForeignFutureFree(handle: UniffiHandle) {
-  const promise = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.remove(handle);
+  const helper = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.remove(handle);
   // #JS_TASK_CANCELLATION
   //
   // This would be where the request from Rust to cancel a JS task would come out.
   // Check if the promise has been settled, and if not, cancel it.
-  //
-  // In the future, we might use an AbortController here, but hermes doesn't implement it yet.
-  //
-  // We would need to:
-  //   - figure out a way of passing the abortController signal to the JS callback.
-  //   - storing a holder with the promise and the abortController in this map.
-  //   - call the abortController in this method.
-  //
-  // abortController.abort();
+  if (!helper.settledHolder.settled) {
+    helper.abortController.abort();
+  }
 }
 
 // For testing

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -99,6 +99,12 @@ export const UniffiInternalError = (() => {
       super("The buffer still has data after lifting its containing value");
     }
   }
+  class AbortError extends Error {
+    constructor() {
+      super("A Rust future was aborted");
+      this.name = "AbortError";
+    }
+  }
   class UnexpectedEnumCase extends Error {
     constructor() {
       super("Raw enum value doesn't match any cases");
@@ -155,6 +161,7 @@ export const UniffiInternalError = (() => {
     BufferOverflow,
     ContractVersionMismatch,
     IncompleteData,
+    AbortError,
     UnexpectedEnumCase,
     UnexpectedNullPointer,
     UnexpectedRustCallStatusCode,

--- a/typescript/src/rust-call.ts
+++ b/typescript/src/rust-call.ts
@@ -89,16 +89,9 @@ function uniffiCheckCallStatus(
       // This error code is expected when a Rust Future is cancelled or aborted, either
       // from the foreign side, or from within Rust itself.
       //
-      // It's expected that this would be encountered when the `completeFunc` is called
-      // from `uniffiRustCallAsync`.
-      //
-      // Currently, there is no generated API of cancelling a promise from JS.
-      //
       // As of uniffi-rs v0.28.0, call cancellation is only checked for in the Swift bindings,
-      // and has a similar Unimplemeneted error.
-      throw new UniffiInternalError.Unimplemented(
-        "Cancellation not supported yet",
-      );
+      // and uses an Unimplemeneted error.
+      throw new UniffiInternalError.AbortError();
 
     default:
       throw new UniffiInternalError.UnexpectedRustCallStatusCode();

--- a/typescript/testing/polyfills.ts
+++ b/typescript/testing/polyfills.ts
@@ -1,0 +1,11 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import "abortcontroller-polyfill/dist/abortcontroller-polyfill-only";
+import { console } from "./hermes";
+
+(globalThis as any).console = console;
+
+export default globalThis;

--- a/typescript/tests/abort-controller.test.ts
+++ b/typescript/tests/abort-controller.test.ts
@@ -1,0 +1,80 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import "../testing/polyfills";
+import { test, asyncTest } from "../testing/asserts";
+
+test("AbortController exists", (t) => {
+  const controller = new AbortController();
+  t.assertNotNull(controller);
+
+  const signal = controller.signal;
+  t.assertNotNull(signal);
+});
+
+(async () => {
+  function delay(delayMs: number): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  function cancellableDelay(
+    delayMs: number,
+    _props?: { signal: AbortSignal },
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, delayMs);
+      _props?.signal.addEventListener("abort", () => {
+        // Stop the main operation
+        clearTimeout(timer);
+        // Reject the promise with the abort reason.
+        reject(_props?.signal.reason);
+      });
+    });
+  }
+
+  await asyncTest("AbortController is polyfilled as expected", async (t) => {
+    // This test passes if it AbortController and AbortSinal are available.
+    let abortController = new AbortController();
+    let abortSignal: AbortSignal = abortController.signal;
+
+    // we don't care too much about the accuracy of the time here, just that the
+    // classes exist and work as intended.
+    await t.asyncMeasure(() => cancellableDelay(500), 500, 100);
+    t.end();
+  });
+
+  await asyncTest("AbortController aborts as expected", async (t) => {
+    const abortController = new AbortController();
+    // A wait for an hour…
+    const promise = cancellableDelay(60 * 60 * 1000, {
+      signal: abortController.signal,
+    });
+    // …cancelled after 1/2 a second.
+    const canceller = delay(500).then(() => abortController.abort());
+
+    await Promise.allSettled([promise, canceller]);
+    t.end();
+  });
+
+  await asyncTest("AbortController rejects with error", async (t) => {
+    const abortController = new AbortController();
+
+    // …cancelled after 1/2 a second.
+    const canceller = delay(500).then(() => abortController.abort());
+
+    try {
+      await cancellableDelay(60 * 60 * 1000, {
+        signal: abortController.signal,
+      });
+      t.fail("Expected an AbortError before we get here");
+    } catch (err: any) {
+      t.assertNotNull(err);
+      t.assertTrue(err instanceof Error);
+      t.assertEqual(err.name, "AbortError");
+    }
+    await Promise.allSettled([canceller]);
+    t.end();
+  });
+})();


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Fixes #73 
Fixes #74 

### Background

Task cancellation is cooperative in both Rust and Javascript. i.e. they rely on cooperation of the task itself to perform cancellation.

In Javascript, there is API for the canceller: the `AbortController`. The `AbortController` has an `AbortSignal` object which can be given to the task.

For example:

```typescript
function cancellableDelayPromise(
  delayMs: number,
  abortSignal: AbortSignal,
): Promise<void> {
  return new Promise((resolve, reject) => {
    const timer = setTimeout(resolve, delayMs);
    abortSignal.addEventListener("abort", () => {
      clearTimeout(timer);
      reject(abortSignal.reason);
    });
  });
}
```

This might be used like so:

```typescript
const abortController = new AbortController();
setTimeout(() => abortController.abort(), 1000); // Abort the task below after 1 second.
try {
  await cancellableDelayPromise(24 * 60 * 60 * 1000, abortController.signal);
  throw new Error("You're too late! It's 24 hours afterwards");
} catch (e: any) {
  assertTrue(e instanceof Error && e.name === "AbortError");
  console.log("Phew, you didn't wait all that time");
}
```

### Cancelling Rust tasks

Uniffi's machinery provides a `cancelFunc`. As of `v0.28.0`, this causes the `Future` to be dropped. The Rust should be written in such a way as to do any cleanup for the task when this happens.

This `cancelFunc` can be called indirectly by passing an `{ signal: AbortSignal; }` when calling any async function. 

There is no way for uniffi to know which Futures can be cancelled, so all async functions have an optional argument of `asyncOpts_?: { signal: AbortSignal; }` appended to their argument list.

Thus:

```typscript
await fetchUser(userId);
```

may also be called with an `AbortSignal`.
```typescript
await fetchUser(userId, { signal });
```

Since these are optional arguments, it is up to the Typescript caller whether or not to include them.

### Cancelling async Javascript callbacks

The `futures_util` crate provides structures similar to `AbortController` and `AbortSignal`. In this example, `obj` is a JS callback interface.

```rust
async fn cancel_delay_using_trait(obj: Arc<dyn AsyncParser>, delay_ms: i32) {
    let (abort_handle, abort_registration) = AbortHandle::new_pair();
    thread::spawn(move || {
        // Simulate a different thread aborting the process
        thread::sleep(Duration::from_millis(1));
        abort_handle.abort();
    });
    let future = Abortable::new(obj.delay(delay_ms), abort_registration);
    assert_eq!(future.await, Err(Aborted));
}
```

The `obj.delay(delay_ms)` call translates to a call to a Javascript function.

```typescript
delay(delayMs: number, asyncOpts_?: { signal: AbortSignal })`
```

When `abort_handle.abort()` is called, the Abortable `future` is dropped. The `AbortSignal` in Javascript is told to abort when it is being cleaned up, and hasn't yet settled.

Because uniffi can't tell which Javascript callbacks support an `AbortSignal`, all async functions have an optional argument of `asyncOpts_?: { signal: AbortSignal; }` appended to their argument list.

Since these are optional arguments, it is up to the Typescript implementer whether or not to include them.

### Caveat emptor

Because of the different APIs across languages _and_ the co-operative nature of task cancellation in Rust, there is a diversity of API support for task cancellation across the various backend languages that uniffi supports. This PR brings uniffi-bindgen-react-native to parity with the Mozilla supported languages.

However, the uniffi docs currently suggest more modest support:

```md
We don't directly support cancellation in UniFFI even when the underlying platforms do.
You should build your cancellation in a separate, library specific channel; for example, exposing a `cancel()` method that sets a flag that the library checks periodically.

Cancellation can then be exposed in the API and be mapped to one of the error variants, or None/empty-vec/whatever makes sense.
There's no builtin way to cancel a future, nor to cause/raise a platform native async cancellation error (eg, a swift `CancellationError`).
```

I would expect this to change over time.