### PR TITLE
Add option to generate native swift bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Upcoming releases
 
 [//]: # (## ✨ What's New)
+
+* Add option to generate native swift bindings ([#214](https://github.com/jhugman/uniffi-bindgen-react-native/pull/214))
+
 [//]: # (## 🦊 What's Changed)
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})

--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -479,6 +479,7 @@ mod tests {
                 targets: Default::default(),
                 cargo_extras: ExtraArgs::default(),
                 codegen_output_dir: "ios/generated".to_string(),
+                native_bindings_dir: "swift".to_string(),
             };
             let bindings = BindingsConfig {
                 cpp: "cpp/bindings".to_string(),

--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -479,7 +479,6 @@ mod tests {
                 targets: Default::default(),
                 cargo_extras: ExtraArgs::default(),
                 codegen_output_dir: "ios/generated".to_string(),
-                native_bindings_dir: "swift".to_string(),
             };
             let bindings = BindingsConfig {
                 cpp: "cpp/bindings".to_string(),

--- a/crates/ubrn_cli/src/codegen/templates/module-template.podspec
+++ b/crates/ubrn_cli/src/codegen/templates/module-template.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   {%- let tm = self.relative_to(root, dir) %}
   {%- let dir = self.config.project.bindings.cpp_path(root) %}
   {%- let bindings = self.relative_to(root, dir) -%}
-  s.source_files = "{{ ios }}/**/*.{h,m,mm}", "{{ codegen }}/**/*.{h,m,mm}", "{{ tm }}/**/*.{hpp,cpp,c,h}", "{{ bindings }}/**/*.{hpp,cpp,c,h}"
+  s.source_files = "{{ ios }}/**/*.{h,m,mm,swift}", "{{ codegen }}/**/*.{h,m,mm}", "{{ tm }}/**/*.{hpp,cpp,c,h}", "{{ bindings }}/**/*.{hpp,cpp,c,h}"
   s.vendored_frameworks = "{{ framework }}"
   s.dependency    "uniffi-bindgen-react-native", "{{ self.config.project.ubrn_version() }}"
 

--- a/crates/ubrn_cli/src/ios.rs
+++ b/crates/ubrn_cli/src/ios.rs
@@ -44,9 +44,6 @@ pub(crate) struct IOsConfig {
 
     #[serde(default = "IOsConfig::default_codegen_output_dir")]
     pub(crate) codegen_output_dir: String,
-
-    #[serde(default = "IOsConfig::default_native_bindings_dir")]
-    pub(crate) native_bindings_dir: String,
 }
 
 impl IOsConfig {
@@ -88,10 +85,6 @@ impl IOsConfig {
     fn default_codegen_output_dir() -> String {
         workspace::package_json().ios_codegen_output_dir()
     }
-
-    fn default_native_bindings_dir() -> String {
-        "swift".to_string()
-    }
 }
 
 impl Default for IOsConfig {
@@ -115,7 +108,7 @@ impl IOsConfig {
     }
 
     pub(crate) fn native_bindings_dir(&self, project_root: &Utf8Path) -> Utf8PathBuf {
-        project_root.join(&self.native_bindings_dir)
+        self.directory(project_root).join("swift")
     }
 }
 

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::fs;
+use std::fs::{self, rename};
 
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -84,6 +84,19 @@ pub fn mk_dir<P: AsRef<Utf8Path>>(dir: P) -> Result<()> {
         fs::create_dir_all(dir)?;
         Ok(())
     }
+}
+
+pub fn mv_files(extension: &str, source: &Utf8Path, destination: &Utf8Path) -> Result<()> {
+    for entry in source.read_dir_utf8()? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_file() || path.extension() != Some(extension) {
+            continue;
+        }
+        let file_name = path.file_name().expect("Could not get file name from path");
+        rename(path, destination.join(file_name))?
+    }
+    Ok(())
 }
 
 pub fn read_from_file<P, T>(file: P) -> Result<T>


### PR DESCRIPTION
Relates to: #149

This adds an option to the `build ios` command to produce native Swift bindings.

Testing with matrix-rust-sdk, using this option would produce the `.h` and `.modulemap` files inside the `.xcframework` and the Swift files in the separate `swift` folder.

```shell
$ tree build/RnMatrixRustSdk.xcframework && tree swift
build/RnMatrixRustSdk.xcframework
├── Info.plist
├── ios-arm64
│   ├── Headers
│   │   ├── matrix_sdkFFI.h
│   │   ├── matrix_sdk_baseFFI.h
│   │   ├── matrix_sdk_commonFFI.h
│   │   ├── matrix_sdk_cryptoFFI.h
│   │   ├── matrix_sdk_ffiFFI.h
│   │   ├── matrix_sdk_uiFFI.h
│   │   └── module.modulemap
│   └── libmatrix_sdk_ffi.a
└── ios-arm64-simulator
    ├── Headers
    │   ├── matrix_sdkFFI.h
    │   ├── matrix_sdk_baseFFI.h
    │   ├── matrix_sdk_commonFFI.h
    │   ├── matrix_sdk_cryptoFFI.h
    │   ├── matrix_sdk_ffiFFI.h
    │   ├── matrix_sdk_uiFFI.h
    │   └── module.modulemap
    └── libmatrix_sdk_ffi.a

5 directories, 17 files
swift
├── matrix_sdk.swift
├── matrix_sdk_base.swift
├── matrix_sdk_common.swift
├── matrix_sdk_crypto.swift
├── matrix_sdk_ffi.swift
└── matrix_sdk_ui.swift

1 directory, 6 files
```