### PR TITLE
Move caching of future-continuation-callback for better hot-reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
+## 🦊 What's Changed
+
+- Hot-reloading: ensure promises resolve after hot reload ([#230](https://github.com/jhugman/uniffi-bindgen-react-native/pull/230)).
+  - Thank you [@matthieugayon](https://github.com/matthieugayon)!
 
 **Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-3...main
 

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Future.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Future.cpp
@@ -11,12 +11,11 @@ template <> struct Bridging<UniffiRustFutureContinuationCallback> {
     const jsi::Value &value
   ) {
     try {
-      static auto callback = {{ cb_type.borrow()|cpp_namespace(ci) }}::makeCallbackFunction(
+      return {{ cb_type.borrow()|cpp_namespace(ci) }}::makeCallbackFunction(
         rt,
         callInvoker,
         value
       );
-      return callback;
     } catch (const std::logic_error &e) {
       throw jsi::JSError(rt, e.what());
     }

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/VTableRegistryHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/VTableRegistryHelper.cpp
@@ -1,0 +1,50 @@
+// In other uniffi bindings, it is assumed that the foreign language holds on
+// to the vtable, which the Rust just gets a pointer to.
+// Here, we need to hold on to them, but also be able to clear them at just the
+// right time so we can support hot-reloading.
+namespace {{ registry }} {
+    template <typename T>
+    class VTableHolder {
+    public:
+        T vtable;
+        VTableHolder(T v) : vtable(v) {}
+    };
+
+    // Mutex to bind the storage and setting of vtable together.
+    // We declare it here, but the lock is taken by callers of the putTable
+    // method who are also sending a pointer to Rust.
+    static std::mutex vtableMutex;
+
+    // Registry to hold all vtables so they persist even when JS objects are GC'd.
+    // The only reason this exists is to prevent a dangling pointer in the
+    // Rust machinery: i.e. we don't need to access or write to this registry
+    // after startup.
+    // Registry to hold all vtables so they persist even when JS objects are GC'd.
+    // Maps string identifiers to vtable holders using type erasure
+    static std::unordered_map<std::string, std::shared_ptr<void>> vtableRegistry;
+
+    // Add a vtable to the registry with an identifier
+    template <typename T>
+    static T* putTable(std::string_view identifier, T vtable) {
+        auto holder = std::make_shared<VTableHolder<T>>(vtable);
+        // Store the raw pointer to the vtable before type erasure
+        T* rawPtr = &(holder->vtable);
+        // Store the holder using type erasure with the string identifier
+        vtableRegistry[std::string(identifier)] = std::shared_ptr<void>(holder);
+        return rawPtr;
+    }
+
+    // Clear the registry.
+    //
+    // Conceptually, this is called after teardown of the module (i.e. after
+    // teardown of the jsi::Runtime). However, because Rust is dropping callbacks
+    // because the Runtime is being torn down, we must keep the registry intact
+    // until after the runtime goes away.
+    //
+    // Therefore, in practice we should call this when the next runtime is
+    // being stood up.
+    static void clearRegistry() {
+        std::lock_guard<std::mutex> lock(vtableMutex);
+        vtableRegistry.clear();
+    }
+} // namespace {{ registry }}

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
@@ -2,6 +2,7 @@
 // Trust me, you don't want to mess with it!
 {%- let namespace = ci.namespace() %}
 {%- let module_name = module.cpp_module() %}
+{%- let registry = ci.cpp_namespace()|fmt("{}::registry") %}
 #include "{{ module.hpp_filename() }}"
 
 #include "UniffiJsiTypes.h"
@@ -29,11 +30,12 @@ extern "C" {
     {%- endfor %}
 }
 
-// This calls into Rust.
-
 {% include "BridgingHelper.cpp" %}
 {% include "RustBufferHelper.cpp" %}
 {% include "RustCallStatusHelper.cpp" %}
+{% include "VTableRegistryHelper.cpp" %}
+
+// This calls into Rust.
 
 {%- for def in ci.ffi_definitions() %}
 {%-   match def %}
@@ -85,7 +87,7 @@ void {{ module_name }}::registerModule(jsi::Runtime &rt, std::shared_ptr<react::
 }
 
 void {{ module_name }}::unregisterModule(jsi::Runtime &rt) {
-    // NOOP
+    {{ registry }}::clearRegistry();
 }
 
 jsi::Value {{ module_name }}::get(jsi::Runtime& rt, const jsi::PropNameID& name) {

--- a/fixtures/callbacks/tests/bindings/test_callbacks.ts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.ts
@@ -78,10 +78,10 @@ test("Boolean values passed between callback interfaces", (t) => {
   rg.uniffiDestroy();
 });
 
-test("List values passed between callback interfaces", (t) => {
+test("String values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  const flag = true;
+  const flag = false;
   for (const v of inputData.string) {
     const expected = callbackInterface.getString(v, flag);
     const observed = rg.getString(callbackInterface, v, flag);
@@ -90,10 +90,10 @@ test("List values passed between callback interfaces", (t) => {
   rg.uniffiDestroy();
 });
 
-test("String values passed between callback interfaces", (t) => {
+test("List values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  const flag = true;
+  const flag = false;
   for (const v of inputData.listInt) {
     const expected = callbackInterface.getList(v, flag);
     const observed = rg.getList(callbackInterface, v, flag);

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -89,7 +89,6 @@ for fixture in ${fixtures} ; do
     # Optionally, it could build the crate for us.
     # Generate hermes flavoured JS from typescript, and runs the test.
     cargo xtask run \
-        --no-cargo \
         --abi-dir "${cpp_dir}" \
         --ts-dir "${ts_dir}" \
         --toml "${config_file}" \


### PR DESCRIPTION
Fixes #224 

This PR eliminates a `static` local variable which was holding on to the `RustFutureContinuationCallback` between cycling of the `jsi::Runtime`.

This was there as a performance optimization, to prevent pointless calls to the `makeCallbackFunction` function.

Now, `makeCallbackFunction` is called each time the Future is polled. To prevent `makeCallbackFunction` doing a lot of duplicated work, we also check that the lambda doesn't exist before making a new one. This lambda is already being cleared by the module destructor.
