### PR TITLE
Translates cli into javascript

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,19 +1,10 @@
-#!/usr/bin/env bash
-#
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/
-#
-set -e
+#!/usr/bin/env node
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
 
-# Use Node to resolve the path to the module. The require.resolve
-# function returns a thing like:
-#
-# PATH_TO/node_modules/uniffi-bindgen-react-native/typescript/src/index.ts
-#
-# So we drop the /typescript/src/index.ts.
-resolved_path=$(node --print "require.resolve('uniffi-bindgen-react-native')")
-root_dir=${resolved_path/\/typescript\/src\/index.ts*/}
-manifest_path="${root_dir}/crates/ubrn_cli/Cargo.toml"
-
-cargo run --quiet --manifest-path "${manifest_path}" -- "$@"
+// Launchable shell script.
+// We just invoke the node cjs file.
+import "./cli.cjs";

--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -1,0 +1,51 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+function getRootDir() {
+  const currentDir = __dirname;
+  const repoMarker = "uniffi-bindgen-react-native";
+
+  // Check if the current directory is within the `uniffi-bindgen-react-native` repo
+  if (currentDir.includes(repoMarker)) {
+    let dir = currentDir;
+    while (dir !== path.parse(dir).root) {
+      if (fs.existsSync(path.join(dir, "Cargo.toml"))) {
+        return dir;
+      }
+      dir = path.dirname(dir);
+    }
+  }
+
+  // Fallback to using require.resolve
+  const resolvedPath = require.resolve("uniffi-bindgen-react-native");
+  return resolvedPath.replace(/\/typescript\/src\/index\.ts$/, "");
+}
+
+// Get the root directory
+const rootDir = getRootDir();
+
+const args = process.argv.slice(2);
+if (args.length === 1 && args[0] === "--path") {
+  console.log(`${rootDir}/bin/cli`);
+  process.exit(0);
+}
+
+// Construct the path to the Cargo.toml file
+const manifestPath = path.join(rootDir, "crates/ubrn_cli/Cargo.toml");
+
+// Run the cargo command
+const command = `cargo run --quiet --manifest-path "${manifestPath}" -- ${args.join(" ")}`;
+try {
+  execSync(command, { stdio: "inherit" });
+} catch (e) {
+  // cargo run errors are reported to stderr already.
+  // We do not want to show the JS error.
+  // All we have left is to exit with a non-zero exit code.
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "type": "module",
   "main": "./typescript/src/index.ts",
   "bin": {
-    "ubrn": "./bin/cli",
-    "uniffi-bindgen-react-native": "./bin/cli"
+    "ubrn.cjs": "./bin/cli.cjs",
+    "uniffi-bindgen-react-native.cjs": "./bin/cli.cjs"
   },
   "devDependencies": {
     "abortcontroller-polyfill": "^1.7.5",


### PR DESCRIPTION
This PR translates the command line launcher in to JS.

This means it can be launched from `package.json`.

Adding to `package.json`:

```json
"scripts": {
    "ubrn": "uniffi-bindgen-react-native"
}
```

means now we can do:

```sh
yarn ubrn --help
```

As a little extra:

```sh
alias ubrn=$(yarn ubrn --path)
```
will make the command invokable from the shell.