### PR TITLE
Release v0.29.0-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.0-0...main
+
+---
+
+# 0.29.0-0
+
 ## 🦊 What's Changed
 
 - Hot-reloading: ensure promises resolve, and callbacks are called after hot reload ([#232](https://github.com/jhugman/uniffi-bindgen-react-native/pull/232)).
@@ -13,15 +19,16 @@
 
 - Add support for Promises/Futures ([#221](https://github.com/jhugman/uniffi-bindgen-react-native/pull/221)).
 
-# (## ⚠️ Breaking Changes)
+## ⚠️ Breaking Changes
 
 - Upgrade [`uniffi-rs` to version 0.29.0](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md#v0290-backend-crates-v0290---2025-02-06).
     - There are several changes users of `uniffi-rs` (and `uniffi-bindgen-react-native`) should be aware; [a migration guide](https://mozilla.github.io/uniffi-rs/latest/Upgrading.html) is provided by the uniffi team.
     - Switching template engines from `askama` to `rinja`.
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-3...main
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-3...0.29.0-0
 
 ---
+
 # 0.28.3-3
 ## ✨ What's New
 

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.28.3-3"
+version = "0.29.0-0"
 edition = "2021"
 
 [[bin]]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.28.3-3",
+  "version": "0.29.0-0",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {


### PR DESCRIPTION
This release is the first that works with [version v0.29.0 of uniffi-rs](https://crates.io/crates/uniffi/0.29.0).

---

# 0.29.0-0

## 🦊 What's Changed

- Hot-reloading: ensure promises resolve, and callbacks are called after hot reload ([#232](https://github.com/jhugman/uniffi-bindgen-react-native/pull/232)).
  - Thank you [@matthieugayon](https://github.com/matthieugayon)!

## 🌏🕸️ WASM!

- Add support for Promises/Futures ([#221](https://github.com/jhugman/uniffi-bindgen-react-native/pull/221)).

## ⚠️ Breaking Changes

- Upgrade [`uniffi-rs` to version 0.29.0](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md#v0290-backend-crates-v0290---2025-02-06).
    - There are several changes users of `uniffi-rs` (and `uniffi-bindgen-react-native`) should be aware; [a migration guide](https://mozilla.github.io/uniffi-rs/latest/Upgrading.html) is provided by the uniffi team.
    - Switching template engines from `askama` to `rinja`.

**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.28.3-3...0.29.0-0