### PR TITLE
Prepare uniffi-runtime-javascript crate for release

### DIFF
--- a/.github/workflows/crates-io.yaml
+++ b/.github/workflows/crates-io.yaml
@@ -1,0 +1,37 @@
+name: Publish to 🦀 crates.io
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Perform a dry run (no actual publish)"
+        type: boolean
+        default: true
+
+env:
+  CARGO_MANIFEST_PATH: crates/uniffi-runtime-javascript/Cargo.toml
+
+jobs:
+  publish-crates-io:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify package
+        run: cargo package --manifest-path ${{ env.CARGO_MANIFEST_PATH }} --allow-dirty
+
+      - name: Publish (dry run)
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: cargo publish --manifest-path ${{ env.CARGO_MANIFEST_PATH }} --dry-run
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish to crates.io
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: cargo publish --manifest-path ${{ env.CARGO_MANIFEST_PATH }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -104,7 +104,7 @@ fn callback_fn_ident() -> Ident {
 
 fn wasm_flavor() -> FlavorParams<'static> {
     FlavorParams {
-        runtime_module: "uniffi_wasm",
+        runtime_module: "uniffi_runtime_javascript",
     }
 }
 

--- a/crates/uniffi-runtime-javascript/Cargo.toml
+++ b/crates/uniffi-runtime-javascript/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uniffi-runtime-javascript"
+version = "0.29.0-0"
+edition = "2021"
+authors = ["James Hugman <james@hugman.tv>"]
+description = "Javascript runtime for UniFFI-generated bindings"
+license = "MPL-2.0"
+repository = "https://github.com/jhugman/uniffi-bindgen-react-native"
+readme = "README.md"
+keywords = ["ffi", "code-generation", "javascript", "wasm"]
+categories = ["api-bindings", "development-tools::ffi"]
+
+[dependencies]
+uniffi_core = { version = "=0.29.0", default-features = false }
+wasm-bindgen = { version = "0.2.97", optional = true }
+
+[features]
+wasm32 = ["wasm-bindgen"]

--- a/crates/uniffi-runtime-javascript/README.md
+++ b/crates/uniffi-runtime-javascript/README.md
@@ -1,0 +1,39 @@
+# `uniffi-runtime-javascript`
+
+The command line tool `uniffi-bindgen-react-native` can generate Javascript bindings crate for your
+Rust crate, from `[uniffi::export]` proc-macros in your code.
+
+These bindings crates depend on this crate. Currently this is for WASM runtimes only.
+
+This crate is not intended to be used directly by hand-written code.
+
+If you find this crate from a `Cargo.toml`, it is almost certain that the crate will have
+been generated.
+
+For more information visit: https://jhugman.github.io/uniffi-bindgen-react-native
+
+# What is `uniffi`?
+
+`uniffi` is a multi-language bindings generator for Rust, started at, and maintained by Mozilla.
+
+For more information visit: https://mozilla.github.io/uniffi-rs
+
+Most uniffi generated bindings go through a C ABI, called through different languages C FFI facilities. This crate is the beginnings of using Rust to call in to the C ABI.
+
+## Features
+
+The crate is split into features, one per Javascript runtime:
+
+- `wasm32`: uses `wasm-bindgen`.
+
+Future features may be:
+
+- `napi`: which uses `napi-rs` to provide node bindings.
+
+## Generating `uniffi` based bindings for other Javascript Runtimes without this crate
+
+- [`uniffi-bindgen-react-native`][ubrn] generates C++ for the Hermes JS engine used by React Native.
+- internally, Firefox uses [uniffi to generate bindings for privileged JS][uniffi-gecko-js].
+
+[ubrn]: https://www.npmjs.com/package/uniffi-bindgen-react-native
+[uniffi-gecko-js]: https://firefox-source-docs.mozilla.org/rust-components/developing-rust-components/uniffi.html

--- a/crates/uniffi-runtime-javascript/src/lib.rs
+++ b/crates/uniffi-runtime-javascript/src/lib.rs
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+#[cfg(feature = "wasm32")]
+mod wasm32;
+
+#[cfg(feature = "wasm32")]
+pub use wasm32::*;

--- a/crates/uniffi-runtime-javascript/src/wasm32.rs
+++ b/crates/uniffi-runtime-javascript/src/wasm32.rs
@@ -4,11 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use std::{cell::RefCell, ptr::NonNull};
-pub use wasm_bindgen::prelude::wasm_bindgen as export;
-use wasm_bindgen::prelude::*;
+pub use wasm_bindgen::prelude::*;
 
 pub mod uniffi {
-    pub use uniffi::{RustBuffer, RustCallStatus, RustCallStatusCode, UniffiForeignPointerCell};
+    pub use uniffi_core::{
+        RustBuffer, RustCallStatus, RustCallStatusCode, UniffiForeignPointerCell,
+    };
     pub type VoidPointer = *const std::ffi::c_void;
 }
 
@@ -157,17 +158,17 @@ impl RustCallStatus {
 
 // Needed for UniffiForeignFutureStruct* structs which are sent from JS when
 // a foreign callback promise resolves or rejects.
-impl IntoRust<RustCallStatus> for ::uniffi::RustCallStatus {
+impl IntoRust<RustCallStatus> for uniffi::RustCallStatus {
     fn into_rust(js: RustCallStatus) -> Self {
         let code = uniffi::RustCallStatusCode::try_from(js.code)
             .expect("Unexpected error code. This is likely a bug in UBRN");
         let bytes = js.error_buf.unwrap_or_default();
         let error_buf = std::mem::ManuallyDrop::new(uniffi::RustBuffer::from_vec(bytes));
-        ::uniffi::RustCallStatus { error_buf, code }
+        uniffi::RustCallStatus { error_buf, code }
     }
 }
 
-impl IntoJs<RustCallStatus> for ::uniffi::RustCallStatus {
+impl IntoJs<RustCallStatus> for uniffi::RustCallStatus {
     fn into_js(self) -> RustCallStatus {
         let mut status = RustCallStatus::new();
         status.copy_from(self);

--- a/crates/uniffi-wasm/Cargo.toml
+++ b/crates/uniffi-wasm/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "uniffi-wasm"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-uniffi = { workspace = true }
-wasm-bindgen = "0.2.97"

--- a/xtask/src/run/Cargo.template.toml
+++ b/xtask/src/run/Cargo.template.toml
@@ -11,9 +11,13 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-wasm-bindgen = "0.2.84"
+# We want to ensure that the version of wasm-bindgen is selected by the
+# uniffi-runtime-javascript crate.
+# cargo is smart enough to do this if we don't put any further restrictions
+# on it.
+wasm-bindgen = "*"
 {{crate_name}} = { path = "{{crate_path}}" }
-uniffi-wasm = { path = "{{uniffi_wasm_path}}" }
+uniffi-runtime-javascript = { path = "{{uniffi_runtime_javascript}}", features = ["wasm32"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -29,3 +33,6 @@ wasm-bindgen-test = "0.3.34"
 opt-level = "s"
 
 [workspace]
+
+[workspace.dependencies]
+wasm-bindgen = "*"

--- a/xtask/src/run/wasm.rs
+++ b/xtask/src/run/wasm.rs
@@ -90,7 +90,7 @@ impl Wasm {
         let src = include_str!("Cargo.template.toml");
         let cargo_toml = generated_crate.join("Cargo.toml");
 
-        let uniffi_wasm_path = repository_root()?.join("crates/uniffi-wasm");
+        let uniffi_runtime_javascript = repository_root()?.join("crates/uniffi-runtime-javascript");
         let cargo_toml_src = src
             .replace("{{crate_name}}", crate_under_test.package_name())
             .replace(
@@ -100,8 +100,8 @@ impl Wasm {
                     .as_str(),
             )
             .replace(
-                "{{uniffi_wasm_path}}",
-                pathdiff::diff_utf8_paths(uniffi_wasm_path, generated_crate)
+                "{{uniffi_runtime_javascript}}",
+                pathdiff::diff_utf8_paths(uniffi_runtime_javascript, generated_crate)
                     .expect("Should be able to find a relative path")
                     .as_str(),
             );


### PR DESCRIPTION
This PR refactors the `uniffi-wasm` crate to a `uniffi-runtime-javascript` crate with a `wasm32` feature.

It also adds a Github Action to publish the newly formed crate.