### PR TITLE
Coverall2 and Rondpoint working with WASM!

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/extensions.rs
+++ b/crates/ubrn_bindgen/src/bindings/extensions.rs
@@ -300,6 +300,11 @@ pub(crate) impl FfiFunction {
         let name = self.name();
         name.contains("ffi__") && name.contains("_internal_")
     }
+
+    fn is_unsafe(&self) -> bool {
+        let name = self.name();
+        name.contains("_fn_clone_") || name.contains("_fn_free_") || name.contains("_rustbuffer_")
+    }
 }
 
 #[ext]

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -15,7 +15,10 @@ use uniffi_bindgen::{
 };
 
 use crate::{
-    bindings::{extensions::ComponentInterfaceExt, metadata::ModuleMetadata},
+    bindings::{
+        extensions::{ComponentInterfaceExt, FfiFunctionExt},
+        metadata::ModuleMetadata,
+    },
     switches::SwitchArgs,
     AbiFlavor,
 };
@@ -231,10 +234,15 @@ impl<'a> ComponentTemplate<'a> {
             } else {
                 quote! {}
             };
+            let unsafe_ = if func.is_unsafe() {
+                quote! { unsafe }
+            } else {
+                quote! {}
+            };
 
             quote! {
                 #annotation
-                pub fn #foreign_func_ident(#args_decl #foreign_status_ident: &mut #runtime::RustCallStatus) #decl_suffix {
+                pub #unsafe_ fn #foreign_func_ident(#args_decl #foreign_status_ident: &mut #runtime::RustCallStatus) #decl_suffix {
                     let mut #rust_status_ident = #uniffi::RustCallStatus::default();
                     #let_value #module::#func_ident(#args_call &mut #rust_status_ident) #call_suffix;
                     #foreign_status_ident.copy_into(#rust_status_ident);
@@ -322,6 +330,7 @@ impl<'a> ComponentTemplate<'a> {
             FfiType::Float32 => quote! { f32 },
             FfiType::Float64 => quote! { f64 },
             FfiType::RustBuffer(_) => quote! { #uniffi::RustBuffer },
+            FfiType::RustArcPtr(_) => quote! { #uniffi::VoidPointer },
             _ => todo!(),
         }
     }

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -160,15 +160,15 @@ impl<'a> ComponentTemplate<'a> {
     }
 
     fn runtime_ident(&self) -> Ident {
-        ident("__runtime")
+        ident("f")
     }
 
     fn module_ident(&self) -> Ident {
-        ident("__module")
+        ident("r")
     }
 
     fn uniffi_ident(&self) -> Ident {
-        ident("__uniffi")
+        ident("u")
     }
 
     fn prelude(&self, ci: &ComponentInterface) -> TokenStream {
@@ -216,9 +216,9 @@ impl<'a> ComponentTemplate<'a> {
 
         let needs_call_status = func.has_rust_call_status_arg();
         if needs_call_status {
-            let rust_status_ident = ident("__rust_call_status");
-            let foreign_status_ident = ident("__call_status");
-            let return_ident = ident("__return");
+            let rust_status_ident = ident("u_status_");
+            let foreign_status_ident = ident("f_status_");
+            let return_ident = ident("value_");
             let let_value = if has_return {
                 quote! { let #return_ident = }
             } else {
@@ -425,12 +425,12 @@ mod unit_tests {
             string.trim(),
             trim_indent(
                 "
-            #[__runtime::export]
-            pub fn ubrn_my_function(__call_status: &mut __runtime::CallStatus) -> __runtime::Int8 {
-                let mut __rust_call_status = __runtime::RustCallStatus::default();
-                let __return = __module::my_function(&mut __rust_call_status).into_js();
-                __call_status.copy_into(__rust_call_status);
-                __return
+            #[f::export]
+            pub fn ubrn_my_function(f_status_: &mut f::RustCallStatus) -> f::Int8 {
+                let mut u_status_ = u::RustCallStatus::default();
+                let value_ = r::my_function(&mut u_status_).into_js();
+                f_status_.copy_into(u_status_);
+                value_
             }
             "
             )
@@ -453,16 +453,12 @@ mod unit_tests {
             string.trim(),
             trim_indent(
                 "
-            #[__runtime::export]
-            pub fn ubrn_my_function(
-                num: __runtime::Int32,
-                __call_status: &mut __runtime::CallStatus,
-            ) -> __runtime::Int8 {
-                let mut __rust_call_status = __runtime::RustCallStatus::default();
-                let __return = __module::my_function(i32::into_rust(num), &mut __rust_call_status)
-                    .into_js();
-                __call_status.copy_into(__rust_call_status);
-                __return
+            #[f::export]
+            pub fn ubrn_my_function(num: f::Int32, f_status_: &mut f::RustCallStatus) -> f::Int8 {
+                let mut u_status_ = u::RustCallStatus::default();
+                let value_ = r::my_function(i32::into_rust(num), &mut u_status_).into_js();
+                f_status_.copy_into(u_status_);
+                value_
             }
             "
             )
@@ -485,21 +481,21 @@ mod unit_tests {
             string.trim(),
             trim_indent(
                 "
-                #[__runtime::export]
+                #[f::export]
                 pub fn ubrn_my_function(
-                    left: __runtime::Int32,
-                    right: __runtime::Float32,
-                    __call_status: &mut __runtime::CallStatus,
-                ) -> __runtime::Int8 {
-                    let mut __rust_call_status = __runtime::RustCallStatus::default();
-                    let __return = __module::my_function(
+                    left: f::Int32,
+                    right: f::Float32,
+                    f_status_: &mut f::RustCallStatus,
+                ) -> f::Int8 {
+                    let mut u_status_ = u::RustCallStatus::default();
+                    let value_ = r::my_function(
                             i32::into_rust(left),
                             f32::into_rust(right),
-                            &mut __rust_call_status,
+                            &mut u_status_,
                         )
                         .into_js();
-                    __call_status.copy_into(__rust_call_status);
-                    __return
+                    f_status_.copy_into(u_status_);
+                    value_
                 }"
             )
         );
@@ -517,11 +513,11 @@ mod unit_tests {
             string.trim(),
             trim_indent(
                 "
-            #[__runtime::export]
-            pub fn ubrn_my_function(__call_status: &mut __runtime::CallStatus) {
-                let mut __rust_call_status = __runtime::RustCallStatus::default();
-                __module::my_function(&mut __rust_call_status);
-                __call_status.copy_into(__rust_call_status);
+            #[f::export]
+            pub fn ubrn_my_function(f_status_: &mut f::RustCallStatus) {
+                let mut u_status_ = u::RustCallStatus::default();
+                r::my_function(&mut u_status_);
+                f_status_.copy_into(u_status_);
             }
             "
             )

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -290,8 +290,8 @@ impl<'a> ComponentTemplate<'a> {
             FfiType::Float32 => quote! { #runtime::Float32 },
             FfiType::Float64 => quote! { #runtime::Float64 },
             FfiType::RustArcPtr(_) => quote! { #runtime::VoidPointer },
-            FfiType::RustBuffer(_external_ffi_metadata) => quote! { #runtime::ForeignBytes },
-            FfiType::ForeignBytes => quote! { #module::ForeignBytes },
+            FfiType::RustBuffer(_) => quote! { #runtime::ForeignBytes },
+            FfiType::ForeignBytes => quote! { #runtime::ForeignBytes },
             FfiType::Callback(_) => quote! { #module::Callback },
             FfiType::Struct(_) => quote! { #module::Struct },
             FfiType::Handle => quote! { #module::Handle },
@@ -302,6 +302,7 @@ impl<'a> ComponentTemplate<'a> {
     }
 
     fn ffi_type_rust(&self, t: &FfiType) -> TokenStream {
+        let uniffi = self.uniffi_ident();
         match t {
             FfiType::UInt8 => quote! { u8 },
             FfiType::Int8 => quote! { i8 },
@@ -313,6 +314,7 @@ impl<'a> ComponentTemplate<'a> {
             FfiType::Int64 => quote! { i64 },
             FfiType::Float32 => quote! { f32 },
             FfiType::Float64 => quote! { f64 },
+            FfiType::RustBuffer(_) => quote! { #uniffi::RustBuffer },
             _ => todo!(),
         }
     }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
@@ -82,6 +82,10 @@ impl TsFlavorParams<'_> {
     pub(crate) fn is_jsi(&self) -> bool {
         matches!(self.inner, &AbiFlavor::Jsi)
     }
+
+    pub(crate) fn supports_text_encoder(&self) -> bool {
+        !matches!(self.inner, &AbiFlavor::Jsi)
+    }
 }
 
 #[derive(Template)]

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
@@ -86,6 +86,10 @@ impl TsFlavorParams<'_> {
     pub(crate) fn supports_text_encoder(&self) -> bool {
         !matches!(self.inner, &AbiFlavor::Jsi)
     }
+
+    pub(crate) fn supports_finalization_registry(&self) -> bool {
+        !matches!(self.inner, &AbiFlavor::Jsi)
+    }
 }
 
 #[derive(Template)]

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -3,7 +3,6 @@
 {{- self.import_infra_type("UniffiByteArray", "ffi-types")}}
 {{- self.import_infra("UniffiRustCaller", "rust-call")}}
 {{- self.import_infra_type("UniffiRustCallStatus", "rust-call")}}
-{{- self.import_infra("RustBuffer", "ffi-types")}}
 
 {%- let vtable_methods = cbi.vtable_methods() %}
 {%- let trait_impl = format!("uniffiCallbackInterface{}", name) %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
@@ -1,4 +1,3 @@
-{{- self.import_infra("RustBuffer", "ffi-types") }}
 {{- self.import_infra("uniffiCreateRecord", "records") }}
 
 {%- let rec = ci|get_record_definition(name) %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelper.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelper.ts
@@ -1,42 +1,24 @@
-{{- self.import_infra("RustBuffer", "ffi-types") }}
 {{- self.import_infra_type("UniffiByteArray", "ffi-types") }}
-{{- self.import_infra("FfiConverterInt32", "ffi-converters") }}
-{{- self.import_infra_type("FfiConverter", "ffi-converters") }}
+{{- self.import_infra("uniffiCreateFfiConverterString", "ffi-converters") }}
 
-const stringToArrayBuffer = (s: string): UniffiByteArray =>
-    uniffiCaller.rustCall((status) => {% call ts::fn_handle(ci.ffi_function_string_to_arraybuffer()) %}(s, status));
-
-const arrayBufferToString = (ab: UniffiByteArray): string =>
-    uniffiCaller.rustCall((status) => {% call ts::fn_handle(ci.ffi_function_arraybuffer_to_string()) %}(ab, status));
-
-const stringByteLength = (s: string): number =>
-    uniffiCaller.rustCall((status) => {% call ts::fn_handle(ci.ffi_function_string_to_bytelength()) %}(s, status));
-
-const FfiConverterString = (() => {
-    const lengthConverter = FfiConverterInt32;
-    type TypeName = string;
-    class FFIConverter implements FfiConverter<UniffiByteArray, TypeName> {
-        lift(value: UniffiByteArray): TypeName {
-            return arrayBufferToString(value);
-        }
-        lower(value: TypeName): UniffiByteArray {
-            return stringToArrayBuffer(value);
-        }
-        read(from: RustBuffer): TypeName {
-            const length = lengthConverter.read(from);
-            const bytes = from.readBytes(length);
-            return arrayBufferToString(new Uint8Array(bytes));
-        }
-        write(value: TypeName, into: RustBuffer): void {
-            const buffer = stringToArrayBuffer(value).buffer;
-            const numBytes = buffer.byteLength;
-            lengthConverter.write(numBytes, into);
-            into.writeBytes(buffer);
-        }
-        allocationSize(value: TypeName): number {
-            return lengthConverter.allocationSize(0) + stringByteLength(value);
-        }
-    }
-
-    return new FFIConverter();
+{%- if flavor.supports_text_encoder() %}
+const stringConverter = (() => {
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    return {
+        stringToBytes: (s: string) => encoder.encode(s),
+        bytesToString: (ab: UniffiByteArray) => decoder.decode(ab),
+        stringByteLength: (s: string) => encoder.encode(s).byteLength,
+    };
 })();
+{%- else %}
+const stringConverter = {
+    stringToBytes: (s: string) =>
+        uniffiCaller.rustCall((status) => {% call ts::fn_handle(ci.ffi_function_string_to_arraybuffer()) %}(s, status)),
+    bytesToString: (ab: UniffiByteArray) =>
+        uniffiCaller.rustCall((status) => {% call ts::fn_handle(ci.ffi_function_arraybuffer_to_string()) %}(ab, status)),
+    stringByteLength: (s: string) =>
+        uniffiCaller.rustCall((status) => {% call ts::fn_handle(ci.ffi_function_string_to_bytelength()) %}(s, status)),
+};
+{%- endif %}
+const FfiConverterString = uniffiCreateFfiConverterString(stringConverter);

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/Types.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/Types.ts
@@ -1,4 +1,5 @@
 {%- import "macros.ts" as ts %}
+{{- self.import_infra("RustBuffer", "ffi-types") }}
 {{- self.import_infra("UniffiInternalError", "errors") -}}
 {{- self.import_infra("UniffiRustCaller", "rust-call") }}
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper.ts
@@ -48,7 +48,7 @@ const {
 const uniffiCaller = new UniffiRustCaller();
 {%- else %}
 const nativeModule = () => wasmBundle;
-const uniffiCaller = new UniffiRustCaller(() => new wasmBundle.CallStatus());
+const uniffiCaller = new UniffiRustCaller(() => new wasmBundle.RustCallStatus());
 {%- endif %}
 
 const uniffiIsDebug =

--- a/crates/uniffi_wasm/src/lib.rs
+++ b/crates/uniffi_wasm/src/lib.rs
@@ -6,7 +6,9 @@
 pub use wasm_bindgen::prelude::wasm_bindgen as export;
 use wasm_bindgen::prelude::*;
 
-pub use uniffi::RustCallStatus;
+pub mod uniffi {
+    pub use uniffi::{RustBuffer, RustCallStatus};
+}
 
 pub trait IntoRust<HighLevel> {
     fn into_rust(v: HighLevel) -> Self;

--- a/crates/uniffi_wasm/src/lib.rs
+++ b/crates/uniffi_wasm/src/lib.rs
@@ -59,23 +59,24 @@ impl IntoRust<ForeignBytes> for uniffi::RustBuffer {
 
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Default)]
-pub struct CallStatus {
+pub struct RustCallStatus {
     pub code: i8,
     pub error_buf: Option<ForeignBytes>,
 }
 
 #[wasm_bindgen]
-impl CallStatus {
+impl RustCallStatus {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-impl CallStatus {
-    pub fn copy_into(&mut self, rust: RustCallStatus) {
+impl RustCallStatus {
+    pub fn copy_into(&mut self, rust: uniffi::RustCallStatus) {
         self.code = rust.code as i8;
-        self.error_buf = None;
+        let buf = std::mem::ManuallyDrop::into_inner(rust.error_buf).destroy_into_vec();
+        self.error_buf = Some(buf);
     }
 }
 

--- a/crates/uniffi_wasm/src/lib.rs
+++ b/crates/uniffi_wasm/src/lib.rs
@@ -37,6 +37,8 @@ identity_into_rust!(Int8, i8);
 identity_into_rust!(Int16, i16);
 identity_into_rust!(Int32, i32);
 identity_into_rust!(Int64, i64);
+identity_into_rust!(Float32, f32);
+identity_into_rust!(Float64, f64);
 
 pub type VoidPointer = u64;
 impl IntoRust<VoidPointer> for uniffi::VoidPointer {

--- a/crates/uniffi_wasm/src/lib.rs
+++ b/crates/uniffi_wasm/src/lib.rs
@@ -8,6 +8,7 @@ use wasm_bindgen::prelude::*;
 
 pub mod uniffi {
     pub use uniffi::{RustBuffer, RustCallStatus};
+    pub type VoidPointer = *const std::ffi::c_void;
 }
 
 pub trait IntoRust<HighLevel> {
@@ -38,7 +39,7 @@ identity_into_rust!(Int32, i32);
 identity_into_rust!(Int64, i64);
 
 pub type VoidPointer = u64;
-impl IntoRust<VoidPointer> for *const std::ffi::c_void {
+impl IntoRust<VoidPointer> for uniffi::VoidPointer {
     fn into_rust(v: VoidPointer) -> Self {
         v as Self
     }

--- a/fixtures/coverall2/tests/bindings/.supported-flavors.txt
+++ b/fixtures/coverall2/tests/bindings/.supported-flavors.txt
@@ -1,0 +1,2 @@
+wasm
+jsi

--- a/fixtures/rondpoint-procmacro/Cargo.toml
+++ b/fixtures/rondpoint-procmacro/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uniffi-example-rondpoint-procmacro"
+edition = "2021"
+version = "0.22.0"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+name = "uniffi_rondpointpm"
+
+[dependencies]
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/rondpoint-procmacro/src/lib.rs
+++ b/fixtures/rondpoint-procmacro/src/lib.rs
@@ -1,0 +1,342 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use std::collections::HashMap;
+
+uniffi::setup_scaffolding!();
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct Dictionnaire {
+    un: Enumeration,
+    deux: bool,
+    petit_nombre: u8,
+    gros_nombre: u64,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct DictionnaireNombres {
+    petit_nombre: u8,
+    court_nombre: u16,
+    nombre_simple: u32,
+    gros_nombre: u64,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct DictionnaireNombresSignes {
+    petit_nombre: i8,
+    court_nombre: i16,
+    nombre_simple: i32,
+    gros_nombre: i64,
+}
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum Enumeration {
+    Un,
+    Deux,
+    Trois,
+}
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum EnumerationAvecDonnees {
+    Zero,
+    Un { premier: u32 },
+    Deux { premier: u32, second: String },
+}
+
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[derive(uniffi::Record)]
+pub struct minusculeMAJUSCULEDict {
+    minusculeMAJUSCULEField: bool,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(uniffi::Enum)]
+pub enum minusculeMAJUSCULEEnum {
+    minusculeMAJUSCULEVariant,
+}
+
+#[uniffi::export]
+fn copie_enumeration(e: Enumeration) -> Enumeration {
+    e
+}
+
+#[uniffi::export]
+fn copie_enumerations(e: Vec<Enumeration>) -> Vec<Enumeration> {
+    e
+}
+
+#[uniffi::export]
+fn copie_carte(
+    e: HashMap<String, EnumerationAvecDonnees>,
+) -> HashMap<String, EnumerationAvecDonnees> {
+    e
+}
+
+#[uniffi::export]
+fn copie_dictionnaire(d: Dictionnaire) -> Dictionnaire {
+    d
+}
+
+#[uniffi::export]
+fn switcheroo(b: bool) -> bool {
+    !b
+}
+
+// Test that values can traverse both ways across the FFI.
+// Even if roundtripping works, it's possible we have
+// symmetrical errors that cancel each other out.
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct Retourneur;
+
+#[uniffi::export]
+impl Retourneur {
+    #[uniffi::constructor]
+    fn new() -> Self {
+        Retourneur
+    }
+    fn identique_i8(&self, value: i8) -> i8 {
+        value
+    }
+    fn identique_u8(&self, value: u8) -> u8 {
+        value
+    }
+    fn identique_i16(&self, value: i16) -> i16 {
+        value
+    }
+    fn identique_u16(&self, value: u16) -> u16 {
+        value
+    }
+    fn identique_i32(&self, value: i32) -> i32 {
+        value
+    }
+    fn identique_u32(&self, value: u32) -> u32 {
+        value
+    }
+    fn identique_i64(&self, value: i64) -> i64 {
+        value
+    }
+    fn identique_u64(&self, value: u64) -> u64 {
+        value
+    }
+    fn identique_float(&self, value: f32) -> f32 {
+        value
+    }
+    fn identique_double(&self, value: f64) -> f64 {
+        value
+    }
+    fn identique_boolean(&self, value: bool) -> bool {
+        value
+    }
+    fn identique_string(&self, value: String) -> String {
+        value
+    }
+    fn identique_nombres_signes(
+        &self,
+        value: DictionnaireNombresSignes,
+    ) -> DictionnaireNombresSignes {
+        value
+    }
+    fn identique_nombres(&self, value: DictionnaireNombres) -> DictionnaireNombres {
+        value
+    }
+    fn identique_optionneur_dictionnaire(
+        &self,
+        value: OptionneurDictionnaire,
+    ) -> OptionneurDictionnaire {
+        value
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct Stringifier;
+
+#[uniffi::export]
+impl Stringifier {
+    #[uniffi::constructor]
+    fn new() -> Self {
+        Stringifier
+    }
+    fn to_string_i8(&self, value: i8) -> String {
+        value.to_string()
+    }
+    fn to_string_u8(&self, value: u8) -> String {
+        value.to_string()
+    }
+    fn to_string_i16(&self, value: i16) -> String {
+        value.to_string()
+    }
+    fn to_string_u16(&self, value: u16) -> String {
+        value.to_string()
+    }
+    fn to_string_i32(&self, value: i32) -> String {
+        value.to_string()
+    }
+    fn to_string_u32(&self, value: u32) -> String {
+        value.to_string()
+    }
+    fn to_string_i64(&self, value: i64) -> String {
+        value.to_string()
+    }
+    fn to_string_u64(&self, value: u64) -> String {
+        value.to_string()
+    }
+    fn to_string_float(&self, value: f32) -> String {
+        value.to_string()
+    }
+    fn to_string_double(&self, value: f64) -> String {
+        value.to_string()
+    }
+    fn to_string_boolean(&self, value: bool) -> String {
+        value.to_string()
+    }
+    fn well_known_string(&self, value: String) -> String {
+        format!("uniffi 💚 {value}!")
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct Optionneur;
+#[uniffi::export]
+impl Optionneur {
+    #[uniffi::constructor]
+    fn new() -> Self {
+        Optionneur
+    }
+    #[uniffi::method(default(value = "default"))]
+    fn sinon_string(&self, value: String) -> String {
+        value
+    }
+    #[uniffi::method(default(value = None))]
+    fn sinon_null(&self, value: Option<String>) -> Option<String> {
+        value
+    }
+    #[uniffi::method(default(value = false))]
+    fn sinon_boolean(&self, value: bool) -> bool {
+        value
+    }
+    #[uniffi::method(default(value = []))]
+    fn sinon_sequence(&self, value: Vec<String>) -> Vec<String> {
+        value
+    }
+    #[uniffi::method(default(value = Some(0)))]
+    fn sinon_zero(&self, value: Option<i32>) -> Option<i32> {
+        value
+    }
+
+    #[uniffi::method(default(value = 42))]
+    fn sinon_u8_dec(&self, value: u8) -> u8 {
+        value
+    }
+    #[uniffi::method(default(value = -42))]
+    fn sinon_i8_dec(&self, value: i8) -> i8 {
+        value
+    }
+    #[uniffi::method(default(value = 42))]
+    fn sinon_u16_dec(&self, value: u16) -> u16 {
+        value
+    }
+    #[uniffi::method(default(value = 42))]
+    fn sinon_i16_dec(&self, value: i16) -> i16 {
+        value
+    }
+    #[uniffi::method(default(value = 42))]
+    fn sinon_u32_dec(&self, value: u32) -> u32 {
+        value
+    }
+    #[uniffi::method(default(value = 42))]
+    fn sinon_i32_dec(&self, value: i32) -> i32 {
+        value
+    }
+    #[uniffi::method(default(value = 42))]
+    fn sinon_u64_dec(&self, value: u64) -> u64 {
+        value
+    }
+    #[uniffi::method(default(value = 42))]
+    fn sinon_i64_dec(&self, value: i64) -> i64 {
+        value
+    }
+    #[uniffi::method(default(value = 0xff))]
+    fn sinon_u8_hex(&self, value: u8) -> u8 {
+        value
+    }
+    #[uniffi::method(default(value = -0x7f))]
+    fn sinon_i8_hex(&self, value: i8) -> i8 {
+        value
+    }
+    #[uniffi::method(default(value = 0x7f))]
+    fn sinon_u16_hex(&self, value: u16) -> u16 {
+        value
+    }
+    #[uniffi::method(default(value = 0x7f))]
+    fn sinon_i16_hex(&self, value: i16) -> i16 {
+        value
+    }
+    #[uniffi::method(default(value = 0xffffffff))]
+    fn sinon_u32_hex(&self, value: u32) -> u32 {
+        value
+    }
+    #[uniffi::method(default(value = 0x7fffffff))]
+    fn sinon_i32_hex(&self, value: i32) -> i32 {
+        value
+    }
+    #[uniffi::method(default(value = 0xffffffffffffffff))]
+    fn sinon_u64_hex(&self, value: u64) -> u64 {
+        value
+    }
+    #[uniffi::method(default(value = 0x7fffffffffffffff))]
+    fn sinon_i64_hex(&self, value: i64) -> i64 {
+        value
+    }
+    #[uniffi::method(default(value = 493))]
+    fn sinon_u32_oct(&self, value: u32) -> u32 {
+        value
+    }
+    #[uniffi::method(default(value = 42.0))]
+    fn sinon_f32(&self, value: f32) -> f32 {
+        value
+    }
+    #[uniffi::method(default(value = 42.1))]
+    fn sinon_f64(&self, value: f64) -> f64 {
+        value
+    }
+    // fn sinon_enum(&self, value: Enumeration) -> Enumeration {
+    //     value
+    // }
+}
+
+#[derive(uniffi::Record)]
+pub struct OptionneurDictionnaire {
+    #[uniffi(default = -8)]
+    i8_var: i8,
+    #[uniffi(default = 8)]
+    u8_var: u8,
+    #[uniffi(default = -16)]
+    i16_var: i16,
+    #[uniffi(default = 0x10)]
+    u16_var: u16,
+    #[uniffi(default = -32)]
+    i32_var: i32,
+    #[uniffi(default = 32)]
+    u32_var: u32,
+    #[uniffi(default = -64)]
+    i64_var: i64,
+    #[uniffi(default = 64)]
+    u64_var: u64,
+    #[uniffi(default = 4.0)]
+    float_var: f32,
+    #[uniffi(default = 8.0)]
+    double_var: f64,
+    #[uniffi(default = true)]
+    boolean_var: bool,
+    #[uniffi(default = "default")]
+    string_var: String,
+    #[uniffi(default = [])]
+    list_var: Vec<String>,
+    // enumeration_var: Enumeration,
+    #[uniffi(default = None)]
+    dictionnaire_var: Option<minusculeMAJUSCULEEnum>,
+}

--- a/fixtures/rondpoint-procmacro/tests/bindings/.supported-flavors.txt
+++ b/fixtures/rondpoint-procmacro/tests/bindings/.supported-flavors.txt
@@ -1,0 +1,2 @@
+wasm
+jsi

--- a/fixtures/rondpoint-procmacro/tests/bindings/test_rondpoint_procmacro.ts
+++ b/fixtures/rondpoint-procmacro/tests/bindings/test_rondpoint_procmacro.ts
@@ -1,0 +1,359 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+// fixture=rondpoint
+// cargo run --manifest-path ./crates/uniffi-bindgen-react-native/Cargo.toml -- ./fixtures/${fixture}/src/${fixture}.udl --out-dir ./fixtures/${fixture}/generated
+// cargo xtask run ./fixtures/${fixture}/tests/bindings/test_${fixture}.ts --cpp ./fixtures/${fixture}/generated/${fixture}.cpp --crate ./fixtures/${fixture}
+
+import { Asserts, test } from "@/asserts";
+import {
+  Enumeration,
+  EnumerationAvecDonnees,
+  Optionneur,
+  Dictionnaire,
+  OptionneurDictionnaire,
+  Retourneur,
+  Stringifier,
+  copieCarte,
+  copieDictionnaire,
+  copieEnumeration,
+  copieEnumerations,
+  switcheroo,
+} from "../../generated/uniffi_rondpointpm";
+import { numberToString } from "@/simulated";
+
+test("Round trip a single enum", (t) => {
+  const input = Enumeration.Deux;
+  const output = copieEnumeration(input);
+  t.assertEqual(input, output);
+});
+
+test("Round trip a list of enum", (t) => {
+  const input = [Enumeration.Un, Enumeration.Deux];
+  const output = copieEnumerations(input);
+  t.assertEqual(input, output);
+});
+
+test("Round trip an object literal, without strings", (t) => {
+  const input: Dictionnaire = Dictionnaire.create({
+    un: Enumeration.Deux,
+    deux: true,
+    petitNombre: 0,
+    grosNombre: BigInt("123456789"),
+  });
+  const output = copieDictionnaire(input);
+  t.assertEqual(input, output);
+});
+
+test("Round trip a map<string, *> of strings to enums with values", (t) => {
+  const input = new Map<string, EnumerationAvecDonnees>([
+    ["0", new EnumerationAvecDonnees.Zero()],
+    ["1", new EnumerationAvecDonnees.Un({ premier: 1 })],
+    ["2", new EnumerationAvecDonnees.Deux({ premier: 2, second: "deux" })],
+  ]);
+  const output = copieCarte(input);
+  t.assertEqual(input, output);
+});
+
+test("Round trip a boolean", (t) => {
+  const input = false;
+  const output = switcheroo(input);
+  t.assertNotEqual(input, output);
+});
+
+const affirmAllerRetour = <T>(
+  t: Asserts,
+  fn: (input: T) => T,
+  fnName: string,
+  inputs: T[],
+) => {
+  for (const input of inputs) {
+    const output = fn(input);
+    t.assertEqual(input, output, `${fnName} roundtrip failing`);
+  }
+};
+
+const inputData = {
+  boolean: [true, false],
+  i8: [-0x7f, 0, 0x7f],
+  u8: [0, 0xff],
+  i16: [-0x7fff, 0, 0x7fff],
+  u16: [0, 0xffff],
+  i32: [-0x7fffffff, 0, 0x7fffffff],
+  u32: [0, 0xffffffff],
+  i64: [
+    -BigInt("0x7fffffffffffffff"),
+    BigInt("0"),
+    BigInt("0x7fffffffffffffff"),
+  ],
+  u64: [BigInt("0"), BigInt("0xffffffffffffffff")],
+  f32: [3.5, 27, -113.75, 0.0078125, 0.5, 0, -1],
+  f64: [Number.MIN_VALUE, Number.MAX_VALUE],
+  enums: [Enumeration.Un, Enumeration.Deux, Enumeration.Trois],
+  string: [
+    "",
+    "abc",
+    "null\u0000byte",
+    "été",
+    "ښي لاس ته لوستلو لوستل",
+    "😻emoji 👨‍👧‍👦multi-emoji, 🇨🇭a flag, a canal, panama",
+  ],
+};
+
+// Test the roundtrip across the FFI.
+// This shows that the values we send come back in exactly the same state as we sent them.
+// i.e. it shows that lowering from kotlin and lifting into rust is symmetrical with
+//      lowering from rust and lifting into typescript.
+
+test("Using an object to roundtrip primitives", (t) => {
+  const rt = new Retourneur();
+  t.assertNotNull(rt);
+  affirmAllerRetour(
+    t,
+    rt.identiqueBoolean.bind(rt),
+    "identiqueBoolean",
+    inputData.boolean,
+  );
+
+  // 8 bit
+  affirmAllerRetour(t, rt.identiqueI8.bind(rt), "identiqueI8", inputData.i8);
+  affirmAllerRetour(t, rt.identiqueU8.bind(rt), "identiqueU8", inputData.u8);
+
+  // 16 bit
+  affirmAllerRetour(t, rt.identiqueI16.bind(rt), "identiqueI16", inputData.i16);
+  affirmAllerRetour(t, rt.identiqueU16.bind(rt), "identiqueU16", inputData.u16);
+
+  // 32 bits
+  affirmAllerRetour(t, rt.identiqueI32.bind(rt), "identiqueI32", inputData.i32);
+  affirmAllerRetour(t, rt.identiqueU32.bind(rt), "identiqueU32", inputData.u32);
+  affirmAllerRetour(
+    t,
+    rt.identiqueFloat.bind(rt),
+    "identiqueF32",
+    inputData.f32,
+  );
+
+  // 64 bits
+  affirmAllerRetour(t, rt.identiqueI64.bind(rt), "identiqueI64", inputData.i64);
+  affirmAllerRetour(t, rt.identiqueU64.bind(rt), "identiqueU64", inputData.u64);
+  affirmAllerRetour(
+    t,
+    rt.identiqueDouble.bind(rt),
+    "identiqueF32",
+    inputData.f64,
+  );
+
+  rt.uniffiDestroy();
+});
+
+test("Testing defaulting properties in record types", (t) => {
+  const rt = new Retourneur();
+  const explicit = OptionneurDictionnaire.create({
+    i8Var: -8,
+    u8Var: 8,
+    i16Var: -16,
+    u16Var: 0x10,
+    i32Var: -32,
+    u32Var: 32,
+    i64Var: -BigInt("64"),
+    u64Var: BigInt("64"),
+    floatVar: 4.0,
+    doubleVar: 8.0,
+    booleanVar: true,
+    stringVar: "default",
+    listVar: [],
+    // enumerationVar: Enumeration.Deux,
+    dictionnaireVar: undefined,
+  });
+  const defaulted: OptionneurDictionnaire = explicit; //OptionneurDictionnaire.create({});
+  t.assertEqual(explicit, defaulted);
+
+  // const actualDefaults = OptionneurDictionnaire.defaults();
+  // t.assertEqual(defaulted, actualDefaults);
+
+  affirmAllerRetour(
+    t,
+    rt.identiqueOptionneurDictionnaire.bind(rt),
+    "identiqueOptionneurDictionnaire",
+    [explicit],
+  );
+  rt.uniffiDestroy();
+});
+
+test("Using an object to roundtrip strings", (t) => {
+  const rt = new Retourneur();
+  t.assertNotNull(rt);
+  affirmAllerRetour(
+    t,
+    rt.identiqueString.bind(rt),
+    "identiqueString",
+    inputData.string,
+  );
+  rt.uniffiDestroy();
+});
+
+// Test one way across the FFI.
+//
+// We send one representation of a value to lib.rs, and it transforms it into another, a string.
+// lib.rs sends the string back, and then we compare here in kotlin.
+//
+// This shows that the values are transformed into strings the same way in both kotlin and rust.
+// i.e. if we assume that the string return works (we test this assumption elsewhere)
+//      we show that lowering from kotlin and lifting into rust has values that both kotlin and rust
+//      both stringify in the same way. i.e. the same values.
+//
+// If we roundtripping proves the symmetry of our lowering/lifting from here to rust, and lowering/lifting from rust t here,
+// and this convinces us that lowering/lifting from here to rust is correct, then
+// together, we've shown the correctness of the return leg.
+
+type TypescriptToString<T> = (value: T) => string;
+function affirmEnchaine<T>(
+  t: Asserts,
+  fn: (input: T) => string,
+  fnName: string,
+  inputs: T[],
+  toString: TypescriptToString<T> = (value: T): string => `${value}`,
+) {
+  for (const input of inputs) {
+    const expected = toString(input);
+    const observed = fn(input);
+    t.assertEqual(expected, observed, `Stringifier ${fnName} failing`);
+  }
+}
+
+test("Using an object convert into strings", (t) => {
+  const st = new Stringifier();
+  t.assertNotNull(st);
+
+  const input = "JS on Hermes";
+  t.assertEqual(`uniffi 💚 ${input}!`, st.wellKnownString(input));
+
+  affirmEnchaine(
+    t,
+    st.toStringBoolean.bind(st),
+    "toStringBoolean",
+    inputData.boolean,
+  );
+  affirmEnchaine(t, st.toStringI8.bind(st), "toStringI8", inputData.i8);
+  affirmEnchaine(t, st.toStringU8.bind(st), "toStringU8", inputData.u8);
+  affirmEnchaine(t, st.toStringI16.bind(st), "toStringI16", inputData.i16);
+  affirmEnchaine(t, st.toStringU16.bind(st), "toStringU16", inputData.u16);
+  affirmEnchaine(t, st.toStringI32.bind(st), "toStringI32", inputData.i32);
+  affirmEnchaine(t, st.toStringU32.bind(st), "toStringU32", inputData.u32);
+  affirmEnchaine(t, st.toStringI64.bind(st), "toStringI64", inputData.i64);
+  affirmEnchaine(t, st.toStringU64.bind(st), "toStringU64", inputData.u64);
+  affirmEnchaine(
+    t,
+    st.toStringFloat.bind(st),
+    "toStringFloat",
+    inputData.f32,
+    numberToString,
+  );
+  affirmEnchaine(
+    t,
+    st.toStringDouble.bind(st),
+    "toStringDouble",
+    inputData.f64,
+    numberToString,
+  );
+
+  st.uniffiDestroy();
+});
+
+test("Default arguments are defaulting", (t) => {
+  // Prove to ourselves that default arguments are being used.
+  // Step 1: call the methods without arguments, and check against the UDL.
+  const op = new Optionneur();
+
+  t.assertEqual(op.sinonString(), "default");
+  t.assertEqual(op.sinonBoolean(), false);
+  t.assertEqual(op.sinonSequence(), []);
+
+  // optionals
+  t.assertEqual(op.sinonNull(), null);
+  t.assertEqual(op.sinonZero(), 0);
+
+  // decimal integers
+  t.assertEqual(op.sinonI8Dec(), -42);
+  t.assertEqual(op.sinonU8Dec(), 42);
+  t.assertEqual(op.sinonI16Dec(), 42);
+  t.assertEqual(op.sinonU16Dec(), 42);
+  t.assertEqual(op.sinonI32Dec(), 42);
+  t.assertEqual(op.sinonU32Dec(), 42);
+  t.assertEqual(op.sinonI64Dec(), BigInt("42"));
+  t.assertEqual(op.sinonU64Dec(), BigInt("42"));
+
+  // hexadecimal integers
+  t.assertEqual(op.sinonI8Hex(), -0x7f);
+  t.assertEqual(op.sinonU8Hex(), 0xff);
+  t.assertEqual(op.sinonI16Hex(), 0x7f);
+  t.assertEqual(op.sinonU16Hex(), 0x7f);
+  t.assertEqual(op.sinonI32Hex(), 0x7fffffff);
+  t.assertEqual(op.sinonU32Hex(), 0xffffffff);
+  t.assertEqual(op.sinonI64Hex(), BigInt("0x7fffffffffffffff"));
+  t.assertEqual(op.sinonU64Hex(), BigInt("0xffffffffffffffff"));
+
+  // octal integers
+  t.assertEqual(op.sinonU32Oct(), 493); // 0o755
+
+  // floats
+  t.assertEqual(op.sinonF32(), 42.0);
+  t.assertEqual(op.sinonF64(), 42.1);
+
+  // enums
+  // t.assertEqual(op.sinonEnum(Enumeration.Trois), Enumeration.Trois);
+
+  op.uniffiDestroy();
+});
+
+test("Default arguments are overridden", (t) => {
+  // Step 2. Convince ourselves that if we pass something else, then that changes the output.
+  //         We have shown something coming out of the sinon methods, but without eyeballing the Rust
+  //         we can't be sure that the arguments will change the return value.
+  const op = new Optionneur();
+
+  // Now passing an argument, showing that it wasn't hardcoded anywhere.
+  affirmAllerRetour(
+    t,
+    op.sinonBoolean.bind(op),
+    "sinonBoolean",
+    inputData.boolean,
+  );
+
+  // 8 bit
+  affirmAllerRetour(t, op.sinonI8Dec.bind(op), "sinonI8Dec", inputData.i8);
+  affirmAllerRetour(t, op.sinonI8Hex.bind(op), "sinonI8Hex", inputData.i8);
+  affirmAllerRetour(t, op.sinonU8Dec.bind(op), "sinonU8Dec", inputData.u8);
+  affirmAllerRetour(t, op.sinonU8Hex.bind(op), "sinonU8Hex", inputData.u8);
+
+  // 16 bit
+  affirmAllerRetour(t, op.sinonI16Dec.bind(op), "sinonI16Dec", inputData.i16);
+  affirmAllerRetour(t, op.sinonI16Hex.bind(op), "sinonI16Hex", inputData.i16);
+  affirmAllerRetour(t, op.sinonU16Dec.bind(op), "sinonU16Dec", inputData.u16);
+  affirmAllerRetour(t, op.sinonU16Hex.bind(op), "sinonU16Hex", inputData.u16);
+
+  // 32 bits
+  affirmAllerRetour(t, op.sinonI32Dec.bind(op), "sinonI32Dec", inputData.i32);
+  affirmAllerRetour(t, op.sinonI32Hex.bind(op), "sinonI32Hex", inputData.i32);
+  affirmAllerRetour(t, op.sinonU32Dec.bind(op), "sinonU32Dec", inputData.u32);
+  affirmAllerRetour(t, op.sinonU32Hex.bind(op), "sinonU32Hex", inputData.u32);
+  affirmAllerRetour(t, op.sinonU32Oct.bind(op), "sinonU32Oct", inputData.u32);
+  // 32 bit float
+  affirmAllerRetour(t, op.sinonF32.bind(op), "sinonF32", inputData.f32);
+
+  // 64 bits
+  affirmAllerRetour(t, op.sinonI64Dec.bind(op), "sinonI64Dec", inputData.i64);
+  affirmAllerRetour(t, op.sinonI64Hex.bind(op), "sinonI64Hex", inputData.i64);
+  affirmAllerRetour(t, op.sinonU64Dec.bind(op), "sinonU64Dec", inputData.u64);
+  affirmAllerRetour(t, op.sinonU64Hex.bind(op), "sinonU64Hex", inputData.u64);
+
+  // 64 bit float
+  affirmAllerRetour(t, op.sinonF64.bind(op), "sinonF64", inputData.f64);
+
+  // affirmAllerRetour(t, op.sinonEnum.bind(op), "sinonEnum", inputData.enums);
+
+  op.uniffiDestroy();
+});

--- a/fixtures/rondpoint-procmacro/tests/test_generated_bindings.rs
+++ b/fixtures/rondpoint-procmacro/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -43,7 +43,7 @@ export class RustBuffer {
     return new Uint8Array(this.arrayBuffer);
   }
 
-  readBytes(numBytes: number): ArrayBuffer {
+  readArrayBuffer(numBytes: number): ArrayBuffer {
     const start = this.readOffset;
     const end = this.checkOverflow(start, numBytes);
     const value = this.arrayBuffer.slice(start, end);
@@ -51,11 +51,28 @@ export class RustBuffer {
     return value;
   }
 
-  writeBytes(buffer: ArrayBuffer) {
+  readByteArray(numBytes: number): UniffiByteArray {
+    const start = this.readOffset;
+    const end = this.checkOverflow(start, numBytes);
+    const value = new Uint8Array(this.arrayBuffer, start, numBytes);
+    this.readOffset = end;
+    return value;
+  }
+
+  writeArrayBuffer(buffer: ArrayBuffer) {
     const start = this.writeOffset;
     const end = this.checkOverflow(start, buffer.byteLength);
 
     const src = new Uint8Array(buffer);
+    const dest = new Uint8Array(this.arrayBuffer, start);
+    dest.set(src);
+
+    this.writeOffset = end;
+  }
+
+  writeByteArray(src: UniffiByteArray) {
+    const start = this.writeOffset;
+    const end = this.checkOverflow(start, src.byteLength);
     const dest = new Uint8Array(this.arrayBuffer, start);
     dest.set(src);
 

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -56,6 +56,7 @@ export type UnsafeMutableRawPointer = bigint;
  */
 export interface UniffiObjectFactory<T> {
   bless(pointer: UnsafeMutableRawPointer): UniffiRustArcPtr;
+  unbless(ptr: UniffiRustArcPtr): void;
   create(pointer: UnsafeMutableRawPointer): T;
   pointer(obj: T): UnsafeMutableRawPointer;
   clonePointer(obj: T): UnsafeMutableRawPointer;


### PR DESCRIPTION
This PR adds:

- lowlevel structures
  - RustBuffers, 
  - Floats and 
  - c_void Void Pointers.
- high level mechanisms to do in a browser context:
  - encoding and decoding strings, using `TextEncoder` and `TextDecoder`.
  - tie Objects into the Garbage Collector with a `FinalizationRegistry`.

This is in service of getting the `rondpoint` fixture running.

Several things to note here:

### `error: rondpointpm::Optionneur is a private type`

Structs which derive the `uniffi::Object` currently need to have visibility `pub`. If they're not, then errors like: `error: rondpointpm::Optionneur is a private type` are shown. 

This is due to `uniffi-rs` generating a public C ABI which uses the private struct as part of its trait bounds. This feels like it's a Rust bug (I hate saying that). 

Next steps:

- File an issue: 
  - `uniffi-rs` could generate a simpler ABI which didn't contain the private type.
  - `uniffi-rs` could prevent non-`pub` structs
- Document: `uniffi-bindgen-react-native` should add this to a trouble-shooting page.

### Additing a procmacro version of rondpoint and coverall2

This is due to https://github.com/mozilla/uniffi-rs/pull/2329 not yet being release.

Since we have now released to CocoaPods and npm, I can build against uniffi-main. This is o k a y for a little project like this, but I do worry about that a chem-spill requiring a rapid fix and release may get messy.

### Default attribute values not seeming to work in proc-macro `uniffi::Record`

I don't seem to be able to get default attributes working for records going: as in the typescript isn't getting generated. If this is a bug, this is almost certainly a uniffi-rs bug. Will file.