### PR TITLE
Make `uniffiIsDebug` definition runtime agnostic

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper.ts
@@ -40,8 +40,12 @@ const {
 } = {{ entry.0.1 }}.converters;
 {%- endfor %}
 
-// @ts-ignore -- The process global might not be defined
-const uniffiIsDebug = (typeof process !== "object" || typeof process.env !== "object" || process.env.NODE_ENV !== "production" || {{ config.is_debug() }});
+const uniffiIsDebug =
+  // @ts-ignore -- The process global might not be defined
+  typeof process !== "object" ||
+  // @ts-ignore -- The process global might not be defined
+  process?.env?.NODE_ENV !== "production" ||
+  {{ config.is_debug() }};
 
 {%- call ts::docstring_value(ci.namespace_docstring(), 0) %}
 

--- a/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper.ts
+++ b/crates/ubrn_bindgen/src/bindings/react_native/gen_typescript/templates/wrapper.ts
@@ -40,7 +40,8 @@ const {
 } = {{ entry.0.1 }}.converters;
 {%- endfor %}
 
-const uniffiIsDebug = (process?.env?.NODE_ENV !== "production" || {{ config.is_debug() }});
+// @ts-ignore -- The process global might not be defined
+const uniffiIsDebug = (typeof process !== "object" || typeof process.env !== "object" || process.env.NODE_ENV !== "production" || {{ config.is_debug() }});
 
 {%- call ts::docstring_value(ci.namespace_docstring(), 0) %}
 


### PR DESCRIPTION
A proposed fix for https://github.com/jhugman/uniffi-bindgen-react-native/issues/178 is to use `typeof` as this handles undefined variables gracefully and use a `@ts-ignore` comment to make the TS compiler happy 🙂

This fixes https://github.com/jhugman/uniffi-bindgen-react-native/issues/178.
