### PR TITLE
Update for react-native 0.76

### DIFF
--- a/crates/ubrn_cli/src/android.rs
+++ b/crates/ubrn_cli/src/android.rs
@@ -67,7 +67,12 @@ impl AndroidConfig {
     }
 
     fn default_platform() -> usize {
-        21
+        // This is minSdkVersion supported for 0.75.4
+        // For 0.76, this increases to 24.
+        // While we still support 0.75.4, we should not raise this.
+        // If users want to raise this, they can change the platform in the
+        // ubrn.config.yaml.
+        23
     }
 
     fn default_directory() -> String {

--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -57,16 +57,33 @@ cmake_path(
 add_library(my_rust_lib STATIC IMPORTED)
 set_target_properties(my_rust_lib PROPERTIES IMPORTED_LOCATION ${MY_RUST_LIB})
 
+# Add ReactAndroid libraries, being careful to account for different versions.
 find_package(ReactAndroid REQUIRED CONFIG)
-find_package(fbjni REQUIRED CONFIG)
 find_library(LOGCAT log)
 
+# REACTNATIVE_MERGED_SO seems to be only be set in a build.gradle.kt file,
+# which we don't use. Thus falling back to version number sniffing.
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  set(REACTNATIVE_MERGED_SO true)
+endif()
+
+# https://github.com/react-native-community/discussions-and-proposals/discussions/816
+# This if-then-else can be removed once this library does not support version below 0.76
+if (REACTNATIVE_MERGED_SO)
+  target_link_libraries({{ self.config.project.cpp_filename() }} ReactAndroid::reactnative)
+else()
+  target_link_libraries({{ self.config.project.cpp_filename() }}
+    ReactAndroid::turbomodulejsijni
+    ReactAndroid::react_nativemodule_core
+  )
+endif()
+
+find_package(fbjni REQUIRED CONFIG)
 target_link_libraries(
   {{ self.config.project.cpp_filename() }}
   fbjni::fbjni
   ReactAndroid::jsi
-  ReactAndroid::turbomodulejsijni
-  ReactAndroid::react_nativemodule_core
   ${LOGCAT}
   my_rust_lib
 )
+{# space #}

--- a/docs/src/guides/getting-started.md
+++ b/docs/src/guides/getting-started.md
@@ -16,10 +16,14 @@ We first use `create-react-native-library` to generate our basic turbo-module li
 npx create-react-native-library@latest my-rust-lib
 ```
 
-```admonish warning title="Builder Bob version drift"
+```admonish warning title="Version drift"
 `create-react-native-library` has changed a few things around recently.
 
 These steps have been tested with `0.35.1` and `0.41.2`, which at time of writing, is the `latest`.
+
+`react-native` also changes from time to time.
+
+These steps have been tested with versions `0.75` and `0.76`, which at time of writing is the `latest`.
 ```
 
 The important bits are:


### PR DESCRIPTION
This PR tests the React Native update to 0.76 and fixes breakages introduced.

Breaking changes:

- We change [the `CMakeLists.txt` to use `libreactnative.so`](https://github.com/react-native-community/discussions-and-proposals/discussions/816). Currently, we're using `externalNativeBuild`, so we're not getting the benefit of the Kotlin gradle plugin to set `REACTNATIVE_MERGED_SO` so we switch on the React Native version.
- The minimum Xcode version increased from `13.0` to `15.1`. This meant upgrading Xcode on my machine, which found some fragility in the `xcrun simctl` and jq scripting in the tests.
- The minimum Android SDK version increased. If we commit to supporting 0.75.4 at the same time as 0.76, then I updated the version passed to `cargo ndk` to what 0.75.4 supports, i.e. 23. This was an increase from 21.
- added documentation in the getting started guide about what version react native is.
