### PR TITLE
Check out shallowly and allow updating a checkout

### DIFF
--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -19,7 +19,7 @@ pub(crate) struct GitRepoArgs {
     pub(crate) repo: String,
     /// The branch or tag which to checkout
     #[clap(long, default_value = "main")]
-    #[serde(default = "GitRepoArgs::default_branch")]
+    #[serde(alias = "rev", alias = "ref", default = "GitRepoArgs::default_branch")]
     pub(crate) branch: String,
 }
 

--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -68,12 +68,31 @@ impl GitRepoArgs {
     }
 
     pub(crate) fn checkout(&self, project_root: &Utf8Path) -> Result<()> {
+        // git clone --depth 1 if directory doesn't already exist
+        if !self.directory(project_root)?.exists() {
+            let mut cmd = Command::new("git");
+            cmd.arg("clone")
+                .arg(&self.repo)
+                .arg(self.directory(project_root)?)
+                .arg("--depth")
+                .arg("1");
+            run_cmd(&mut cmd)?;
+        }
+
+        // git fetch --depth 1 origin $branch
         let mut cmd = Command::new("git");
-        cmd.arg("clone")
-            .arg(&self.repo)
-            .arg(self.directory(project_root)?)
-            .arg("--single-branch")
-            .arg("--branch")
+        cmd.current_dir(self.directory(project_root)?)
+            .arg("fetch")
+            .arg("--depth")
+            .arg("1")
+            .arg("origin")
+            .arg(&self.branch);
+        run_cmd(&mut cmd)?;
+
+        // git checkout $branch
+        let mut cmd = Command::new("git");
+        cmd.current_dir(self.directory(project_root)?)
+            .arg("checkout")
             .arg(&self.branch);
         run_cmd(&mut cmd)
     }

--- a/docs/src/api/config-yaml.md
+++ b/docs/src/api/config-yaml.md
@@ -28,7 +28,7 @@ rust:
 	branch: main
 	manifest-path: crates/my-api/Cargo.toml
 ```
-In this case, the `ubrn checkout` command will clone the given repo with the branch/ref into the `rust_modules` directory of the project.
+In this case, the `ubrn checkout` command will clone the given repo with the branch/ref into the `rust_modules` directory of the project. Note that instead of `branch` you can also use `rev` or `ref`.
 
 If run a second time, no overwriting will occur.
 


### PR DESCRIPTION
This fixes #114 by:

* Performing a shallow clone if the directory doesn't already exist
* Using a combination of `git fetch` and `git checkout` to shallowly check out the supplied branch

This unintentionally also fixes #113 because the git commands used work for both refs and SHAs.