### PR TITLE
Support abortController.abort() call after the future has finished

### DIFF
--- a/fixtures/futures/tests/bindings/test_futures.ts
+++ b/fixtures/futures/tests/bindings/test_futures.ts
@@ -497,6 +497,42 @@ function checkRemainingFutures(t: Asserts) {
   );
 
   await asyncTest(
+    "future method… which is cancelled after it is resolved",
+    async (t) => {
+      const abortController = new AbortController();
+      const expected = await fallibleMe(false, {
+        signal: abortController.signal,
+      });
+      t.assertEqual(expected, 42);
+      // Now we cancel, but after the task has been resolved.
+      // This should do so cleanly.
+      abortController.abort();
+      // Are we still here? Then we pass.
+      t.end();
+    },
+  );
+
+  await asyncTest(
+    "future method… which is cancelled after it is rejected",
+    async (t) => {
+      const abortController = new AbortController();
+      try {
+        await fallibleMe(true, {
+          signal: abortController.signal,
+        });
+        t.fail("We should have failed here. This is not the test.");
+      } catch (e: any) {
+        // OK
+      }
+      // Now we cancel, but after the task has been rejected.
+      // This should do so cleanly.
+      abortController.abort();
+      // Are we still here? Then we pass.
+      t.end();
+    },
+  );
+
+  await asyncTest(
     "a future that uses a lock and that is not cancelled",
     async (t) => {
       const task1 = useSharedResource(


### PR DESCRIPTION
Fixes #144.

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

If an `AbortSignal` is passed to a Promise returning function, and the promise returns then this should do nothing.

This commit unregister the AbortSignal callback after the Promise has been resolved or rejected.

This does not need any additional documentation.