### PR TITLE
Update "bin" of package.json to point to an executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "type": "module",
   "main": "./typescript/src/index.ts",
   "bin": {
-    "ubrn": "./bin/cli.cjs",
-    "uniffi-bindgen-react-native": "./bin/cli.cjs"
+    "ubrn": "./bin/cli",
+    "uniffi-bindgen-react-native": "./bin/cli"
   },
   "devDependencies": {
     "abortcontroller-polyfill": "^1.7.5",


### PR DESCRIPTION
The file referenced by the `bin` property of a package.json, must be executable, meaning, it must start with the "node shebang". Or as the docs put it: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin

> Please make sure that your file(s) referenced in bin starts with #!/usr/bin/env node, otherwise the scripts are started without the node executable!