### PR TITLE
Hot-reloading: ensure jsi::Runtime can be destroyed and remade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
+## 🦊 What's Changed
+
+- Hot-reloading: ensure promises resolve, and callbacks are called after hot reload ([#232](https://github.com/jhugman/uniffi-bindgen-react-native/pull/232)).
+  - Thank you [@matthieugayon](https://github.com/matthieugayon)!
+
 ## 🌏🕸️ WASM!
 
 - Add support for Promises/Futures ([#221](https://github.com/jhugman/uniffi-bindgen-react-native/pull/221)).

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Future.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Future.cpp
@@ -11,12 +11,11 @@ template <> struct Bridging<UniffiRustFutureContinuationCallback> {
     const jsi::Value &value
   ) {
     try {
-      static auto callback = {{ cb_type.borrow()|cpp_namespace(ci) }}::makeCallbackFunction(
+      return {{ cb_type.borrow()|cpp_namespace(ci) }}::makeCallbackFunction(
         rt,
         callInvoker,
         value
       );
-      return callback;
     } catch (const std::logic_error &e) {
       throw jsi::JSError(rt, e.what());
     }

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/VTableRegistryHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/VTableRegistryHelper.cpp
@@ -1,0 +1,50 @@
+// In other uniffi bindings, it is assumed that the foreign language holds on
+// to the vtable, which the Rust just gets a pointer to.
+// Here, we need to hold on to them, but also be able to clear them at just the
+// right time so we can support hot-reloading.
+namespace {{ registry }} {
+    template <typename T>
+    class VTableHolder {
+    public:
+        T vtable;
+        VTableHolder(T v) : vtable(v) {}
+    };
+
+    // Mutex to bind the storage and setting of vtable together.
+    // We declare it here, but the lock is taken by callers of the putTable
+    // method who are also sending a pointer to Rust.
+    static std::mutex vtableMutex;
+
+    // Registry to hold all vtables so they persist even when JS objects are GC'd.
+    // The only reason this exists is to prevent a dangling pointer in the
+    // Rust machinery: i.e. we don't need to access or write to this registry
+    // after startup.
+    // Registry to hold all vtables so they persist even when JS objects are GC'd.
+    // Maps string identifiers to vtable holders using type erasure
+    static std::unordered_map<std::string, std::shared_ptr<void>> vtableRegistry;
+
+    // Add a vtable to the registry with an identifier
+    template <typename T>
+    static T* putTable(std::string_view identifier, T vtable) {
+        auto holder = std::make_shared<VTableHolder<T>>(vtable);
+        // Store the raw pointer to the vtable before type erasure
+        T* rawPtr = &(holder->vtable);
+        // Store the holder using type erasure with the string identifier
+        vtableRegistry[std::string(identifier)] = std::shared_ptr<void>(holder);
+        return rawPtr;
+    }
+
+    // Clear the registry.
+    //
+    // Conceptually, this is called after teardown of the module (i.e. after
+    // teardown of the jsi::Runtime). However, because Rust is dropping callbacks
+    // because the Runtime is being torn down, we must keep the registry intact
+    // until after the runtime goes away.
+    //
+    // Therefore, in practice we should call this when the next runtime is
+    // being stood up.
+    static void clearRegistry() {
+        std::lock_guard<std::mutex> lock(vtableMutex);
+        vtableRegistry.clear();
+    }
+} // namespace {{ registry }}

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
@@ -2,6 +2,7 @@
 // Trust me, you don't want to mess with it!
 {%- let namespace = ci.namespace() %}
 {%- let module_name = module.cpp_module() %}
+{%- let registry = ci.cpp_namespace()|fmt("{}::registry") %}
 #include "{{ module.hpp_filename() }}"
 
 #include "UniffiJsiTypes.h"
@@ -29,11 +30,12 @@ extern "C" {
     {%- endfor %}
 }
 
-// This calls into Rust.
-
 {% include "BridgingHelper.cpp" %}
 {% include "RustBufferHelper.cpp" %}
 {% include "RustCallStatusHelper.cpp" %}
+{% include "VTableRegistryHelper.cpp" %}
+
+// This calls into Rust.
 
 {%- for def in ci.ffi_definitions() %}
 {%-   match def %}
@@ -85,7 +87,7 @@ void {{ module_name }}::registerModule(jsi::Runtime &rt, std::shared_ptr<react::
 }
 
 void {{ module_name }}::unregisterModule(jsi::Runtime &rt) {
-    // NOOP
+    {{ registry }}::clearRegistry();
 }
 
 jsi::Value {{ module_name }}::get(jsi::Runtime& rt, const jsi::PropNameID& name) {

--- a/fixtures/callbacks/tests/bindings/test_callbacks.ts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.ts
@@ -78,10 +78,10 @@ test("Boolean values passed between callback interfaces", (t) => {
   rg.uniffiDestroy();
 });
 
-test("List values passed between callback interfaces", (t) => {
+test("String values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  const flag = true;
+  const flag = false;
   for (const v of inputData.string) {
     const expected = callbackInterface.getString(v, flag);
     const observed = rg.getString(callbackInterface, v, flag);
@@ -90,10 +90,10 @@ test("List values passed between callback interfaces", (t) => {
   rg.uniffiDestroy();
 });
 
-test("String values passed between callback interfaces", (t) => {
+test("List values passed between callback interfaces", (t) => {
   const rg = new RustGetters();
   const callbackInterface = new TypeScriptGetters();
-  const flag = true;
+  const flag = false;
   for (const v of inputData.listInt) {
     const expected = callbackInterface.getList(v, flag);
     const observed = rg.getList(callbackInterface, v, flag);

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -89,7 +89,6 @@ for fixture in ${fixtures} ; do
     # Optionally, it could build the crate for us.
     # Generate hermes flavoured JS from typescript, and runs the test.
     cargo xtask run \
-        --no-cargo \
         --abi-dir "${cpp_dir}" \
         --ts-dir "${ts_dir}" \
         --toml "${config_file}" \

--- a/typescript/src/async-callbacks.ts
+++ b/typescript/src/async-callbacks.ts
@@ -104,7 +104,7 @@ function uniffiForeignFutureFree(handle: UniffiHandle) {
   //
   // This would be where the request from Rust to cancel a JS task would come out.
   // Check if the promise has been settled, and if not, cancel it.
-  if (!helper.settledHolder.settled) {
+  if (helper?.settledHolder.settled === false) {
     helper.abortController.abort();
   }
 }

--- a/typescript/src/async-rust-call.ts
+++ b/typescript/src/async-rust-call.ts
@@ -148,7 +148,9 @@ const uniffiFutureContinuationCallback: UniffiRustFutureContinuationCallback = (
   // > callback, some futures will deadlock and our scheduler code might as well.
   //
   // We avoid this by using UniffiCallInvoker::invokeNonBlocking for this callback.
-  resolve(pollResult);
+  if (resolve) {
+    resolve(pollResult);
+  }
 };
 
 // For testing only.

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -36,7 +36,7 @@ export class FfiConverterCallback<T> implements FfiConverter<UniffiHandle, T> {
   allocationSize(value: T): number {
     return handleConverter.allocationSize(defaultUniffiHandle);
   }
-  drop(handle: UniffiHandle): T {
+  drop(handle: UniffiHandle): T | undefined {
     return this.handleMap.remove(handle);
   }
 }

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -129,7 +129,9 @@ export const UniffiInternalError = (() => {
   }
   class UnexpectedStaleHandle extends Error {
     constructor() {
-      super("The object in the handle map has been dropped already");
+      super(
+        "The object is no longer in the handle map, likely because of a hot-reload",
+      );
     }
   }
   class ContractVersionMismatch extends Error {

--- a/typescript/src/handle-map.ts
+++ b/typescript/src/handle-map.ts
@@ -20,17 +20,38 @@ export class UniffiHandleMap<T> {
   get(handle: UniffiHandle): T {
     const obj = this.map.get(handle);
     if (obj === undefined) {
+      // Rust is holding a handle which is no longer in the handle map, either
+      // because this is a different handle map to the one it was inserted in,
+      // or that the handle has already been removed from the handlemap it was
+      // originally in.
+      //
+      // This is because of either:
+      //   a) the Typescript has changed state without resetting a callback
+      //      interface, i.e. a hot reload.
+      //   b) a bug in uniffi-bindgen-react-native.
+      //
+      // If this error is thrown when the app is in the wild, i.e. outside of a
+      // development, i.e. not a hot reload, then please file a bug with
+      // uniffi-bindgen-react-native.
+      //
+      // Otherwise, this error is not recoverable, and a cold reload is
+      // necessary.
+      //
+      // If the error is not intermittent, i.e. happening every reload, then
+      // you should probably consider changing the Rust library to not hold
+      // on to callback interfaces and foreign trait instances across reloads,
+      // e.g. creating app or page lifecycle API, or replacing rather than
+      // appending listeners.
       throw new UniffiInternalError.UnexpectedStaleHandle();
     }
     return obj;
   }
 
-  remove(handle: UniffiHandle): T {
+  remove(handle: UniffiHandle): T | undefined {
     const obj = this.map.get(handle);
-    if (obj === undefined) {
-      throw new UniffiInternalError.UnexpectedStaleHandle();
+    if (obj !== undefined) {
+      this.map.delete(handle);
     }
-    this.map.delete(handle);
     return obj;
   }
 

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -122,11 +122,7 @@ export class FfiConverterObjectWithCallbacks<T> extends FfiConverterObject<T> {
   }
 
   drop(handle: UniffiHandle): T | undefined {
-    if (this.handleMap.has(handle)) {
-      return this.handleMap.remove(handle);
-    } else {
-      return undefined;
-    }
+    return this.handleMap.remove(handle);
   }
 }
 


### PR DESCRIPTION
According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Fixes #224.

This PR eliminates static local variables which were holding on to:

- the `RustFutureContinuationCallback` between cycling of the `jsi::Runtime`.
- callback interface vtables which needed to be stored while a pointer was given to Rust.

The test-runner now runs every test twice with two different `jsi::Runtimes` but the same Rust, ensuring that every structure works across a reload of the Javascript (i.e. simulating a hot-reload).

This PR should be backported to `releases/v0.28.x`, currently: #230.