### PR TITLE
Tighten up logic around generated codegened spec filename

### DIFF
--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -64,6 +64,8 @@ impl TemplateConfig {
         rust_crate: CrateMetadata,
         modules: Vec<ModuleMetadata>,
     ) -> Self {
+        let mut modules = modules;
+        modules.sort_by_key(|m| m.ts());
         Self {
             project,
             rust_crate,

--- a/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.h
+++ b/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.h
@@ -6,7 +6,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "{{ self.config.project.tm.name() }}.h"
 
-@interface {{ self.config.project.name_upper_camel() }} : NSObject <{{ self.config.project.tm.spec_name() }}>
+@interface {{ self.config.project.name_upper_camel() }} : NSObject <{{ self.config.project.codegen_filename() }}Spec>
 #else
 #import <React/RCTBridgeModule.h>
 

--- a/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.java
+++ b/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.java
@@ -11,7 +11,7 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 
 @ReactModule(name = {{ module_class_name }}.NAME)
-public class {{ module_class_name }} extends {{ self.config.project.tm.spec_name() }} {
+public class {{ module_class_name }} extends {{ self.config.project.codegen_filename() }}Spec {
   public static final String NAME = "{{ name }}";
 
   public {{ module_class_name }}(ReactApplicationContext reactContext) {

--- a/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.mm
+++ b/crates/ubrn_cli/src/codegen/templates/ModuleTemplate.mm
@@ -1,5 +1,5 @@
 {%- let module_name = self.config.project.name_upper_camel() %}
-{%- let spec_jsi = self.config.project.tm.spec_name()|fmt("{}JSI") %}
+{%- let spec_jsi = self.config.project.codegen_filename()|fmt("{}JSI") %}
 {%- let ns = self.config.project.cpp_namespace() %}
 {%- let uniffi_ns = "uniffi_generated" %}
 {%- let fn_prefix = "__hostFunction_{}"|format(module_name) -%}

--- a/crates/ubrn_cli/src/codegen/templates/NativeCodegenTemplate.ts
+++ b/crates/ubrn_cli/src/codegen/templates/NativeCodegenTemplate.ts
@@ -7,4 +7,4 @@ export interface Spec extends TurboModule {
   cleanupRustCrate(): boolean;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('{{ self.config.project.name_upper_camel() }}');
+export default TurboModuleRegistry.getEnforcing<Spec>('{{ self.config.project.tm.spec_name() }}');

--- a/crates/ubrn_cli/src/codegen/templates/TurboModuleTemplate.cpp
+++ b/crates/ubrn_cli/src/codegen/templates/TurboModuleTemplate.cpp
@@ -14,7 +14,7 @@ namespace {{ self.config.project.cpp_namespace() }} {
         {%- for m in self.config.modules %}
 		{{ m.cpp_module() }}::registerModule(runtime, callInvoker);
         {%- endfor %}
-		return false;
+		return true;
 	}
 
 	uint8_t cleanupRustCrate(jsi::Runtime &runtime) {

--- a/crates/ubrn_cli/src/config/mod.rs
+++ b/crates/ubrn_cli/src/config/mod.rs
@@ -7,6 +7,7 @@ mod npm;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use globset::GlobSet;
+use heck::ToUpperCamelCase;
 pub(crate) use npm::PackageJson;
 
 use serde::Deserialize;
@@ -45,7 +46,7 @@ pub(crate) struct ProjectConfig {
 
 impl ProjectConfig {
     fn default_name() -> String {
-        workspace::package_json().raw_name()
+        workspace::package_json().trimmed_name()
     }
 
     fn default_repository() -> String {
@@ -73,7 +74,7 @@ impl ProjectConfig {
 
 impl ProjectConfig {
     fn name(&self) -> String {
-        trim_react_native(&self.name)
+        self.name.clone()
     }
 
     pub(crate) fn raw_name(&self) -> &str {
@@ -180,8 +181,7 @@ impl TurboModulesConfig {
 
     fn default_spec_name() -> String {
         let package_json = workspace::package_json();
-        let codegen_name = &package_json.codegen().name;
-        format!("Native{}", trim_react_native(codegen_name))
+        trim_react_native(&package_json.codegen().name)
     }
 }
 
@@ -201,7 +201,7 @@ impl TurboModulesConfig {
     }
 
     pub(crate) fn spec_name(&self) -> String {
-        self.spec_name.clone()
+        self.spec_name.to_upper_camel_case()
     }
 
     pub(crate) fn name(&self) -> String {

--- a/crates/ubrn_cli/src/config/npm.rs
+++ b/crates/ubrn_cli/src/config/npm.rs
@@ -25,7 +25,7 @@ impl PackageJson {
         self.name.clone()
     }
 
-    pub(crate) fn name(&self) -> String {
+    pub(crate) fn trimmed_name(&self) -> String {
         trim_react_native(&self.name)
     }
 
@@ -34,7 +34,14 @@ impl PackageJson {
             .android
             .java_package_name
             .clone()
-            .unwrap_or_else(|| format!("com.{}", self.name().to_upper_camel_case().to_lowercase()))
+            .unwrap_or_else(|| {
+                format!(
+                    "com.{}",
+                    trim_react_native(&self.raw_name())
+                        .to_upper_camel_case()
+                        .to_lowercase()
+                )
+            })
     }
 
     pub(crate) fn repo(&self) -> &PackageJsonRepo {

--- a/crates/ubrn_cli/src/ios.rs
+++ b/crates/ubrn_cli/src/ios.rs
@@ -47,7 +47,9 @@ impl IOsConfig {
     fn default_framework_name() -> String {
         format!(
             "{}Framework",
-            workspace::package_json().name().to_upper_camel_case()
+            workspace::package_json()
+                .trimmed_name()
+                .to_upper_camel_case()
         )
     }
 


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Fixes #44.

This PR investigates and fixes how the React Native Codegen file is named, taking into consideration the rules around what it creates.

It turns out that it:

 * has to start with `Native`
 * it is the file name that is used to generate all the other files 
 * the spec name in pacakge.json seems to be irrelevant.

The PR still allows ReactNative and RN to be trimmed, but only if it is not specified in the configuration YAML.

E.g. `name: RnDiode` to the top of the `config.yaml`.