### PR TITLE
Make first run more informative while compiling

### DIFF
--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -39,6 +39,12 @@ if (args.length === 1 && args[0] === "--path") {
 // Construct the path to the Cargo.toml file
 const manifestPath = path.join(rootDir, "crates/ubrn_cli/Cargo.toml");
 
+if (!fs.existsSync(path.join(rootDir, "target"))) {
+  console.log(
+    "🤖 Building the uniffi-bindgen-react-native command… this is only needed first time",
+  );
+}
+
 // Run the cargo command
 const command = `cargo run --quiet --manifest-path "${manifestPath}" -- ${args.join(" ")}`;
 try {


### PR DESCRIPTION
Fixes #181 

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This uses the "naive" solution suggested by @kraenhansen—it just detects the absence of the `target` directory.

I added the `--quiet` flag sometime ago because the default cargo output of the `ubrn`  was getting to be annoying. Hopefully this is a reasonable compromise.