### PR TITLE
Small change in "getting started" to make wording more generic

### DIFF
--- a/docs/src/guides/getting-started.md
+++ b/docs/src/guides/getting-started.md
@@ -139,7 +139,7 @@ Until then, you need to add the dependency to the app's Podfile, in this case `e
   )
 
 +  # We need to specify this here in the app because we can't add a local dependency within
-+  # the react-native-matrix-rust-sdk
++  # the library package
 +  pod 'uniffi-bindgen-react-native', :path => '../../node_modules/uniffi-bindgen-react-native'
 ```
 


### PR DESCRIPTION
The [getting started guide](https://jhugman.github.io/uniffi-bindgen-react-native/guides/getting-started.html) mentions a "react-native-matrix-rust-sdk" which hasn't been introduced in the guide. An alternative is to change this to say "react-native-my-rust-lib" as that's the name given to the library package, earlier in the guide.