### PR TITLE
Add measure of roundtrip performance for ArrayBuffers in coverall2 test

### DIFF
--- a/fixtures/coverall2/tests/bindings/test_coverall2.ts
+++ b/fixtures/coverall2/tests/bindings/test_coverall2.ts
@@ -42,6 +42,41 @@ test("array buffer roundtrip using read/write", (t) => {
   }
 });
 
+test("ArrayBuffer roundtrip of different sizes", (t) => {
+  function rt(ab: ArrayBuffer) {
+    t.assertNotNull(identityArrayBuffer(ab)!);
+  }
+  // 1 kB = 1<<10
+  // 1 MB = 1<<20
+  // 16 MB = 1<<24
+  for (let i = 0; i < 26; i++) {
+    const byteLength = 1 << i;
+    const buffer = new ArrayBuffer(byteLength);
+    const start = Date.now();
+    rt(buffer);
+    const end = Date.now();
+    console.log(
+      `ArrayBuffer roundtrip: ${bytes(byteLength)} in ${end - start} ms`,
+    );
+  }
+});
+
+function bytes(n: number): string {
+  if (n === 0) {
+    return "0 bytes";
+  }
+  if (n < 1 << 10) {
+    return `${n} bytes`;
+  }
+  if (n < 1 << 20) {
+    return `${n / (1 << 10)} kB`;
+  }
+  if (n < 1 << 30) {
+    return `${n / (1 << 20)} MB`;
+  }
+  return `${n / (1 << 30)} GB`;
+}
+
 test("array buffer roundtrip with ArrayBufferView", (t) => {
   function rt(ab: ArrayBuffer) {
     t.assertEqual(
@@ -107,6 +142,6 @@ function abEquals(a: ArrayBuffer, b: ArrayBuffer): boolean {
 }
 
 function arrayBuffer(numBytes: number): ArrayBuffer {
-  const array = Uint8Array.from({ length: numBytes }, (_v, i) => i);
+  const array = Uint8Array.from({ length: numBytes }, (_v, i) => i % 255);
   return array.buffer;
 }


### PR DESCRIPTION
This PR adds a test round tripping of up to 32 megabytes with millisecond timings.

The Linux box on CI shows:
```
ArrayBuffer roundtrip: 1 bytes in 2 ms
ArrayBuffer roundtrip: 2 bytes in 1 ms
ArrayBuffer roundtrip: 4 bytes in 0 ms
ArrayBuffer roundtrip: 8 bytes in 1 ms
ArrayBuffer roundtrip: 16 bytes in 1 ms
ArrayBuffer roundtrip: 32 bytes in 0 ms
ArrayBuffer roundtrip: 64 bytes in 0 ms
ArrayBuffer roundtrip: 128 bytes in 1 ms
ArrayBuffer roundtrip: 256 bytes in 1 ms
ArrayBuffer roundtrip: 512 bytes in 0 ms
ArrayBuffer roundtrip: 1 kB in 0 ms
ArrayBuffer roundtrip: 2 kB in 0 ms
ArrayBuffer roundtrip: 4 kB in 0 ms
ArrayBuffer roundtrip: 8 kB in 1 ms
ArrayBuffer roundtrip: 16 kB in 2 ms
ArrayBuffer roundtrip: 32 kB in 3 ms
ArrayBuffer roundtrip: 64 kB in 6 ms
ArrayBuffer roundtrip: 128 kB in 11 ms
ArrayBuffer roundtrip: 256 kB in 21 ms
ArrayBuffer roundtrip: 512 kB in 67 ms
ArrayBuffer roundtrip: 1 MB in 96 ms
ArrayBuffer roundtrip: 2 MB in 192 ms
ArrayBuffer roundtrip: 4 MB in 369 ms
ArrayBuffer roundtrip: 8 MB in 702 ms
ArrayBuffer roundtrip: 16 MB in 1368 ms
ArrayBuffer roundtrip: 32 MB in 2652 ms
```

My M3 MBP shows:

```
ArrayBuffer roundtrip: 1 bytes in 1 ms
ArrayBuffer roundtrip: 2 bytes in 0 ms
ArrayBuffer roundtrip: 4 bytes in 0 ms
ArrayBuffer roundtrip: 8 bytes in 1 ms
ArrayBuffer roundtrip: 16 bytes in 0 ms
ArrayBuffer roundtrip: 32 bytes in 0 ms
ArrayBuffer roundtrip: 64 bytes in 0 ms
ArrayBuffer roundtrip: 128 bytes in 0 ms
ArrayBuffer roundtrip: 256 bytes in 0 ms
ArrayBuffer roundtrip: 512 bytes in 0 ms
ArrayBuffer roundtrip: 1 kB in 0 ms
ArrayBuffer roundtrip: 2 kB in 0 ms
ArrayBuffer roundtrip: 4 kB in 1 ms
ArrayBuffer roundtrip: 8 kB in 0 ms
ArrayBuffer roundtrip: 16 kB in 1 ms
ArrayBuffer roundtrip: 32 kB in 1 ms
ArrayBuffer roundtrip: 64 kB in 3 ms
ArrayBuffer roundtrip: 128 kB in 7 ms
ArrayBuffer roundtrip: 256 kB in 13 ms
ArrayBuffer roundtrip: 512 kB in 43 ms
ArrayBuffer roundtrip: 1 MB in 59 ms
ArrayBuffer roundtrip: 2 MB in 114 ms
ArrayBuffer roundtrip: 4 MB in 245 ms
ArrayBuffer roundtrip: 8 MB in 429 ms
ArrayBuffer roundtrip: 16 MB in 838 ms
ArrayBuffer roundtrip: 32 MB in 1648 ms
```

Let's see what the device shows.