### PR TITLE
Callbacks now have UniffiResult to communicate between typescript and C++

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/mod.rs
@@ -17,8 +17,8 @@ use uniffi_bindgen::ComponentInterface;
 pub(crate) use self::{config::CppConfig as Config, util::format_directory};
 use crate::bindings::{
     extensions::{
-        ComponentInterfaceExt, FfiArgumentExt, FfiCallbackFunctionExt, FfiFieldExt, FfiStructExt,
-        FfiTypeExt, ObjectExt,
+        ComponentInterfaceExt, FfiCallbackFunctionExt, FfiFieldExt, FfiStructExt, FfiTypeExt,
+        ObjectExt,
     },
     metadata::ModuleMetadata,
 };

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/filters.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/filters.rs
@@ -22,6 +22,15 @@ pub(super) fn type_name(
     Ok(type_.as_codetype().type_label(types.ci))
 }
 
+pub(super) fn ffi_type_name_from_type(
+    as_type: &impl AsType,
+    types: &TypeRenderer,
+) -> Result<String, askama::Error> {
+    let type_ = types.as_type(as_type);
+    let ffi_type = FfiType::from(type_);
+    ffi_type_name(&ffi_type)
+}
+
 pub(super) fn decl_type_name(
     as_type: &impl AsType,
     types: &TypeRenderer,

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi.ts
@@ -7,6 +7,7 @@ import {
   type UniffiRustArcPtr,
   type UniffiRustCallStatus,
   type UniffiRustFutureContinuationCallback as RuntimeUniffiRustFutureContinuationCallback,
+  type UniffiResult,
  } from 'uniffi-bindgen-react-native';
 
 interface NativeModuleInterface {
@@ -42,10 +43,13 @@ export default getter;
 {%-   if callback.has_rust_call_status_arg() -%}
 {%      if callback.arguments().len() > 0 %}, {% endif %}callStatus: UniffiRustCallStatus
 {%-   endif %}) => {# space #}
-{%-   match callback.return_type() %}
-{%-     when Some(return_type) %}{{ return_type|ffi_type_name }}
-{%-     when None %}void
-{%-   endmatch %};
+{%-   if callback.returns_result() %}
+{%-     match callback.arg_return_type() %}
+{%-       when Some(return_type) %}UniffiResult<{{ return_type|ffi_type_name }}>
+{%-       when None %}UniffiResult<void>
+{%-     endmatch %}
+{%    else %}void
+{%-   endif %};
 {%- when FfiDefinition::Struct(ffi_struct) %}
 {% call exported(ffi_struct) %}type {{ ffi_struct.name()|ffi_struct_name }} = {
   {%- for field in ffi_struct.fields() %}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -16,6 +16,7 @@ export * from "./ffi-types";
 export * from "./handle-map";
 export * from "./objects";
 export * from "./records";
+export * from "./result";
 export * from "./rust-call";
 export * from "./symbols";
 export * from "./type-utils";

--- a/typescript/src/result.ts
+++ b/typescript/src/result.ts
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+import { type UniffiByteArray } from "./ffi-types";
+import { type UniffiReferenceHolder } from "./callbacks";
+import { type UniffiRustCallStatus } from "./rust-call";
+
+// This Result combines RustCallStatus and ReferenceHolder.
+// This is principally so we can _return_ something from calling from native into typescript.
+
+export type UniffiResult<T> = UniffiReferenceHolder<T> | UniffiRustCallStatus;
+
+export const UniffiResult = {
+  ready<T>(): UniffiResult<T> {
+    return { code: 0 };
+  },
+  writeError<T>(
+    result: UniffiResult<T>,
+    code: number,
+    buf: UniffiByteArray,
+  ): UniffiResult<T> {
+    const status = result as UniffiRustCallStatus;
+    status.code = code;
+    status.errorBuf = buf;
+    return status;
+  },
+  writeSuccess<T>(result: UniffiResult<T>, obj: T): UniffiResult<T> {
+    const refHolder = result as UniffiReferenceHolder<T>;
+    refHolder.pointee = obj;
+    return refHolder;
+  },
+  success<T>(pointee: T): UniffiResult<T> {
+    return { pointee };
+  },
+};


### PR DESCRIPTION
This is the first of between 1 and 3 PRs on the JSI to unify `uniffi_out_return` and `RustCallStatus` into new `UniffiResult<T>` object.

This PR eliminates the need for out parameters for callbacks between typescript and C++. The out paramaters are still needed to call into Rust, but these are all now hidden from the typescript.

Primarily this is to enable WASM callbacks.

This is not yet done for ordinary functions (which use an out parameter `RustCallStatus` for errors), and may never be.

For async callbacks, the errors and returns are passed by calling from typescript into Rust. There is a complication about __what__ is being called, but I don't think this needs any action yet.

For Typescript to Rust promises/futures, there is already an result object of sorts: it is monomorphisized already, which we're going to have to do soon with `UniffiResult`, so I'm not quite sure if we need to use those instead of a new type.