### PR TITLE
Default to x86_64-apple-ios if ubrn is built for x86

### DIFF
--- a/crates/ubrn_cli/src/ios.rs
+++ b/crates/ubrn_cli/src/ios.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-use std::{collections::HashMap, fmt::Display, process::Command, str::FromStr};
+use std::{collections::HashMap, env::consts::ARCH, fmt::Display, process::Command, str::FromStr};
 
 use anyhow::{Context, Error, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -66,7 +66,12 @@ impl IOsConfig {
     }
 
     fn default_targets() -> Vec<Target> {
-        let args: &[&str] = &["aarch64-apple-ios", "aarch64-apple-ios-sim"];
+        let sim_target = if ARCH.starts_with("x86") {
+            "x86_64-apple-ios"
+        } else {
+            "aarch64-apple-ios-sim"
+        };
+        let args: &[&str] = &["aarch64-apple-ios", sim_target];
         args.iter().map(|s| Target::from_str(s).unwrap()).collect()
     }
 }


### PR DESCRIPTION
This adds `x86_64-apple-ios` rather than `aarch64-apple-ios-sim` to the default targets on iOS if UBRN itself was built for x86.

Given that x86 Macs are slowly becoming extinct, I think, it may not be worth to include both targets by default because it'll result in a lot of pointless compilation.

I believe the `ARCH` value is baked in at compile time. So this may not work correctly in some edge cases. @trevoranderson, maybe you could give this a test on your Intel Mac?

Fixes: #134