### PR TITLE
Fixup GC'ing objects with callbacks intermittent crasher

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/extensions.rs
+++ b/crates/ubrn_bindgen/src/bindings/extensions.rs
@@ -414,7 +414,7 @@ pub(crate) impl FfiCallbackFunction {
     }
 
     fn is_blocking(&self) -> bool {
-        self.name() != "RustFutureContinuationCallback"
+        !self.is_free_callback() && self.name() != "RustFutureContinuationCallback"
     }
 
     fn arguments_no_return(&self) -> impl Iterator<Item = &FfiArgument> {

--- a/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
+++ b/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
@@ -44,7 +44,7 @@ async function testToMax(max: number, t: AsyncAsserts) {
 }
 
 (async () => {
-  for (let i = 1; i <= 512; i *= 2) {
+  for (let i = 1; i <= 4096; i *= 2) {
     await asyncTest(
       `Full tilt test up to ${i}`,
       async (t) => await testToMax(i, t),

--- a/fixtures/gc-callbacks-crasher/Cargo.toml
+++ b/fixtures/gc-callbacks-crasher/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "gc-callbacks-crasher"
+edition = "2021"
+version = "0.22.0"
+license = "MPL-2.0"
+publish = false
+
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+async-std = "1.12.0"
+async-trait = "0.1.83"
+thiserror = "1.0"
+uniffi = { workspace = true, features = ["tokio"] }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/gc-callbacks-crasher/src/lib.rs
+++ b/fixtures/gc-callbacks-crasher/src/lib.rs
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use std::sync::Arc;
+
+#[uniffi::export(callback_interface)]
+#[async_trait::async_trait]
+pub trait AsyncDelegate: Sync + Send {
+    async fn method(&self, user_id: String) -> String;
+}
+
+#[uniffi::export(callback_interface)]
+pub trait BasicDelegate: Sync + Send {
+    fn method(&self, user_id: String) -> String;
+}
+
+#[derive(Clone, uniffi::Object)]
+pub struct Builder {
+    async_delegate: Option<Arc<dyn AsyncDelegate>>,
+    basic_delegate: Option<Arc<dyn BasicDelegate>>,
+}
+
+pub(crate) fn unwrap_or_clone_arc<T: Clone>(arc: Arc<T>) -> T {
+    Arc::try_unwrap(arc).unwrap_or_else(|x| (*x).clone())
+}
+
+#[uniffi::export]
+impl Builder {
+    pub fn echo(self: Arc<Self>) -> String {
+        "echo".to_string()
+    }
+    pub fn set_async_delegate(self: Arc<Self>, delegate: Box<dyn AsyncDelegate>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.async_delegate = Some(delegate.into());
+        Arc::new(builder)
+    }
+    pub fn set_basic_delegate(self: Arc<Self>, delegate: Box<dyn BasicDelegate>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.basic_delegate = Some(delegate.into());
+        Arc::new(builder)
+    }
+}
+
+impl Builder {
+    pub fn set_basic_delegate_simplistic(&mut self, delegate: Box<dyn BasicDelegate>) {
+        self.basic_delegate = Some(delegate.into());
+    }
+}
+
+#[uniffi::export]
+pub fn get_builder() -> Arc<Builder> {
+    Arc::new(new_builder())
+}
+
+pub fn new_builder() -> Builder {
+    Builder {
+        async_delegate: None,
+        basic_delegate: None,
+    }
+}
+
+#[uniffi::export]
+pub fn create_arc_dropping_builder(delegate: Box<dyn BasicDelegate>) {
+    let builder = get_builder();
+    builder.set_basic_delegate(delegate);
+}
+
+// Not crashing
+#[uniffi::export]
+pub fn create_dropping_builder(delegate: Box<dyn BasicDelegate>) {
+    let mut builder = new_builder();
+    builder.set_basic_delegate_simplistic(delegate);
+    drop(builder);
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/gc-callbacks-crasher/tests/bindings/test_gc_callbacks_crasher.ts
+++ b/fixtures/gc-callbacks-crasher/tests/bindings/test_gc_callbacks_crasher.ts
@@ -1,0 +1,101 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { asyncTest } from "@/asserts";
+import theModule, {
+  type BasicDelegate,
+  Builder,
+  createArcDroppingBuilder,
+  createDroppingBuilder,
+  getBuilder,
+} from "../../generated/gc_callbacks_crasher";
+
+theModule.initialize();
+
+function delayPromise(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+const basicDelegate: BasicDelegate = {
+  method: (userId: string) => {
+    return "foo";
+  },
+};
+
+(async () => {
+  await asyncTest("using no callback", async (t) => {
+    const makeClientBuilder = async () => {
+      try {
+        const builder = getBuilder();
+        (builder as Builder).uniffiDestroy();
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    for (let i = 0; i < 1000; i++) {
+      await makeClientBuilder();
+    }
+    await delayPromise(1000);
+    t.end();
+  });
+  await asyncTest("using uniffiDestroy", async (t) => {
+    const makeClientBuilder = async () => {
+      try {
+        const builder = getBuilder();
+        builder.setBasicDelegate(basicDelegate);
+        (builder as Builder).uniffiDestroy();
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    for (let i = 0; i < 1000; i++) {
+      await makeClientBuilder();
+    }
+    await delayPromise(1000);
+    t.end();
+  });
+
+  await asyncTest("Dropping in Rust", async (t) => {
+    try {
+      for (let i = 0; i < 1000; i++) {
+        createDroppingBuilder(basicDelegate);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+    await delayPromise(1000);
+    t.end();
+  });
+
+  await asyncTest("Dropping Arc in Rust", async (t) => {
+    try {
+      for (let i = 0; i < 1000; i++) {
+        createArcDroppingBuilder(basicDelegate);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+    await delayPromise(1000);
+    t.end();
+  });
+
+  await asyncTest("using C++ destructors", async (t) => {
+    const makeClientBuilder = async () => {
+      try {
+        const builder = getBuilder();
+        builder.setBasicDelegate(basicDelegate);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    for (let i = 0; i < 1000; i++) {
+      await makeClientBuilder();
+    }
+    await delayPromise(1000);
+    t.end();
+  });
+})();


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Fixes https://github.com/zzorba/ubrn-sample-app/pull/1

The investigation for this was in https://github.com/zzorba/ubrn-sample-app/pull/1.

The key insight here is that the "fake GC" destructor is calling into Rust which then calls a free callback in hermes, which somehow triggers another GC.

The fix is to schedule the free callback on the event loop.

This also fixes previously encountered `"Stats not submitted."` assertion failures.

Possible other things to do for this: document that you shouldn't call callbacks in a `Drop::drop` though I'm not sure how to phrase that without being too restrictive.