### PR TITLE
Reduce the generated C++ by removing unused structs

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/extensions.rs
+++ b/crates/ubrn_bindgen/src/bindings/extensions.rs
@@ -139,6 +139,18 @@ pub(crate) impl ComponentInterface {
         "uniffi_jsi".to_string()
     }
 
+    fn has_callbacks(&self) -> bool {
+        !self.callback_interface_definitions().is_empty()
+            || self
+                .object_definitions()
+                .iter()
+                .any(|o| o.has_callback_interface())
+    }
+
+    fn has_async_calls(&self) -> bool {
+        self.iter_callables().any(|c| c.is_async())
+    }
+
     /// We want to control the ordering of definitions in typescript, especially
     /// the FfiConverters which rely on Immediately Invoked Function Expressions (IIFE),
     /// or straight up expressions.
@@ -402,6 +414,10 @@ pub(crate) impl FfiCallbackFunction {
 
     fn is_user_callback(&self) -> bool {
         self.name().starts_with("CallbackInterface")
+    }
+
+    fn is_function_literal(&self) -> bool {
+        self.name().starts_with("ForeignFutureComplete")
     }
 
     fn has_return_out_param(&self) -> bool {

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/extensions.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/extensions.rs
@@ -60,6 +60,9 @@ fn ffi_definitions2(
             // we will do something different with future callbacks.
             continue;
         }
+        if !has_callbacks && ffi_struct.is_vtable() {
+            continue;
+        }
         let mut method_module_idents = HashMap::new();
         for field in ffi_struct.fields() {
             let FfiType::Callback(name) = &field.type_() else {
@@ -82,9 +85,6 @@ fn ffi_definitions2(
                 callback.module_ident()
             };
             method_module_idents.insert(field.name().to_string(), module_ident);
-        }
-        if ffi_struct.is_vtable() && !has_callbacks {
-            continue;
         }
         definitions.push(FfiDefinition2::Struct(FfiStruct2 {
             ffi_struct,

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/extensions.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/extensions.rs
@@ -9,12 +9,14 @@ use extend::ext;
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use syn::Ident;
 use uniffi_bindgen::{
-    interface::{FfiArgument, FfiCallbackFunction, FfiDefinition, FfiField, FfiStruct, FfiType},
+    interface::{FfiCallbackFunction, FfiDefinition, FfiField, FfiStruct, FfiType},
     ComponentInterface,
 };
 
 use super::{ident, snake_case_ident};
-use crate::bindings::extensions::{FfiCallbackFunctionExt as _, FfiStructExt as _};
+use crate::bindings::extensions::{
+    ComponentInterfaceExt as _, FfiCallbackFunctionExt as _, FfiStructExt as _,
+};
 
 #[ext]
 pub(super) impl ComponentInterface {
@@ -30,18 +32,6 @@ pub(super) impl ComponentInterface {
             has_callbacks,
             has_async_callbacks,
         )
-    }
-
-    fn has_callbacks(&self) -> bool {
-        !self.callback_interface_definitions().is_empty()
-            || self
-                .object_definitions()
-                .iter()
-                .any(|o| o.has_callback_interface())
-    }
-
-    fn has_async_calls(&self) -> bool {
-        self.iter_callables().any(|c| c.is_async())
     }
 }
 
@@ -131,13 +121,6 @@ fn ffi_definitions2(
     definitions.into_iter()
 }
 
-#[ext]
-impl FfiArgument {
-    fn is_return(&self) -> bool {
-        self.name() == "uniffi_out_return"
-    }
-}
-
 pub(super) enum FfiDefinition2 {
     CallbackFunction(FfiCallbackFunction2),
     FunctionLiteral(FfiCallbackFunction2),
@@ -168,9 +151,6 @@ pub(super) impl FfiCallbackFunction {
     }
     fn module_ident(&self) -> Ident {
         snake_case_ident(self.name())
-    }
-    fn is_function_literal(&self) -> bool {
-        self.name().starts_with("ForeignFutureComplete")
     }
 }
 


### PR DESCRIPTION
This work fell out of the WASM binding generation.