### PR TITLE
Use version released to Cocoapods and npm

### DIFF
--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.28.3-0"
+version = "0.28.3-1"
 edition = "2021"
 
 [[bin]]

--- a/crates/ubrn_cli/src/codegen/templates/module-template.podspec
+++ b/crates/ubrn_cli/src/codegen/templates/module-template.podspec
@@ -32,6 +32,9 @@ Pod::Spec.new do |s|
   {%- let bindings = self.relative_to(root, dir) -%}
   s.source_files = "{{ ios }}/**/*.{h,m,mm}", "{{ codegen }}/**/*.{h,m,mm}", "{{ tm }}/**/*.{hpp,cpp,c,h}", "{{ bindings }}/**/*.{hpp,cpp,c,h}"
   s.vendored_frameworks = "{{ framework }}"
+  if ENV['UBRN_INSTALLED_LOCALLY'] != '1' then
+    s.dependency    "uniffi-bindgen-react-native", "{{ self.config.project.ubrn_version() }}"
+  end
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/crates/ubrn_cli/src/codegen/templates/module-template.podspec
+++ b/crates/ubrn_cli/src/codegen/templates/module-template.podspec
@@ -32,9 +32,7 @@ Pod::Spec.new do |s|
   {%- let bindings = self.relative_to(root, dir) -%}
   s.source_files = "{{ ios }}/**/*.{h,m,mm}", "{{ codegen }}/**/*.{h,m,mm}", "{{ tm }}/**/*.{hpp,cpp,c,h}", "{{ bindings }}/**/*.{hpp,cpp,c,h}"
   s.vendored_frameworks = "{{ framework }}"
-  if ENV['UBRN_INSTALLED_LOCALLY'] != '1' then
-    s.dependency    "uniffi-bindgen-react-native", "{{ self.config.project.ubrn_version() }}"
-  end
+  s.dependency    "uniffi-bindgen-react-native", "{{ self.config.project.ubrn_version() }}"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/crates/ubrn_cli/src/config/mod.rs
+++ b/crates/ubrn_cli/src/config/mod.rs
@@ -102,6 +102,10 @@ impl ProjectConfig {
             trim_react_native(name).to_upper_camel_case()
         }
     }
