### PR TITLE
Use `ArrayBufferLike` instead of `ArrayBuffer` for reading/writing bytes

### DIFF
--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -43,7 +43,7 @@ export class RustBuffer {
     return new Uint8Array(this.arrayBuffer);
   }
 
-  readArrayBuffer(numBytes: number): ArrayBuffer {
+  readArrayBuffer(numBytes: number): ArrayBufferLike {
     const start = this.readOffset;
     const end = this.checkOverflow(start, numBytes);
     const value = this.arrayBuffer.slice(start, end);
@@ -59,7 +59,7 @@ export class RustBuffer {
     return value;
   }
 
-  writeArrayBuffer(buffer: ArrayBuffer) {
+  writeArrayBuffer(buffer: ArrayBufferLike) {
     const start = this.writeOffset;
     const end = this.checkOverflow(start, buffer.byteLength);
 


### PR DESCRIPTION
Prior to using `ArrayBufferLike`, TypeScript compilation errors in the generated output would occur:

```
src/generated/foobar.ts:1133:25 - error TS2345: Argument of type '(value: ArrayBuffer) => string' is not assignable to parameter of type 'StringLifter'.
  Types of parameters 'value' and 'bytes' are incompatible.
    Type 'Uint8Array<ArrayBufferLike>' is missing the following properties from type 'ArrayBuffer': maxByteLength, resizable, resize, detached, and 2 more.
```

Unfortunately, due to merging #197, these legitimate errors were also hidden. Ideally, we should investigate why the generated output has compilation issues and resolve them, and then revert #197.