### PR TITLE
Followup to using non-blocking calls more widely

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -15,12 +15,9 @@ const {{ trait_impl }}: { vtable: {{ vtable|ffi_type_name }}; register: () => vo
     vtable: {
         {%- for (ffi_callback, meth) in vtable_methods %}
         {{ meth.name()|fn_name }}: (
-            {%- for arg in ffi_callback.arguments() %}
+            {%- for arg in ffi_callback.arguments_no_return() %}
             {{ arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name }}{% if !loop.last || ffi_callback.has_rust_call_status_arg() %},{% endif %}
             {%- endfor -%}
-            {%- if ffi_callback.has_rust_call_status_arg() %}
-            uniffiCallStatus: UniffiRustCallStatus
-            {%- endif %}
         ) => {
             const uniffiMakeCall = {# space #}
             {%- if meth.is_async() %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi.ts
@@ -3,9 +3,9 @@
 
 import {
   type StructuralEquality as UniffiStructuralEquality,
-  type UniffiReferenceHolder,
-  type UniffiRustArcPtr,
+  type UniffiForeignFuture as RuntimeUniffiForeignFuture,
   type UniffiRustCallStatus,
+  type UniffiRustArcPtr,
   type UniffiRustFutureContinuationCallback as RuntimeUniffiRustFutureContinuationCallback,
   type UniffiResult,
  } from 'uniffi-bindgen-react-native';
@@ -37,12 +37,9 @@ export default getter;
 {%- match def %}
 {%- when FfiDefinition::CallbackFunction(callback) %}
 {% call exported(callback) %}type {{ callback.name()|ffi_callback_name }} = (
-{%-   for arg in callback.arguments() %}
+{%-   for arg in callback.arguments_no_return() %}
 {{- arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name }}{% if !loop.last %}, {% endif %}
-{%-   endfor %}
-{%-   if callback.has_rust_call_status_arg() -%}
-{%      if callback.arguments().len() > 0 %}, {% endif %}callStatus: UniffiRustCallStatus
-{%-   endif %}) => {# space #}
+{%-   endfor %}) => {# space #}
 {%-   if callback.returns_result() %}
 {%-     match callback.arg_return_type() %}
 {%-       when Some(return_type) %}UniffiResult<{{ return_type|ffi_type_name }}>
@@ -88,6 +85,10 @@ export default getter;
 const isRustFutureContinuationCallbackTypeCompatible: UniffiStructuralEquality<
   RuntimeUniffiRustFutureContinuationCallback,
   UniffiRustFutureContinuationCallback
+> = true;
+const isUniffiForeignFutureTypeCompatible: UniffiStructuralEquality<
+  RuntimeUniffiForeignFuture,
+  UniffiForeignFuture
 > = true;
 
 {%- import "macros.ts" as ts %}

--- a/typescript/src/async-callbacks.ts
+++ b/typescript/src/async-callbacks.ts
@@ -29,7 +29,7 @@ function emptyLowerError<E>(e: E): UniffiByteArray {
 }
 
 // Callbacks passed into Rust.
-export type UniffiForeignFutureFree = (handle: bigint) => void;
+type UniffiForeignFutureFree = (handle: bigint) => void;
 
 export type UniffiForeignFuture = {
   handle: bigint;


### PR DESCRIPTION
This is a followup to #208 to tidy up the `FfiCallbackFuncrtion` extensions in `extensions.rs`.

Most notably, it generalizes the `is_blocking` function to callback functions that do not have a return and are not expected to error, ever. 