### PR TITLE
Silence git checkout warnings

### DIFF
--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -111,10 +111,11 @@ impl GitRepoArgs {
             .arg(sha);
         run_cmd(&mut cmd)?;
 
-        // git checkout $sha
+        // git checkout --quiet $sha
         let mut cmd = Command::new("git");
         cmd.current_dir(self.directory(project_root)?)
             .arg("checkout")
+            .arg("--quiet") // Suppress detached head and dangling commit warnings
             .arg(sha);
         run_cmd(&mut cmd)
     }

--- a/crates/ubrn_cli/src/repo.rs
+++ b/crates/ubrn_cli/src/repo.rs
@@ -123,7 +123,7 @@ impl GitRepoArgs {
             .arg(sha);
         run_cmd(&mut cmd)?;
 
-        // git checkout --quiet $sha
+        // git checkout $sha
         let mut cmd = Command::new("git");
         cmd.current_dir(self.directory(project_root)?)
             .arg("checkout")


### PR DESCRIPTION
This silences the `git checkout` warnings. I wasn't sure if you wanted to remove output from the other git commands, too?

Fixes: #126