### PR TITLE
Split CI into several jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   lint:
-    name: Lint
+    name: 🔍 Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
         run: cargo xtask fmt --check rust
 
   build:
-    name: Build
+    name: 🏗️ Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
         run: cargo build --verbose
 
   unit-tests:
-    name: Unit tests
+    name: 🧪 Unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
         run: cargo test --verbose
 
   integration-tests-generation:
-    name: Integration tests (generation)
+    name: 🧩 Integration tests (generation)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
         run: ./scripts/run-tests.sh
 
   integration-tests-checkout:
-    name: Integration tests (checkout)
+    name: 🧩 Integration tests (checkout)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint, build & test
+name: CI
 
 on:
   push:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Lint, build & test
 
 on:
   push:
@@ -10,39 +10,62 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Build
-      - name: Build
-        run: cargo build --verbose
 
-      # Install tooling
       - name: Install clang-format
         run: sudo apt-get install -y clang-format
+
       - name: Install yarn
         run: cargo xtask bootstrap yarn
 
-      # Lint
       - name: Check Typescript format
         run: cargo xtask fmt --check typescript
+
       - name: Check Rust format
         run: cargo xtask fmt --check rust
 
-      # Unit tests
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: cargo build --verbose
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Run tests
         run: cargo test --verbose
 
-      # Integration tests
+  integration-tests-generation:
+    name: Integration tests (generation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Install tooling for building C++
         run: sudo apt-get install -y cmake ninja-build
+
       - name: Installing hermes and test-runner
         run: cargo xtask bootstrap
+
       - name: Run tests of generated bindings
         run: ./scripts/run-tests.sh
+
+  integration-tests-checkout:
+    name: Integration tests (checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Run tests for checkout command
         run: ./scripts/run-checkout-tests.sh
-
-      - name: Done
-        run: echo "Success!"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/ci.yml/badge.svg)](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/ci.yml)
+
 # uniffi-bindgen-react-native
 [UniFFI](https://mozilla.github.io/uniffi-rs/latest/) is a multi-language bindings generator for Rust.
 


### PR DESCRIPTION
I noticed that the CI job takes quite long but most of the time is spent in the code generation tests. This splits up the one job into several which gives better progress visualization and faster status feedback on PRs.

I guess I got carried away a little with the emoji. 😅 They didn't turn out as fancy as I thought though. Maybe you have better ideas or otherwise I can just remove them again.

While at it, I also added a status badge in the `README`.