### PR TITLE
Allow record default properties to be overridden

### DIFF
--- a/typescript/src/records.ts
+++ b/typescript/src/records.ts
@@ -12,6 +12,6 @@ export const uniffiCreateRecord = <T, D extends Partial<T>>(
   defaults: () => D,
 ) => {
   type MissingKeys = Omit<T, keyof D>;
-  return (partial: Required<MissingKeys> & Partial<D>): T =>
+  return (partial: Partial<T> & Required<MissingKeys>): T =>
     Object.freeze({ ...defaults(), ...partial } as T);
 };

--- a/typescript/tests/playground/records.ts
+++ b/typescript/tests/playground/records.ts
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+import { uniffiCreateRecord } from "../../src/records";
+
+export type MyRecord = {
+  string: string;
+  number: number;
+  optionalString: string | undefined;
+  bool: boolean;
+  optionalBool: boolean | undefined;
+};
+
+export const MyRecord = (() => {
+  const defaults = () => ({
+    string: "default",
+    optionalString: undefined,
+  });
+
+  const create = uniffiCreateRecord<MyRecord, ReturnType<typeof defaults>>(
+    defaults,
+  );
+
+  return {
+    create,
+  };
+})();

--- a/typescript/tests/records.test.ts
+++ b/typescript/tests/records.test.ts
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+import { Asserts, test, xtest } from "../testing/asserts";
+import { console } from "../testing/hermes";
+import { MyRecord } from "./playground/records";
+
+test("Allow defaults to be missing", (t) => {
+  const v: MyRecord = MyRecord.create({
+    number: 42,
+    bool: true,
+    optionalBool: undefined,
+  });
+  t.assertEqual(v.string, "default");
+  t.assertEqual(v.optionalString, undefined);
+  t.assertEqual(v.number, 42);
+  t.assertEqual(v.bool, true);
+  t.assertEqual(v.optionalBool, undefined);
+});
+
+test("Allow defaults to be overridden", (t) => {
+  const v: MyRecord = MyRecord.create({
+    string: "overridden",
+    optionalString: "also overridden",
+    number: 43,
+    bool: false,
+    optionalBool: true,
+  });
+
+  t.assertEqual(v.string, "overridden");
+  t.assertEqual(v.optionalString, "also overridden");
+  t.assertEqual(v.number, 43);
+  t.assertEqual(v.bool, false);
+  t.assertEqual(v.optionalBool, true);
+});


### PR DESCRIPTION
Fixes #101 .

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR adds a test for the behaviour described in #101, and a fix.
