### PR TITLE
Fix tag checkouts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,8 @@ jobs:
         run: cargo xtask bootstrap
       - name: Run tests of generated bindings
         run: ./scripts/run-tests.sh
+      - name: Run tests for checkout command
+        run: ./scripts/run-checkout-tests.sh
 
       - name: Done
         run: echo "Success!"

--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -84,7 +84,8 @@ impl GitRepoArgs {
             .current_dir(self.directory(project_root)?)
             .arg("ls-remote")
             .arg("origin")
-            .arg(&self.branch).output()?;
+            .arg(&self.branch)
+            .output()?;
         let output = String::from_utf8(output.stdout)?;
 
         // Find $branch in the output and resolve the SHA or fall back to $branch

--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -89,16 +89,17 @@ impl GitRepoArgs {
         let output = String::from_utf8(output.stdout)?;
 
         // Find $branch in the output and resolve the SHA or fall back to $branch
-        let mut sha = None;
         let branch_ref = format!("refs/heads/{}", &self.branch);
         let tag_ref = format!("refs/tags/{}", &self.branch);
-        for line in output.lines() {
-            if line.ends_with(&branch_ref) || line.ends_with(&tag_ref) {
-                sha = Some(line.split_whitespace().next().unwrap());
-                break;
-            }
-        }
-        let sha = sha.unwrap_or(&self.branch);
+        let sha = output
+            .lines()
+            .find(|line| line.ends_with(&branch_ref) || line.ends_with(&tag_ref))
+            .map(|line| {
+                line.split_whitespace()
+                    .next()
+                    .expect("Git lines have sha then space")
+            })
+            .unwrap_or(&self.branch);
 
         // git fetch --depth 1 origin $sha
         let mut cmd = Command::new("git");

--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -79,21 +79,41 @@ impl GitRepoArgs {
             run_cmd(&mut cmd)?;
         }
 
-        // git fetch --depth 1 origin $branch
+        // git ls-remote origin $branch
+        let output = Command::new("git")
+            .current_dir(self.directory(project_root)?)
+            .arg("ls-remote")
+            .arg("origin")
+            .arg(&self.branch).output()?;
+        let output = String::from_utf8(output.stdout)?;
+
+        // Find $branch in the output and resolve the SHA or fall back to $branch
+        let mut sha = None;
+        let branch_ref = format!("refs/heads/{}", &self.branch);
+        let tag_ref = format!("refs/tags/{}", &self.branch);
+        for line in output.lines() {
+            if line.ends_with(&branch_ref) || line.ends_with(&tag_ref) {
+                sha = Some(line.split_whitespace().next().unwrap());
+                break;
+            }
+        }
+        let sha = sha.unwrap_or(&self.branch);
+
+        // git fetch --depth 1 origin $sha
         let mut cmd = Command::new("git");
         cmd.current_dir(self.directory(project_root)?)
             .arg("fetch")
             .arg("--depth")
             .arg("1")
             .arg("origin")
-            .arg(&self.branch);
+            .arg(sha);
         run_cmd(&mut cmd)?;
 
-        // git checkout $branch
+        // git checkout $sha
         let mut cmd = Command::new("git");
         cmd.current_dir(self.directory(project_root)?)
             .arg("checkout")
-            .arg(&self.branch);
+            .arg(sha);
         run_cmd(&mut cmd)
     }
 }

