### PR TITLE
Fixup bin scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "type": "module",
   "main": "./typescript/src/index.ts",
   "bin": {
-    "ubrn.cjs": "./bin/cli.cjs",
-    "uniffi-bindgen-react-native.cjs": "./bin/cli.cjs"
+    "ubrn": "./bin/cli",
+    "uniffi-bindgen-react-native": "./bin/cli"
   },
   "devDependencies": {
     "abortcontroller-polyfill": "^1.7.5",


### PR DESCRIPTION
#102 changed the `bin` entries in `package.json`. This turned out to be incorrect.

It worked in development because I was copying the files into `.bin`, when I should've been soft linking them.

This PR reverts that change.