### PR TITLE
Stabilise `require.resolve` by looking up `package.json` instead of entrypoint

### DIFF
--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -24,8 +24,10 @@ function getRootDir() {
   }
 
   // Fallback to using require.resolve
-  const resolvedPath = require.resolve("uniffi-bindgen-react-native");
-  return resolvedPath.replace(/\/typescript\/src\/index\.ts$/, "");
+  const resolvedPath = require.resolve(
+    "uniffi-bindgen-react-native/package.json",
+  );
+  return path.dirname(resolvedPath);
 }
 
 // Get the root directory

--- a/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
+++ b/crates/ubrn_cli/src/codegen/templates/CMakeLists.txt
@@ -13,12 +13,12 @@ set (CMAKE_CXX_STANDARD 17)
 
 # Resolve the path to the uniffi-bindgen-react-native package
 execute_process(
-    COMMAND node -p "require.resolve('uniffi-bindgen-react-native')"
+    COMMAND node -p "require.resolve('uniffi-bindgen-react-native/package.json')"
     OUTPUT_VARIABLE UNIFFI_BINDGEN_PATH
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 string(REGEX
-  REPLACE "/typescript/src/index\\.ts$" ""
+  REPLACE "/package\\.json$" ""
   UNIFFI_BINDGEN_PATH ${UNIFFI_BINDGEN_PATH}
 )
 


### PR DESCRIPTION
This change decouples the path lookup from the internal entrypoint of `uniffi-bindgen-react-native`.

Since `package.json` always lives at the root of an npm module, `require.resolve`-ing it and then either stripping `/package.json` from the end, or passing the path to `path.dirname()` will get the module's path on-disk.