### PR TITLE
Output selected library file when using --and-generate and reproducibly pick the same file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## 🦊 What's Changed
 * Switched from passing `ArrayBuffer`s to using `Uint8Array`, to accommodate WASM better. ([#187](https://github.com/jhugman/uniffi-bindgen-react-native/pull/187))
+* Reproducibly pick the same library file when using `--and-generate` ([#194](https://github.com/jhugman/uniffi-bindgen-react-native/pull/194))
 
 **Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-1...main
 

--- a/crates/ubrn_cli/src/building.rs
+++ b/crates/ubrn_cli/src/building.rs
@@ -40,6 +40,7 @@ impl BuildArgs {
     }
 
     fn generate(&self, lib_file: Utf8PathBuf) -> Result<()> {
+        eprintln!("Generating bindings and turbo module from lib file {}", lib_file);
         GenerateAllCommand::platform_specific(
             lib_file,
             self.cmd.project_config()?,
@@ -51,10 +52,12 @@ impl BuildArgs {
 
 impl BuildCmd {
     pub(crate) fn build(&self) -> Result<Utf8PathBuf> {
-        let files = match self {
+        let mut files = match self {
             Self::Android(a) => a.build()?,
             Self::Ios(a) => a.build()?,
         };
+
+        files.sort(); // Sort so that we reproducibly pick the same file below
 
         files
             .first()

--- a/crates/ubrn_cli/src/building.rs
+++ b/crates/ubrn_cli/src/building.rs
@@ -40,7 +40,10 @@ impl BuildArgs {
     }
 
     fn generate(&self, lib_file: Utf8PathBuf) -> Result<()> {
-        eprintln!("Generating bindings and turbo module from lib file {}", lib_file);
+        eprintln!(
+            "Generating bindings and turbo module from lib file {}",
+            lib_file
+        );
         GenerateAllCommand::platform_specific(
             lib_file,
             self.cmd.project_config()?,


### PR DESCRIPTION
Part of the problem in #136 is that the concrete library file used for generating the bindings and turbo module is subject to external factors. This change outputs the path of the selected file and deterministically picks the first one in alphabetic order.

When building for both aarch64 and x86, this coincidentally hides the error described in #136.