### PR TITLE
Allow turbo-modules with names with @my-org/project-name

### DIFF
--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -327,7 +327,7 @@ mod files {
     templated_file!(PodspecTemplate, "module-template.podspec");
     impl RenderedFile for PodspecTemplate {
         fn path(&self, project_root: &Utf8Path) -> Utf8PathBuf {
-            let name = self.config.project.raw_name();
+            let name = self.config.project.cpp_filename();
             let filename = format!("{name}.podspec");
             project_root.join(filename)
         }

--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -327,7 +327,7 @@ mod files {
     templated_file!(PodspecTemplate, "module-template.podspec");
     impl RenderedFile for PodspecTemplate {
         fn path(&self, project_root: &Utf8Path) -> Utf8PathBuf {
-            let name = self.config.project.cpp_filename();
+            let name = self.config.project.podspec_filename();
             let filename = format!("{name}.podspec");
             project_root.join(filename)
         }

--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -30,8 +30,7 @@ include_directories(
     ${UNIFFI_BINDGEN_PATH}/cpp/includes
 )
 
-add_library(
-    ${CMAKE_PROJECT_NAME} SHARED
+add_library({{ self.config.project.cpp_filename() }}            SHARED
     {{ tm_dir }}/{{ self.config.project.cpp_filename() }}.cpp
     {%- for m in self.config.modules %}
     {{ bindings_dir }}/{{ m.cpp_filename() }}
@@ -63,7 +62,7 @@ find_package(fbjni REQUIRED CONFIG)
 find_library(LOGCAT log)
 
 target_link_libraries(
-  ${CMAKE_PROJECT_NAME}
+  {{ self.config.project.cpp_filename() }}
   fbjni::fbjni
   ReactAndroid::jsi
   ReactAndroid::turbomodulejsijni

--- a/crates/ubrn_cli/src/codegen/templates/module-template.podspec
+++ b/crates/ubrn_cli/src/codegen/templates/module-template.podspec
@@ -5,7 +5,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
-  s.name         = "{{ self.config.project.raw_name() }}"
+  s.name         = "{{ self.config.project.cpp_filename() }}"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]

--- a/crates/ubrn_cli/src/config/mod.rs
+++ b/crates/ubrn_cli/src/config/mod.rs
@@ -127,6 +127,10 @@ impl ProjectConfig {
         self.raw_name().to_kebab_case()
     }
 
+    pub(crate) fn podspec_filename(&self) -> String {
+        self.cpp_filename()
+    }
+
     pub(crate) fn codegen_filename(&self) -> String {
         format!("Native{}", self.spec_name())
     }

--- a/crates/ubrn_cli/src/config/mod.rs
+++ b/crates/ubrn_cli/src/config/mod.rs
@@ -76,13 +76,31 @@ pub(crate) fn trim_react_native(name: &str) -> String {
         .to_string()
 }
 
+pub(crate) fn org_and_name(name: &str) -> (Option<&str>, &str) {
+    if let Some((left, right)) = name.split_once('/') {
+        let org = left.strip_prefix('@').unwrap_or(left);
+        (Some(org), right)
+    } else {
+        (None, name)
+    }
+}
+
+pub(crate) fn lower(s: &str) -> String {
+    s.to_upper_camel_case().to_lowercase()
+}
+
 impl ProjectConfig {
     pub(crate) fn project_root(&self) -> &Utf8Path {
         &self.crate_.project_root
     }
 
     pub(crate) fn module_cpp(&self) -> String {
-        trim_react_native(&self.name).to_upper_camel_case()
+        let (org, name) = org_and_name(&self.name);
+        if org.is_some() {
+            name.to_upper_camel_case()
+        } else {
+            trim_react_native(name).to_upper_camel_case()
+        }
     }
 }
 
@@ -96,9 +114,12 @@ impl ProjectConfig {
     }
 
     pub(crate) fn cpp_namespace(&self) -> String {
-        trim_react_native(&self.name)
-            .to_upper_camel_case()
-            .to_lowercase()
+        let (org, name) = org_and_name(&self.name);
+        if let Some(org) = org {
+            format!("{}_{}", lower(org), lower(name))
+        } else {
+            lower(&trim_react_native(name))
+        }
     }
 
     pub(crate) fn cpp_filename(&self) -> String {
@@ -111,7 +132,7 @@ impl ProjectConfig {
     }
 
     pub(crate) fn spec_name(&self) -> String {
-        trim_react_native(&self.name).to_upper_camel_case()
+        self.module_cpp()
     }
 
     pub(crate) fn exclude_files(&self) -> &GlobSet {

--- a/crates/ubrn_cli/src/config/npm.rs
+++ b/crates/ubrn_cli/src/config/npm.rs
@@ -4,8 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-use heck::ToUpperCamelCase;
 use serde::Deserialize;
+
+use crate::config::{lower, org_and_name};
 
 use super::{trim, trim_react_native};
 
@@ -34,14 +35,16 @@ impl PackageJson {
             .android
             .java_package_name
             .clone()
-            .unwrap_or_else(|| {
-                format!(
-                    "com.{}",
-                    trim_react_native(&self.name)
-                        .to_upper_camel_case()
-                        .to_lowercase()
-                )
-            })
+            .unwrap_or_else(|| self.default_android_package_name())
+    }
+
+    fn default_android_package_name(&self) -> String {
+        let (org, name) = org_and_name(&self.name);
+        if let Some(org) = org {
+            format!("com.{}.{}", lower(org), lower(name))
+        } else {
+            format!("com.{}", lower(&trim_react_native(name)))
+        }
     }
 
     pub(crate) fn repo(&self) -> &PackageJsonRepo {

--- a/integration/fixtures/turbo-module-testing/App.tsx
+++ b/integration/fixtures/turbo-module-testing/App.tsx
@@ -1,0 +1,56 @@
+import { StyleSheet, View, Text } from "react-native";
+import { multiply } from "react-native-by-hand";
+import {
+  Calculator,
+  type BinaryOperator,
+  SafeAddition,
+  ComputationResult,
+} from "../../src";
+
+// A Rust object
+const calculator = new Calculator();
+// A Rust object implementing the Rust trait BinaryOperator
+const addOp = new SafeAddition();
+
+// A Typescript class, implementing BinaryOperator
+class SafeMultiply implements BinaryOperator {
+  perform(lhs: bigint, rhs: bigint): bigint {
+    return lhs * rhs;
+  }
+}
+const multOp = new SafeMultiply();
+
+// bigints
+const three = 3n;
+const seven = 7n;
+
+// Perform the calculation, and to get an object
+// representing the computation result.
+const computation: ComputationResult = calculator
+  .calculate(addOp, three, three)
+  .calculateMore(multOp, seven)
+  .lastResult()!;
+
+// Unpack the bigint value into a string.
+const result = computation.value.toString();
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Result: {result}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  box: {
+    width: 60,
+    height: 60,
+    marginVertical: 20,
+  },
+});

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -374,50 +374,50 @@ run_default() {
   local config="$fixture_dir/ubrn.config.yaml"
   local app_tsx="$fixture_dir/App.tsx"
   main \
-        --force-new-directory \
-        --keep-directory-on-exit \
-        --ubrn-config "$config" \
-        --builder-bob-version 0.35.1 \
-        --skip-ios \
-        --skip-android \
-        --slug dummy-lib \
-        "$working_dir/dummy-lib"
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --skip-android \
+    --slug dummy-lib \
+    "$working_dir/dummy-lib"
   main \
-        --force-new-directory \
-        --keep-directory-on-exit \
-        --ubrn-config "$config" \
-        --builder-bob-version 0.35.1 \
-        --skip-ios \
-        --skip-android \
-        --slug rn-dummy-lib \
-        "$working_dir/rn-dummy-lib"
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --skip-android \
+    --slug rn-dummy-lib \
+    "$working_dir/rn-dummy-lib"
   main \
-        --force-new-directory \
-        --keep-directory-on-exit \
-        --ubrn-config "$config" \
-        --builder-bob-version 0.35.1 \
-        --skip-ios \
-        --skip-android \
-        --slug react-native-dummy-lib \
-        "$working_dir/react-native-dummy-lib"
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --skip-android \
+    --slug react-native-dummy-lib \
+    "$working_dir/react-native-dummy-lib"
   main \
-        --force-new-directory \
-        --keep-directory-on-exit \
-        --ubrn-config "$config" \
-        --builder-bob-version 0.35.1 \
-        --skip-ios \
-        --skip-android \
-        --slug dummy-lib-react-native \
-        "$working_dir/dummy-lib-react-native"
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --skip-android \
+    --slug dummy-lib-react-native \
+    "$working_dir/dummy-lib-react-native"
   main \
-        --force-new-directory \
-        --keep-directory-on-exit \
-        --ubrn-config "$config" \
-        --builder-bob-version 0.35.1 \
-        --skip-ios \
-        --skip-android \
-        --slug dummy-lib-react-native \
-        "$working_dir/dummy-lib-rn"
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --skip-android \
+    --slug dummy-lib-react-native \
+    "$working_dir/dummy-lib-rn"
   # ReactNativeDummyLib fails with "› Must be a valid npm package name"
   main \
     --force-new-directory \

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -229,6 +229,7 @@ check_lines() {
   check_line_unchanged "./src/Native*" "getEnforcing"
 
   check_line_unchanged "./android/CMakeLists.txt" "^project"
+  check_line_unchanged "./android/CMakeLists.txt" "^add_library.*SHARED"
   check_line_unchanged "./android/build.gradle" "return rootProject"
   check_line_unchanged "./android/build.gradle" "libraryName"
   check_line_unchanged "./android/src/*/*Package*" "package"

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -247,10 +247,11 @@ check_lines() {
   check_line_unchanged "./ios/*.mm" "#import \""
   check_line_unchanged "./ios/*.mm" "@implementation"
   check_line_unchanged "./ios/*.mm" "::multiply"
+  check_line_unchanged "./*.podspec" "s.name"
 }
 
 clean_turbo_modules() {
-  rm -Rf cpp/ android/src/main/java ios/ src/Native* src/generated/ src/index.ts*
+  rm -Rf cpp/ android/src/main/java ios/ src/Native* src/generated/ src/index.ts* ./*.podspec
 }
 
 generate_turbo_module_for_diffing() {
@@ -401,6 +402,51 @@ run_default() {
         --slug dummy-lib-react-native \
         "$working_dir/dummy-lib-rn"
   # ReactNativeDummyLib fails with "› Must be a valid npm package name"
+  main \
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --skip-android \
+    --slug @my-org/react-native-dummy-lib \
+    "$working_dir/@my-org/react-native-dummy-lib"
+  main \
+      --force-new-directory \
+      --keep-directory-on-exit \
+      --ubrn-config "$config" \
+      --builder-bob-version 0.35.1 \
+      --skip-ios \
+      --skip-android \
+      --slug @my-org/dummy-lib \
+      "$working_dir/@my-org/dummy-lib"
+  main \
+      --force-new-directory \
+      --keep-directory-on-exit \
+      --ubrn-config "$config" \
+      --builder-bob-version 0.35.1 \
+      --skip-ios \
+      --skip-android \
+      --slug @react-native/dummy-lib \
+      "$working_dir/@react-native/dummy-lib"
+  main \
+      --force-new-directory \
+      --keep-directory-on-exit \
+      --ubrn-config "$config" \
+      --builder-bob-version 0.35.1 \
+      --skip-ios \
+      --skip-android \
+      --slug @react-native-org/dummy-lib \
+      "$working_dir/@react-native-org/dummy-lib"
+  main \
+      --force-new-directory \
+      --keep-directory-on-exit \
+      --ubrn-config "$config" \
+      --builder-bob-version 0.35.1 \
+      --skip-ios \
+      --skip-android \
+      --slug @react-native/dummy-lib \
+      "$working_dir/@react-native/react-native-lib"
   local os
   os=$(uname -o)
   if [ "$os" == "Darwin" ] ; then
@@ -413,6 +459,15 @@ run_default() {
         --skip-android \
         --ios-name DummyLibForIos \
         "$working_dir/react-native-dummy-lib-for-ios"
+    main \
+      --force-new-directory \
+      --keep-directory-on-exit \
+      --ubrn-config "$config" \
+      --builder-bob-version 0.35.1 \
+      --skip-android \
+      --ios-name ReactNativeDummyLibForIos \
+      --slug @my-org/react-native-dummy-lib-for-ios \
+      "$working_dir/@my-org/react-native-dummy-lib-for-ios"
   fi
   main \
     --force-new-directory \
@@ -422,6 +477,14 @@ run_default() {
     --slug react-native-dummy-lib-for-android \
     --skip-ios \
     "$working_dir/react-native-dummy-lib-for-android"
+  main \
+    --force-new-directory \
+    --keep-directory-on-exit \
+    --ubrn-config "$config" \
+    --builder-bob-version 0.35.1 \
+    --skip-ios \
+    --slug @my-org/react-native-dummy-lib-for-android \
+    "$working_dir/@my-org/react-native-dummy-lib-for-android"
 }
 
 derive_paths


### PR DESCRIPTION
Fixes #124 

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This adds to the tests introduced in #123 to support names with an org name.