--- a/scripts/run-checkout-tests.sh
+++ b/scripts/run-checkout-tests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -e
+
+ubrn=./bin/cli
+
+function clean_up {
+  rm -rf rust_modules
+}
+
+function announce {
+  echo "[TEST] $1"
+}
+
+rc=0
+
+function assert_eq {
+  if [[ $1 == $2 ]]; then
+    echo "✅ OK"
+  else
+    echo "❌ FAILURE: '$1' != '$2'"
+    rc=1
+  fi
+}
+
+clean_up
+
+announce "checkout with default"
+"$ubrn" checkout https://github.com/actions/checkout
+pushd rust_modules/checkout
+assert_eq $(git ls-remote --heads origin | grep refs/heads/main | cut -f1) $(git rev-parse HEAD)
+popd
+
+clean_up
+
+announce "checkout with branch"
+"$ubrn" checkout https://github.com/actions/checkout --branch releases/v1
+pushd rust_modules/checkout
+assert_eq $(git ls-remote --heads origin | grep refs/heads/releases/v1 | cut -f1) $(git rev-parse HEAD)
+popd
+
+clean_up
+
+announce "checkout with tag"
+"$ubrn" checkout https://github.com/actions/checkout --branch v4.0.0
+pushd rust_modules/checkout
+assert_eq $(git ls-remote --tags origin | grep refs/tags/v4.0.0 | cut -f1) $(git rev-parse HEAD)
+popd
+
+clean_up
+
+announce "checkout with sha"
+"$ubrn" checkout https://github.com/actions/checkout --branch c533a0a4cfc4962971818edcfac47a2899e69799
+pushd rust_modules/checkout
+assert_eq c533a0a4cfc4962971818edcfac47a2899e69799 $(git rev-parse HEAD)
+popd
+
+clean_up
+
+announce "update checkout from sha to sha"
+"$ubrn" checkout https://github.com/actions/checkout --branch c533a0a4cfc4962971818edcfac47a2899e69799
+"$ubrn" checkout https://github.com/actions/checkout --branch 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd
+pushd rust_modules/checkout
+assert_eq 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd $(git rev-parse HEAD)
+popd
+
+clean_up
+
+announce "update checkout from tag to sha"
+"$ubrn" checkout https://github.com/actions/checkout --branch v4.0.0
+"$ubrn" checkout https://github.com/actions/checkout --branch 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd
+pushd rust_modules/checkout
+assert_eq 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd $(git rev-parse HEAD)
+popd
+
+clean_up
+
+exit $rc


### PR DESCRIPTION
Unfortunately dealing with tags and branches in shallow clones turned out more involved than I thought. This change uses `git ls-remote` to determine the SHA of a branch or tag without fetching the entire history.

In case it helps, I've used the following (dumb) script to test my changes:

```bash
#!/usr/bin/env bash

set -e

ubrn=./bin/cli

function clean_up {
  rm -rf rust_modules
}

function announce {
  echo "[TEST] $1"
}

rc=0

function assert_eq {
  if [[ $1 == $2 ]]; then
    echo "✅ OK"
  else
    echo "❌ FAILURE: '$1' != '$2'"
    rc=1
  fi
}

clean_up

announce "checkout with default"
"$ubrn" checkout https://github.com/actions/checkout
pushd rust_modules/checkout
assert_eq $(git ls-remote --heads origin | grep refs/heads/main | cut -f1) $(git rev-parse HEAD)
popd

clean_up

announce "checkout with branch"
"$ubrn" checkout https://github.com/actions/checkout --branch releases/v1
pushd rust_modules/checkout
assert_eq $(git ls-remote --heads origin | grep refs/heads/releases/v1 | cut -f1) $(git rev-parse HEAD)
popd

clean_up

announce "checkout with tag"
"$ubrn" checkout https://github.com/actions/checkout --branch v4.0.0
pushd rust_modules/checkout
assert_eq $(git ls-remote --tags origin | grep refs/tags/v4.0.0 | cut -f1) $(git rev-parse HEAD)
popd

clean_up

announce "checkout with sha"
"$ubrn" checkout https://github.com/actions/checkout --branch c533a0a4cfc4962971818edcfac47a2899e69799
pushd rust_modules/checkout
assert_eq c533a0a4cfc4962971818edcfac47a2899e69799 $(git rev-parse HEAD)
popd

clean_up

announce "update checkout from sha to sha"
"$ubrn" checkout https://github.com/actions/checkout --branch c533a0a4cfc4962971818edcfac47a2899e69799
"$ubrn" checkout https://github.com/actions/checkout --branch 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd
pushd rust_modules/checkout
assert_eq 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd $(git rev-parse HEAD)
popd

clean_up

announce "update checkout from tag to sha"
"$ubrn" checkout https://github.com/actions/checkout --branch v4.0.0
"$ubrn" checkout https://github.com/actions/checkout --branch 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd
pushd rust_modules/checkout
assert_eq 2d7d9f7ff5b310f983d059b68785b3c74d8b8edd $(git rev-parse HEAD)
popd

clean_up

exit $rc
```

Fixes: #118