### PR TITLE
Add to "who is using" section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ WASM is an amazing virtual machine however:
 ## Who is using `uniffi-bindgen-react-native`?
 
 - [@unomed/react-native-matrix-sdk](https://www.npmjs.com/package/@unomed/react-native-matrix-sdk)
-- [ChessTiles on iOS](https://apps.apple.com/us/app/chesstiles/id6737867924) "UBRN lets us run our performance critical solution search algorithm and business logic in rust, while rapidly prototying the UI with ReactNative"
+- [ChessTiles on iOS](https://apps.apple.com/us/app/chesstiles/id6737867924) "uniffi-bindgen-react-native lets us run our performance critical solution search algorithm and business logic in Rust, while rapidly prototying the UI with React Native"
 
 ## Prior art and related projects
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ WASM is an amazing virtual machine however:
 ## Who is using `uniffi-bindgen-react-native`?
 
 - [@unomed/react-native-matrix-sdk](https://www.npmjs.com/package/@unomed/react-native-matrix-sdk)
+- [ChessTiles on iOS](https://apps.apple.com/us/app/chesstiles/id6737867924) "UBRN lets us run our performance critical solution search algorithm and business logic in rust, while rapidly prototying the UI with ReactNative"
 
 ## Prior art and related projects
 


### PR DESCRIPTION
Hello ubrn maintainers!
I have an app in the iOS app store that uses ubrn. All my business logic is in Rust with React Native used for the UI layer. The app is not open source, and offers in-app-purchases, but the core functionality is free to use to show people what is possible using the combination of Rust + React Native to combine the performance of Rust with the UI of React Native in a nontrivial application with synchronous and async UI updates.

This pull request adds to the "who is using" section of the readme with a link to where people can download the app and an endorsement blurb about why ubrn has been good for the project.

Open to feedback: thanks for this library!