### PR TITLE
Fix documentation publishing

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/book
+          path: ./docs/book/html
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Super cool project! I get a bunch of React Native requests for a library I work on and am looking forward to giving this a try!

I noticed when looking for docs that you've got GitHub pages set up, but it's not easy to find, since it's under an `html` subdirectory right now: https://jhugman.github.io/uniffi-bindgen-react-native/html/. I figured this out after downloading the CI artifact.

I _think_ this tweak to the workflow will make the docs more accessible. Might also want to link it in the repo metadata on GitHub so there's a link right there on the right side, but I can't open a PR for that ;)