### PR TITLE
Fixup hermes build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         run: sudo apt-get install -y cmake ninja-build
 
       - name: Installing hermes and test-runner
-        run: cargo xtask bootstrap
+        run: |
+          cargo xtask bootstrap hermes --branch rn/0.77-stable
+          cargo xtask bootstrap
 
       - name: Run tests of generated JSI bindings
         run: ./scripts/run-tests.sh


### PR DESCRIPTION
This PR changes the version of Hermes used to run the JSI tests to be the version release in React Native 0.77.

It switches from `main`, which was failing to build on Linux with the toolchain currently installed on CI.

Subsequent PRs may either change this back and fix the toolchain, or increment the release branch used.