### PR TITLE
Generate nested optionals avoiding degenerate case

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/compounds.rs
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/compounds.rs
@@ -25,10 +25,14 @@ impl OptionalCodeType {
 
 impl CodeType for OptionalCodeType {
     fn type_label(&self, ci: &ComponentInterface) -> String {
-        format!(
-            "{} | undefined",
-            CodeOracle.find(self.inner()).type_label(ci)
-        )
+        let inner = self.inner();
+        let inner_ts = CodeOracle.find(inner).type_label(ci);
+        if !matches!(inner, Type::Optional { .. }) {
+            format!("{inner_ts} | undefined",)
+        } else {
+            // Nested optionals shouldn't degenerate into T | undefined | undefined
+            inner_ts
+        }
     }
 
     fn canonical_name(&self) -> String {

--- a/fixtures/coverall2/src/lib.rs
+++ b/fixtures/coverall2/src/lib.rs
@@ -27,4 +27,22 @@ pub fn identity_array_buffer_forced_read(bytes: Option<Vec<u8>>) -> Option<Vec<u
     bytes
 }
 
+#[uniffi::export]
+pub fn identity_nested_optional(value: Option<Option<String>>) -> Option<Option<String>> {
+    value
+}
+
+#[uniffi::export]
+pub fn match_nested_optional(value: Option<Option<String>>) -> i8 {
+    let Some(inner) = value else {
+        // if value.is_none
+        return 0;
+    };
+    if inner.is_none() {
+        1
+    } else {
+        2
+    }
+}
+
 uniffi::setup_scaffolding!();

--- a/fixtures/coverall2/tests/bindings/test_coverall2.ts
+++ b/fixtures/coverall2/tests/bindings/test_coverall2.ts
@@ -6,6 +6,8 @@
 import {
   identityArrayBuffer,
   identityArrayBufferForcedRead,
+  identityNestedOptional,
+  matchNestedOptional,
   wellKnownArrayBuffer,
 } from "../../generated/uniffi_coverall2";
 import { test } from "@/asserts";
@@ -145,3 +147,14 @@ function arrayBuffer(numBytes: number): ArrayBuffer {
   const array = Uint8Array.from({ length: numBytes }, (_v, i) => i % 255);
   return array.buffer;
 }
+
+test("Test nested optionals", (t) => {
+  t.assertEqual("foo", identityNestedOptional("foo"));
+  t.assertEqual(undefined, identityNestedOptional(undefined));
+
+  // We can model None…
+  t.assertEqual(0, matchNestedOptional(undefined));
+  // …and Some(Some(_))
+  t.assertEqual(2, matchNestedOptional("foo"));
+  // but not Some(None).
+});


### PR DESCRIPTION
`Option<Option<T>>` used to generate `T | undefined | undefined`. This PR removes the second and subsequent `| undefined`s.