### PR TITLE
Handle type parameter change in crnl 0.45.1

### DIFF
--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -174,6 +174,11 @@ create_library() {
     rm -rf "$base" || error "Failed to remove existing directory $base"
   fi
 
+  local type="turbo-module"
+  if [[ "$BOB_VERSION" != "0.45.1" && "$BOB_VERSION" = "`echo -e "0.45.1\n$BOB_VERSION" | sort -V | head -n1`" ]]; then
+    type="module-new"
+  fi
+
   echo "-- Creating library $PROJECT_SLUG with create-react-native-library@$BOB_VERSION"
   npm_config_yes=true npx "create-react-native-library@$BOB_VERSION" \
     --react-native-version "$RN_VERSION" \
@@ -184,7 +189,7 @@ create_library() {
     --author-url "https://nowhere.com/james" \
     --repo-url "https://github.com/jhugman/$PROJECT_SLUG" \
     --languages cpp \
-    --type module-new \
+    --type "$type" \
     --example vanilla \
     --local false \
     "$base"


### PR DESCRIPTION
Looks like this was renamed in https://github.com/callstack/react-native-builder-bob/commit/e9f80ea0055f5b3b7d123dcd08b3de8052206c92 which now breaks some of the compat jobs.

https://github.com/jhugman/uniffi-bindgen-react-native/actions/runs/12208165279/job/34060907217