### PR TITLE
Fix missing cmakelist libs for android with RN 0.76

### DIFF
--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -61,12 +61,27 @@ find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 find_library(LOGCAT log)
 
-target_link_libraries(
-  {{ self.config.project.cpp_filename() }}
-  fbjni::fbjni
-  ReactAndroid::jsi
-  ReactAndroid::turbomodulejsijni
-  ReactAndroid::react_nativemodule_core
-  ${LOGCAT}
-  my_rust_lib
-)
+# Ideally we would just depend on `REACTNATIVE_MERGED_SO`
+# See https://github.com/react-native-community/discussions-and-proposals/discussions/816
+# For some reason (yet to be determined) we don't have REACTNATIVE_MERGED_SO set here.
+# See https://github.com/react-native-community/discussions-and-proposals/discussions/816#discussioncomment-10659654
+if (REACTNATIVE_MERGED_SO OR ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+    target_link_libraries(
+        {{ self.config.project.cpp_filename() }}
+        fbjni::fbjni
+        ReactAndroid::jsi
+        ReactAndroid::reactnative
+        ${LOGCAT}
+        my_rust_lib
+    )
+else()
+    target_link_libraries(
+        {{ self.config.project.cpp_filename() }}
+        fbjni::fbjni
+        ReactAndroid::jsi
+        ReactAndroid::turbomodulejsijni
+        ReactAndroid::react_nativemodule_core
+        ${LOGCAT}
+        my_rust_lib
+    )
+endif()


### PR DESCRIPTION
When using with RN 0.76 fixes the build error for missing linked libs. Only have tested on android, but shouldn't be a problem for ios.

```
npx create-react-native-library@latest my-rust-lib
```

Both "ReactAndroid::turbomodulejsijni" and "ReactAndroid::react_nativemodule_core" have been removed.