### PR TITLE
Add option to generate native kotlin bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Upcoming releases
 
-[//]: # (## ✨ What's New)
+## ✨ What's New
 
 * Add option to generate native swift bindings ([#214](https://github.com/jhugman/uniffi-bindgen-react-native/pull/214))
 * Add option to generate native kotlin bindings ([#218](https://github.com/jhugman/uniffi-bindgen-react-native/pull/218))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [//]: # (## ✨ What's New)
 
 * Add option to generate native swift bindings ([#214](https://github.com/jhugman/uniffi-bindgen-react-native/pull/214))
+* Add option to generate native kotlin bindings ([#218](https://github.com/jhugman/uniffi-bindgen-react-native/pull/218))
 
 [//]: # (## 🦊 What's Changed)
 [//]: # (## ⚠️ Breaking Changes)

--- a/crates/ubrn_cli/src/android.rs
+++ b/crates/ubrn_cli/src/android.rs
@@ -4,7 +4,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use serde::Deserialize;
-use std::{collections::HashMap, fmt::Display, fs, process::Command, str::FromStr};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Display,
+    fs,
+    process::Command,
+    str::FromStr,
+};
 
 use clap::Args;
 
@@ -304,11 +310,10 @@ impl AndroidArgs {
         let manifest_path = config.crate_.manifest_path()?;
         let metadata = CrateMetadata::cargo_metadata(manifest_path)?;
         let config_supplier = CrateConfigSupplier::from(metadata);
-        let mut libs = target_files
+        let libs = target_files
             .clone()
             .into_values()
-            .collect::<Vec<Utf8PathBuf>>();
-        libs.sort();
+            .collect::<BTreeSet<Utf8PathBuf>>();
         let library_path = libs
             .first()
             .context("Need at least one library file to generate native Kotlin bindings")?;

--- a/crates/ubrn_cli/src/android.rs
+++ b/crates/ubrn_cli/src/android.rs
@@ -8,9 +8,13 @@ use std::{collections::HashMap, fmt::Display, fs, process::Command, str::FromStr
 
 use clap::Args;
 
-use anyhow::{Error, Result};
+use anyhow::{Context, Error, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use ubrn_common::{mk_dir, rm_dir, run_cmd, CrateMetadata};
+use uniffi_bindgen::{
+    bindings::KotlinBindingGenerator, cargo_metadata::CrateConfigSupplier,
+    library_mode::generate_bindings,
+};
 
 use crate::{
     building::{CommonBuildArgs, ExtraArgs},
@@ -153,6 +157,10 @@ pub(crate) struct AndroidArgs {
     /// Suppress the copying of the Rust library into the JNI library directories.
     #[clap(long = "no-jniLibs")]
     no_jni_libs: bool,
+
+    /// Generate native Kotlin Bindings together with the JNI libraries
+    #[clap(long, conflicts_with_all = ["no_jni_libs"], default_value = "false")]
+    native_bindings: bool,
 }
 
 impl AndroidArgs {
@@ -189,6 +197,9 @@ impl AndroidArgs {
                 &android.jni_libs(project_root),
                 &target_files,
             )?;
+            if self.native_bindings {
+                self.generate_native_bindings(&config, &target_files)?;
+            }
         }
 
         Ok(target_files.into_values().collect())
@@ -281,6 +292,36 @@ impl AndroidArgs {
             println!("cp {library} {dst_lib}");
             fs::copy(library, &dst_lib)?;
         }
+        Ok(())
+    }
+
+    fn generate_native_bindings(
+        &self,
+        config: &ProjectConfig,
+        target_files: &HashMap<Target, Utf8PathBuf>,
+    ) -> Result<(), anyhow::Error> {
+        println!("-- Generating native Kotlin bindings");
+        let manifest_path = config.crate_.manifest_path()?;
+        let metadata = CrateMetadata::cargo_metadata(manifest_path)?;
+        let config_supplier = CrateConfigSupplier::from(metadata);
+        let mut libs = target_files
+            .clone()
+            .into_values()
+            .collect::<Vec<Utf8PathBuf>>();
+        libs.sort();
+        let library_path = libs
+            .first()
+            .context("Need at least one library file to generate native Kotlin bindings")?;
+        let out_dir = config.android.src_main_java_dir(config.project_root());
+        generate_bindings(
+            library_path,
+            None,
+            &KotlinBindingGenerator,
+            &config_supplier,
+            None,
+            &out_dir,
+            false,
+        )?;
         Ok(())
     }
 

--- a/docs/src/reference/commandline.md
+++ b/docs/src/reference/commandline.md
@@ -101,6 +101,9 @@ Options:
       --no-jniLibs
           Suppress the copying of the Rust library into the JNI library directories
 
+      --native-bindings
+          Generate native Kotlin Bindings together with the JNI libraries
+
   -h, --help
           Print help (see a summary with '-h')
 ```
@@ -156,6 +159,9 @@ Options:
           Does not perform the xcodebuild step to generate the xcframework
 
           The xcframework will need to be generated externally from this tool. This is useful when adding extra bindings (e.g. Swift) to the project.
+
+      --native-bindings
+          Generate native Swift Bindings together with the xcframework
 
   -t, --targets <TARGETS>...
           Comma separated list of targets, that override the values in the `config.yaml` file.


### PR DESCRIPTION
Relates to: #149

Using react-native-matrix-sdk as an example, the new option will generate the following files:

```
$ tree android
android
├── ...
└── src
    └── main
        ├── ...
        ├── java
        │   ├── ...
        │   ├── org
        │   │   └── matrix
        │   │       └── rustcomponents
        │   │           └── sdk
        │   │               └── matrix_sdk_ffi.kt
        │   └── uniffi
        │       ├── matrix_sdk
        │       │   └── matrix_sdk.kt
        │       ├── matrix_sdk_base
        │       │   └── matrix_sdk_base.kt
        │       ├── matrix_sdk_common
        │       │   └── matrix_sdk_common.kt
        │       ├── matrix_sdk_crypto
        │       │   └── matrix_sdk_crypto.kt
        │       └── matrix_sdk_ui
        │           └── matrix_sdk_ui.kt
        └── jniLibs
            └── ...
```