### PR TITLE
Fixup tsc build breakage in test_coverall2.ts

### DIFF
--- a/fixtures/coverall2/tests/bindings/test_coverall2.ts
+++ b/fixtures/coverall2/tests/bindings/test_coverall2.ts
@@ -94,32 +94,97 @@ test("array buffer roundtrip with ArrayBufferView", (t) => {
 });
 
 test("array buffer roundtrip with ArrayBufferView of different sizes", (t) => {
-  function rt(ta: ArrayBuffer, slice: ArrayBuffer) {
-    t.assertEqual(slice, identityArrayBuffer(ta), undefined, abEquals);
+  function rt(viewName: string, ta: ArrayBuffer, slice: ArrayBuffer) {
+    t.assertEqual(
+      slice,
+      identityArrayBuffer(ta),
+      `${viewName} didn't match`,
+      abEquals,
+    );
   }
   const base = arrayBuffer(64);
-  for (const TypedArray of [
-    Uint8Array,
-    Uint16Array,
-    Uint32Array,
-    BigUint64Array,
-    Int8Array,
-    Int16Array,
-    Int32Array,
-    BigInt64Array,
-    Float32Array,
-    Float64Array,
-  ]) {
-    const width = TypedArray.BYTES_PER_ELEMENT;
-    for (let length = width; length < base.byteLength; length += width) {
+  const arrayTypes = [
+    {
+      name: "Uint8Array",
+      bytesPerElement: Uint8Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Uint8Array(ab, byteOffset, length),
+    },
+    {
+      name: "Uint16Array",
+      bytesPerElement: Uint16Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Uint16Array(ab, byteOffset, length),
+    },
+    {
+      name: "Uint32Array",
+      bytesPerElement: Uint32Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Uint32Array(ab, byteOffset, length),
+    },
+    {
+      name: "BigUint64Array",
+      bytesPerElement: BigUint64Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new BigUint64Array(ab, byteOffset, length),
+    },
+    {
+      name: "Int8Array",
+      bytesPerElement: Int8Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Int8Array(ab, byteOffset, length),
+    },
+    {
+      name: "Int16Array",
+      bytesPerElement: Int16Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Int16Array(ab, byteOffset, length),
+    },
+    {
+      name: "Int32Array",
+      bytesPerElement: Int32Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Int32Array(ab, byteOffset, length),
+    },
+    {
+      name: "BigInt64Array",
+      bytesPerElement: BigInt64Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new BigInt64Array(ab, byteOffset, length),
+    },
+    {
+      name: "Float32Array",
+      bytesPerElement: Float32Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Float32Array(ab, byteOffset, length),
+    },
+    {
+      name: "Float64Array",
+      bytesPerElement: Float64Array.BYTES_PER_ELEMENT,
+      new: (ab: ArrayBuffer, byteOffset: number, length: number) =>
+        new Float64Array(ab, byteOffset, length),
+    },
+  ];
+  for (const arrayType of arrayTypes) {
+    const bytesPerElement = arrayType.bytesPerElement;
+    const viewName = arrayType.name;
+    for (
+      let byteLength = bytesPerElement;
+      byteLength < base.byteLength;
+      byteLength += bytesPerElement
+    ) {
       for (
-        let offset = 0;
-        offset + length < base.byteLength;
-        offset += length
+        let byteOffset = 0;
+        byteOffset + byteLength < base.byteLength;
+        byteOffset += byteLength
       ) {
-        const typedArray = new TypedArray(base, offset, length / width);
-        const slice = base.slice(offset, offset + length);
-        rt(typedArray, slice);
+        const typedArray = arrayType.new(
+          base,
+          byteOffset,
+          byteLength / bytesPerElement,
+        );
+        const slice = base.slice(byteOffset, byteOffset + byteLength);
+        rt(viewName, typedArray, slice);
       }
     }
   }


### PR DESCRIPTION
Fixes #167 

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

The build was breaking due to a compilation error in the Typescript test, due to a change in Typescript versions. 

You can see the code in [this Typescript playground](https://www.typescriptlang.org/play/?target=7&ts=5.6.3#code/FDAEoMwVwOwYwC4EsD2NQCcEAoEEMAuUAQQwzwE8AhKCCAUwwBpQBnAGyTnqNPOtoMMASlABvMKAC+kuGlYJQAIzyt6oALygY9AO4kylGnUbYAbABZhAbkkQUGUNjkwFoACoUADvQAmfSlAUCFAAbUlwAFUkGAQADgCKJgjQaNiARjNE5PAomIQAZgAmbJSqJABzNIRLUtzQAElYhMMklKaETLrcjuLu8HKKjtrWnNyAMXYUPEKS0ZTJ6ZqLboBdUQl6lzddJF8EAAtND28-RIA6KgBNdwBRAGUAfQAFW4AlR9uAGVuAWVuAHLuWz1eyObDseiKSEwCqHY67fYHaygGFwo4AHmUqno5yUFAQ9C+9FhhxRaPhAGotIjDhsUuAwU4GblIYpghA1IotAAGEH1XIcrmgSmokno0BYlRqPEEonisks8BCqEirQUg4s+kC3LbRQIU7+VrHHT6Tw+I38bDS+gsFUIFga0AAelAtIONiVoD1bE43GONvOHC49Gw9rtdGFoo1np14CwuEN2V9IdjApk9Qz0mAQA): updating to Typescript v5.7.2 introduces the compile time error. 

The fix presented here is the simplest dumbest fix: we no longer are relying on enumerating the type constructors, we now enumerate transitional objects that we provide, with hand written calls into a constructor.