+
+    pub(crate) fn ubrn_version(&self) -> String {
+        env!("CARGO_PKG_VERSION").to_string()
+    }
 }
 
 impl ProjectConfig {

--- a/docs/src/contributing/cutting-a-release.md
+++ b/docs/src/contributing/cutting-a-release.md
@@ -1,12 +1,21 @@
 # Cutting a Release
 
+1. The version number should be incremented in the [`package.json`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/package.json#L3) and the [`crates/ubrn_cli/Cargo.toml`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/crates/ubrn_cli/Cargo.toml#L3).
+1. Push as a PR as usual, with subject: `Release ${VERSION_NUMBER}`.
+1. Once this has landed, [draft a new release](https://github.com/jhugman/uniffi-bindgen-react-native/releases/new).
+1. Create a new tag (in the choose a new tag dialog) with the version number (without a `v`).
+1. Use the version number again, but with a `v` prepended for the release title, `v${VERSION_NUMBER}`.
+1. Publish the release.
+1. Wait until the [Cocoapods](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/cocoapods.yml) and [NPM](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm.yml) publishing jobs are finished.
+1. Tell your friends, make a song and dance, you've done a new release.
+
 ## Version numbers
 
 Uniffi has a `semver` versioning scheme. At time of writing, the current version of `uniffi-rs` is `0.28.3`
 
 `uniffi-bindgen-react-native` uses this version number with prepended with a `-` and a variant number, starting at `0`.
 
-Thus, at first release, the version of `uniffi-bindgen-react-native` will be `0.28.3-0`.
+Thus, at first release, the version of `uniffi-bindgen-react-native` was `0.28.3-0`.
 
 ### Compatibility with other packages
 
@@ -14,3 +23,5 @@ Other versioning we should take care to note:
 
 - React Native
 - `create-react-native-library`
+
+A version matrix is built during CI: [![version compatibility](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/compat.yml/badge.svg?query=branch%3Amain) compatibility matrix](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/compat.yml?query=branch%3Amain).

--- a/docs/src/guides/getting-started.md
+++ b/docs/src/guides/getting-started.md
@@ -78,12 +78,6 @@ Using `yarn` add the `uniffi-bindgen-react-native` package to your project.
 yarn add uniffi-bindgen-react-native
 ```
 
-```admonish warning title="Pre-release"
-While this is before the first release, we're installing straight from github.
-
-`yarn add uniffi-bindgen-react-native@https://github.com/jhugman/uniffi-bindgen-react-native`
-```
-
 Opening `package.json` add the following:
 
 ```diff
@@ -121,27 +115,6 @@ alias ubrn=$(yarn ubrn --path)
 There is a guide to the `ubrn` command [here][cli].
 
 [cli]: ../reference/commandline.md
-
-
-```admonish warning title="Pre-release"
-While this is before the first release, we're installing straight from local `node_modules`.
-
-After release, the C++ runtime will be published to Cocoa Pods.
-
-Until then, you need to add the dependency to the app's Podfile, in this case `example/ios/Podfile`:
-```
-
-```diff
-  use_react_native!(
-    :path => config[:reactNativePath],
-    # An absolute path to your application root.
-    :app_path => "#{Pod::Config.instance.installation_root}/.."
-  )
-
-+  # We need to specify this here in the app because we can't add a local dependency within
-+  # the library package
-+  pod 'uniffi-bindgen-react-native', :path => '../../node_modules/uniffi-bindgen-react-native'
-```
 
 ## Step 3: Create the `ubrn.config.yaml` file
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.28.3-0",
+  "version": "0.28.3-1",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -351,13 +351,12 @@ build_ios_example() {
   enter_dir "$PROJECT_DIR"
   echo "-- Running ubrn build ios"
   "$UBRN_BIN" build ios     --config "$UBRN_CONFIG" --and-generate --targets aarch64-apple-ios-sim
+  # Comment out the dependency from CocoaPods
+  sed -i '' -E 's|s.dependency  *"uniffi-bindgen-react-native"|# &|' ./*.podspec
   exit_dir
+  # Use local version, but added via the Podfile.
   enter_dir "$PROJECT_DIR/example/ios"
-  cat <<HEREDOC >> Podfile
-if ENV['UBRN_INSTALLED_LOCALLY'] != '1' then
-  pod 'uniffi-bindgen-react-native', :path => '../../node_modules/uniffi-bindgen-react-native'
-end
-HEREDOC
+  echo "pod 'uniffi-bindgen-react-native', :path => '../../node_modules/uniffi-bindgen-react-native'" >> Podfile
   pod install || error "Cannot run Podfile"
   exit_dir
   enter_dir "$PROJECT_DIR/example"

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -353,7 +353,11 @@ build_ios_example() {
   "$UBRN_BIN" build ios     --config "$UBRN_CONFIG" --and-generate --targets aarch64-apple-ios-sim
   exit_dir
   enter_dir "$PROJECT_DIR/example/ios"
-  echo "pod 'uniffi-bindgen-react-native', :path => '../../node_modules/uniffi-bindgen-react-native'" >> Podfile
+  cat <<HEREDOC >> Podfile
+if ENV['UBRN_INSTALLED_LOCALLY'] != '1' then
+  pod 'uniffi-bindgen-react-native', :path => '../../node_modules/uniffi-bindgen-react-native'
+end
+HEREDOC
   pod install || error "Cannot run Podfile"
   exit_dir
   enter_dir "$PROJECT_DIR/example"


### PR DESCRIPTION
Follow up to #166, now that has been released.

Once this is landed, we should:

1. land anything that is to be in the next release.
2. do a release.

We need to do a release now because:
* The generated podspec file now includes a dependency on `uniffi-bindgen-react-native`.
* We can remove pre-release caveats from the documentation.