### PR TITLE
Fix the configuration errors in the document about ubrn.config.yaml

### DIFF
--- a/docs/src/reference/config-yaml.md
+++ b/docs/src/reference/config-yaml.md
@@ -70,10 +70,10 @@ android:
 	directory: ./android
 	cargoExtras: []
 	targets:
-	- aarch64-linux-android
-	- armv7-linux-androideabi
-	- i686-linux-android
-	- x86_64-linux-android
+	- arm64-v8a
+	- armeabi-v7a
+	- x86
+	- x86_64
 	apiLevel: 21
 	jniLibs: src/main/jniLibs
 	packageName: <DERIVED FROM package.json>


### PR DESCRIPTION
 There's a problem with the [android](https://jhugman.github.io/uniffi-bindgen-react-native/reference/config-yaml.html#android) configuration in the `ubrn.config.yaml` file in the document.

When I configure android according to the document, the following error occurs:
```bash
# Error: Failed to read "ubrn.config.yaml" as valid YAML

# Caused by:
#     android.targets[0]: unknown variant `aarch64-linux-android`, expected one of `armeabi-v7a`, `arm64-v8a`, `x86`, `x86_64` at line 10 column 5
```
After looking at the [code](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/crates/ubrn_cli/src/android.rs#L135), I found that it does need to be changed to Abi `armeabi-v7a`, `arm64-v8a`, `x86`, `x86_64`.
