### PR TITLE
Release v0.28.3-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ---
 
+# 0.28.3-5
+
+## 🦊 What's Changed
+
+- Republishing v0.28.3.4 because Cocoapods timeout.
+
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-4...0.28.3-5
+
+---
+
 # 0.28.3-4
 ## 🦊 What's Changed
 

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.28.3-4"
+version = "0.28.3-5"
 edition = "2021"
 
 [[bin]]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.28.3-4",
+  "version": "0.28.3-5",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {


### PR DESCRIPTION
# 0.28.3-5

## 🦊 What's Changed

- Republishing v0.28.3.4 because Cocoapods timeout.

**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-4...0.28.3-5