### PR TITLE
Build for selected Android targets

### DIFF
--- a/crates/ubrn_cli/src/android.rs
+++ b/crates/ubrn_cli/src/android.rs
@@ -124,16 +124,10 @@ pub(crate) struct AndroidArgs {
     /// `config.yaml` file.
     ///
     /// Android:
-    ///   aarch64-linux-android,
-    ///   armv7-linux-androideabi,
-    ///   x86_64-linux-android
-    ///   i686-linux-android,
+    ///   aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android,
     ///
     /// Synonyms for:
-    ///   arm64-v8a,
-    ///   armeabi-v7a,
-    ///   x86_64,
-    ///   x86
+    ///   arm64-v8a,armeabi-v7a,x86_64,x86
     #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ',')]
     pub(crate) targets: Vec<Target>,
 
@@ -148,15 +142,9 @@ pub(crate) struct AndroidArgs {
 impl AndroidArgs {
     pub(crate) fn build(&self) -> Result<Vec<Utf8PathBuf>> {
         let config: ProjectConfig = self.project_config()?;
-
-        let crate_ = &config.crate_;
-
         let android = &config.android;
-        let target_list = if !self.targets.is_empty() {
-            &self.targets
-        } else {
-            &android.targets
-        };
+        let target_list = &android.targets;
+        let crate_ = &config.crate_;
         let target_files = if self.common_args.no_cargo {
             let files = self.find_existing(&crate_.metadata()?, target_list);
             if !files.is_empty() {
@@ -280,11 +268,12 @@ impl AndroidArgs {
     }
 
     pub(crate) fn project_config(&self) -> Result<ProjectConfig> {
-        self.config.clone().try_into()
-    }
-
-    pub(crate) fn config(&self) -> Utf8PathBuf {
-        self.config.clone()
+        let mut config: ProjectConfig = self.config.clone().try_into()?;
+        let android = &mut config.android;
+        if !self.targets.is_empty() {
+            android.targets = self.targets.clone();
+        }
+        Ok(config)
     }
 }
 

--- a/crates/ubrn_cli/src/codegen/templates/build.gradle
+++ b/crates/ubrn_cli/src/codegen/templates/build.gradle
@@ -67,6 +67,13 @@ android {
         arguments '-DANDROID_STL=c++_shared'
       }
     }
+    ndk {
+      abiFilters {# space #}
+      {%- for t in self.config.project.android.targets -%}
+      "{{ t }}"
+      {%- if !loop.last %}, {% endif %}
+      {%- endfor %}
+    }
   }
 
   externalNativeBuild {

--- a/crates/ubrn_cli/src/config/mod.rs
+++ b/crates/ubrn_cli/src/config/mod.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 
 use crate::{android::AndroidConfig, ios::IOsConfig, rust::CrateConfig, workspace};
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ProjectConfig {
     #[serde(default = "ProjectConfig::default_name")]
@@ -111,7 +111,7 @@ impl ProjectConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BindingsConfig {
     #[serde(default = "BindingsConfig::default_cpp_dir")]
@@ -153,7 +153,7 @@ impl BindingsConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TurboModulesConfig {
     #[serde(default = "TurboModulesConfig::default_cpp_dir")]

--- a/crates/ubrn_cli/src/ios.rs
+++ b/crates/ubrn_cli/src/ios.rs
@@ -109,9 +109,7 @@ pub(crate) struct IOsArgs {
     /// the `config.yaml` file.
     ///
     /// iOS:
-    ///  aarch64-apple-ios,
-    ///  aarch64-apple-ios-sim,
-    ///  x86_64-apple-ios
+    ///  aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
     #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ',')]
     pub(crate) targets: Vec<Target>,
 
@@ -124,12 +122,7 @@ impl IOsArgs {
         let config = self.project_config()?;
         let crate_ = &config.crate_;
         let ios = &config.ios;
-
-        let target_list = if !self.targets.is_empty() {
-            &self.targets
-        } else {
-            &ios.targets
-        };
+        let target_list = &ios.targets;
 
         let targets = target_list
             .iter()
@@ -291,11 +284,12 @@ impl IOsArgs {
     }
 
     pub(crate) fn project_config(&self) -> Result<ProjectConfig> {
-        self.config.clone().try_into()
-    }
-
-    pub(crate) fn config(&self) -> Utf8PathBuf {
-        self.config.clone()
+        let mut config: ProjectConfig = self.config.clone().try_into()?;
+        let ios = &mut config.ios;
+        if !self.targets.is_empty() {
+            ios.targets = self.targets.clone();
+        }
+        Ok(config)
     }
 }
 

--- a/crates/ubrn_cli/src/main.rs
+++ b/crates/ubrn_cli/src/main.rs
@@ -50,3 +50,9 @@ impl TryFrom<Utf8PathBuf> for ProjectConfig {
         ubrn_common::read_from_file(value)
     }
 }
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Platform {
+    Android,
+    Ios,
+}

--- a/crates/ubrn_cli/src/rust.rs
+++ b/crates/ubrn_cli/src/rust.rs
@@ -12,7 +12,7 @@ use ubrn_common::CrateMetadata;
 
 use crate::{repo::GitRepoArgs, workspace};
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CrateConfig {
     #[serde(default = "CrateConfig::default_project_root", skip)]
@@ -54,14 +54,14 @@ impl CrateConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum RustSource {
     OnDisk(OnDiskArgs),
     GitRepo(GitRepoArgs),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct OnDiskArgs {
     #[serde(alias = "rust", alias = "directory")]
     pub(crate) src: String,

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -92,6 +92,9 @@ where
     for<'a> T: Deserialize<'a>,
 {
     let file = file.as_ref();
+    if !file.exists() {
+        anyhow::bail!("File {file} does not exist");
+    }
     let s =
         std::fs::read_to_string(file).with_context(|| format!("Failed to read from {file:?}"))?;
     Ok(if is_yaml(file) {

--- a/docs/src/getting-started/guide.md
+++ b/docs/src/getting-started/guide.md
@@ -191,6 +191,14 @@ Building for Android will:
 yarn ubrn:android
 ```
 
+```admonish hint
+You can change the targets that get built by adding a comma separated list to the `ubrn build android` and `ubrn build ios` commands.
+```
+
+```sh
+yarn ubrn:android --targets aarch64-linux-android,armv7-linux-androideabi
+```
+
 ## Step 5: Write an example app exercising the Rust API
 
 Here, we're editing the app file at `example/src/App.tsx`.

--- a/docs/src/reference/commandline.md
+++ b/docs/src/reference/commandline.md
@@ -101,7 +101,9 @@ Options:
 
 `--release` sets the release profile for `cargo`.
 
-`--and-generate` is a convenience option to pass the built library file to `generate bindings` and `generate turbo-module`.
+`--and-generate` is a convenience option to pass the built library file to `generate bindings` and `generate turbo-module` for Android and common files.
+
+This is useful as some generated files use the targets specified in this command.
 
 Once the library files (one for each target) are created, they are copied into the `jniLibs` specified by the YAML configuration.
 
@@ -174,7 +176,9 @@ The configuration file refers to [the YAML configuration][config].
 
 `--sim-only` and `--no-sim` restricts the targets to targets with/without `sim` in the target triple.
 
-`--and-generate` is a convenience option to pass the built library file to `generate bindings` and `generate turbo-module`.
+`--and-generate` is a convenience option to pass the built library file to `generate bindings` and `generate turbo-module` for iOS and common files.
+
+This is useful as some generated files use the targets specified in this command.
 
 Once the target libraries are compiled, and a config file is specified, they are passed to `xcodebuild -create-xcframework` to generate an `xcframework`.
 


### PR DESCRIPTION
Fixes #106

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This issue is conceptually simple: we need to add one line to the `build.gradle` template.

Driving that line in the file is data about the targets being built.

`targets` comes from the `ProjectConfig` (a.k.a. `ubrn.config.yaml`), which makes this straightforward.

HOWEVER, `--targets` can be used when building!

SO, we can mutate the `ProjectConfig` while we're building.

BUT we don't want the second command overwriting the `build.gradle` so carefully specified in the first.

```sh
ubrn build android --and-generate --config ubrn.config.yaml --targets aarch64-linux-android,armv7-linux-androideabi

ubrn build ios --and-generate --config ubrn.config.yaml
```

THIS MEANT: adding platform specificity to the each of the generated files.

Drive-by Review also requested from @Johennes , if interested.