### PR TITLE
docs: update bindings to use uniffi 0.29

### DIFF
--- a/docs/src/guides/getting-started.md
+++ b/docs/src/guides/getting-started.md
@@ -129,7 +129,7 @@ For now, we just want to get started; let's start with an existing Rust crate th
 rust:
   repo: https://github.com/jhugman/uniffi-starter.git
   branch: jhugman/bump-uniffi-to-0.29
-  manifestPath: foobar/Cargo.toml
+  manifestPath: rust/foobar/Cargo.toml
 ```
 
 Save this in a file at the root of your directory, called `ubrn.config.yaml`.

--- a/docs/src/guides/getting-started.md
+++ b/docs/src/guides/getting-started.md
@@ -127,9 +127,9 @@ For now, we just want to get started; let's start with an existing Rust crate th
 ```yaml
 ---
 rust:
-  repo: https://github.com/ianthetechie/uniffi-starter
-  branch: main
-  manifestPath: rust/foobar/Cargo.toml
+  repo: https://github.com/jhugman/uniffi-starter.git
+  branch: jhugman/bump-uniffi-to-0.29
+  manifestPath: foobar/Cargo.toml
 ```
 
 Save this in a file at the root of your directory, called `ubrn.config.yaml`.

--- a/integration/fixtures/compat/ubrn.config.yaml
+++ b/integration/fixtures/compat/ubrn.config.yaml
@@ -1,4 +1,4 @@
 rust:
-  repo: https://github.com/ianthetechie/uniffi-starter
-  branch: main
-  manifestPath: rust/foobar/Cargo.toml
+  repo: https://github.com/jhugman/uniffi-starter.git
+  branch: jhugman/bump-uniffi-to-0.29
+  manifestPath: foobar/Cargo.toml

--- a/integration/fixtures/compat/ubrn.config.yaml
+++ b/integration/fixtures/compat/ubrn.config.yaml
@@ -1,4 +1,4 @@
 rust:
   repo: https://github.com/jhugman/uniffi-starter.git
   branch: jhugman/bump-uniffi-to-0.29
-  manifestPath: foobar/Cargo.toml
+  manifestPath: rust/foobar/Cargo.toml

--- a/integration/fixtures/turbo-module-testing/ubrn.config.yaml
+++ b/integration/fixtures/turbo-module-testing/ubrn.config.yaml
@@ -1,4 +1,4 @@
 rust:
-  repo: https://github.com/ianthetechie/uniffi-starter
-  branch: main
-  manifestPath: rust/foobar/Cargo.toml
+  repo: https://github.com/jhugman/uniffi-starter.git
+  branch: jhugman/bump-uniffi-to-0.29
+  manifestPath: foobar/Cargo.toml

--- a/integration/fixtures/turbo-module-testing/ubrn.config.yaml
+++ b/integration/fixtures/turbo-module-testing/ubrn.config.yaml
@@ -1,4 +1,4 @@
 rust:
   repo: https://github.com/jhugman/uniffi-starter.git
   branch: jhugman/bump-uniffi-to-0.29
-  manifestPath: foobar/Cargo.toml
+  manifestPath: rust/foobar/Cargo.toml


### PR DESCRIPTION
closes #249