### PR TITLE
Add CLI testing for uniffi-bindgen-react-native command.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1"
 camino = "1.1.6"
 cargo_metadata = "0.15"
 clap = { version = "4.5.4", features = ["derive"] }
+extend = "1.2.0"
 heck = "0.5.0"
 paste = "1.0.14"
 pathdiff = { version = "0.2.1", features = ["camino"] }

--- a/crates/ubrn_bindgen/Cargo.toml
+++ b/crates/ubrn_bindgen/Cargo.toml
@@ -13,17 +13,17 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 cargo_metadata = { workspace = true }
 clap = { workspace = true }
+extend = { workspace = true }
 heck = { workspace = true }
 paste = { workspace = true }
 rinja = { workspace = true }
 serde = { workspace = true }
 textwrap = "0.16.1"
+toml = "0.5"
+topological-sort = "0.2.2"
 ubrn_common = { path = "../ubrn_common" }
 uniffi_bindgen = { workspace = true }
 uniffi_meta = { workspace = true }
-extend = "1.2.0"
-topological-sort = "0.2.2"
-toml = "0.5"
 
 [dependencies.quote]
 version = "1.0"

--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::Metadata;
 use clap::{command, Args};
-use ubrn_common::{mk_dir, CrateMetadata};
+use ubrn_common::{mk_dir, path_or_shim, CrateMetadata, Utf8PathBufExt as _};
 use uniffi_bindgen::{cargo_metadata::CrateConfigSupplier, BindingGenerator};
 
 #[cfg(feature = "wasm")]
@@ -134,8 +134,8 @@ impl BindingsArgs {
 
         mk_dir(&out.ts_dir)?;
         mk_dir(&out.cpp_dir)?;
-        let ts_dir = out.ts_dir.canonicalize_utf8()?;
-        let abi_dir = out.cpp_dir.canonicalize_utf8()?;
+        let ts_dir = out.ts_dir.canonicalize_utf8_or_shim()?;
+        let abi_dir = out.cpp_dir.canonicalize_utf8_or_shim()?;
 
         let switches = self.switches();
         let abi_dir = abi_dir.clone();
@@ -172,7 +172,7 @@ impl BindingsArgs {
 
         let configs: Vec<ModuleMetadata> = if input.library_mode {
             uniffi_bindgen::library_mode::generate_bindings(
-                &input.source,
+                &path_or_shim(&input.source)?,
                 input.crate_name.clone(),
                 binding_generator,
                 &config_supplier,

--- a/crates/ubrn_bindgen/src/react_native.rs
+++ b/crates/ubrn_bindgen/src/react_native.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-use std::fs;
-
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -49,11 +47,11 @@ impl ReactNativeBindingGenerator {
                 &type_map,
             )?;
             let api_ts_path = out_dir.join(module.ts_filename());
-            fs::write(api_ts_path, api_ts)?;
+            ubrn_common::write_file(api_ts_path, api_ts)?;
 
             let lowlevel_ts = gen_typescript::generate_lowlevel_code(&component.ci, &module)?;
             let lowlevel_ts_path = out_dir.join(module.ts_ffi_filename());
-            fs::write(lowlevel_ts_path, lowlevel_ts)?;
+            ubrn_common::write_file(lowlevel_ts_path, lowlevel_ts)?;
         }
         if try_format_code {
             gen_typescript::format_directory(out_dir)?;
@@ -71,11 +69,11 @@ impl ReactNativeBindingGenerator {
 
             let cpp = gen_cpp::generate_cpp(&component.ci, &component.config.cpp, &module)?;
             let cpp_path = out_dir.join(module.cpp_filename());
-            fs::write(cpp_path, cpp)?;
+            ubrn_common::write_file(cpp_path, cpp)?;
 
             let hpp = gen_cpp::generate_hpp(&component.ci, &component.config.cpp, &module)?;
             let hpp_path = out_dir.join(module.hpp_filename());
-            fs::write(hpp_path, hpp)?;
+            ubrn_common::write_file(hpp_path, hpp)?;
         }
         if try_format_code {
             gen_cpp::format_directory(out_dir)?;

--- a/crates/ubrn_bindgen/src/wasm.rs
+++ b/crates/ubrn_bindgen/src/wasm.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-use std::fs;
-
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -49,7 +47,7 @@ impl WasmBindingGenerator {
                 &type_map,
             )?;
             let api_ts_path = out_dir.join(module.ts_filename());
-            fs::write(api_ts_path, api_ts)?;
+            ubrn_common::write_file(api_ts_path, api_ts)?;
         }
         if try_format_code {
             gen_typescript::format_directory(out_dir)?;
@@ -74,7 +72,7 @@ impl WasmBindingGenerator {
                 try_format_code,
             )?;
             let rs_path = out_dir.join(module.rs_filename());
-            fs::write(rs_path, rs_code)?;
+            ubrn_common::write_file(rs_path, rs_code)?;
         }
         Ok(())
     }

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -22,18 +22,18 @@ anyhow = { workspace = true }
 rinja = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true }
+extend = { workspace = true }
+globset = { version = "0.4.14", features = ["serde1"] }
 heck = { workspace = true }
 paste = { workspace = true }
 pathdiff = { workspace = true }
 serde = { workspace = true }
 textwrap = "0.16.1"
+topological-sort = "0.2.2"
 ubrn_bindgen = { path = "../ubrn_bindgen", features = ["wasm"] }
 ubrn_common = { path = "../ubrn_common" }
 uniffi_bindgen = { workspace = true }
 uniffi_meta = { workspace = true }
-extend = "1.2.0"
-topological-sort = "0.2.2"
-globset = { version = "0.4.14", features = ["serde1"] }
 
 [dev-dependencies]
 ubrn_cli_testing = { path = "../ubrn_cli_testing" }

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -3,9 +3,14 @@ name = "uniffi-bindgen-react-native"
 version = "0.29.0-0"
 edition = "2021"
 
+[lib]
+name = "ubrn_cli"
+path = "src/lib.rs"
+
+# This explicitly defines the binary
 [[bin]]
 name = "uniffi-bindgen-react-native"
-
+path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -29,3 +34,6 @@ uniffi_meta = { workspace = true }
 extend = "1.2.0"
 topological-sort = "0.2.2"
 globset = { version = "0.4.14", features = ["serde1"] }
+
+[dev-dependencies]
+ubrn_cli_testing = { path = "../ubrn_cli_testing" }

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -1,0 +1,161 @@
+{
+  "name": "dummy-lib",
+  "version": "0.1.0",
+  "description": "An automated test",
+  "default": "./src/index.web.ts",
+  "browser": "./src/index.web.ts",
+  "react-native": "./src/index.tsx",
+  "files": [
+    "src",
+    "lib",
+    "android",
+    "ios",
+    "cpp",
+    "*.podspec",
+    "react-native.config.js",
+    "!ios/build",
+    "!android/build",
+    "!android/gradle",
+    "!android/gradlew",
+    "!android/gradlew.bat",
+    "!android/local.properties",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__",
+    "!**/.*"
+  ],
+  "scripts": {
+    "example": "yarn workspace dummy-lib-example",
+    "test": "jest",
+    "typecheck": "tsc",
+    "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
+    "prepare": "bob build",
+    "release": "release-it"
+  },
+  "keywords": [
+    "react-native",
+    "ios",
+    "android"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jhugman/dummy-lib.git"
+  },
+  "author": "James <noop@nomail.com> (https://nowhere.com/james)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jhugman/dummy-lib/issues"
+  },
+  "homepage": "https://github.com/jhugman/dummy-lib#readme",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "@commitlint/config-conventional": "^19.6.0",
+    "@eslint/compat": "^1.2.7",
+    "@eslint/eslintrc": "^3.3.0",
+    "@eslint/js": "^9.22.0",
+    "@evilmartians/lefthook": "^1.5.0",
+    "@react-native-community/cli": "15.0.0-alpha.2",
+    "@react-native/babel-preset": "0.79.2",
+    "@react-native/eslint-config": "^0.78.0",
+    "@release-it/conventional-changelog": "^9.0.2",
+    "@types/jest": "^29.5.5",
+    "@types/react": "^19.0.0",
+    "commitlint": "^19.6.1",
+    "del-cli": "^5.1.0",
+    "eslint": "^9.22.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-prettier": "^5.2.3",
+    "jest": "^29.7.0",
+    "prettier": "^3.5.3",
+    "react": "19.0.0",
+    "react-native": "0.79.2",
+    "react-native-builder-bob": "^0.40.10",
+    "release-it": "^17.10.0",
+    "turbo": "^1.10.7",
+    "typescript": "^5.2.2"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
+  "workspaces": [
+    "example",
+    "example-expo"
+  ],
+  "packageManager": "yarn@3.6.1",
+  "jest": {
+    "preset": "react-native",
+    "modulePathIgnorePatterns": [
+      "<rootDir>/example/node_modules",
+      "<rootDir>/lib/"
+    ]
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "release-it": {
+    "git": {
+      "commitMessage": "chore: release ${version}",
+      "tagName": "v${version}"
+    },
+    "npm": {
+      "publish": true
+    },
+    "github": {
+      "release": true
+    },
+    "plugins": {
+      "@release-it/conventional-changelog": {
+        "preset": {
+          "name": "angular"
+        }
+      }
+    }
+  },
+  "prettier": {
+    "quoteProps": "consistent",
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "es5",
+    "useTabs": false
+  },
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      [
+        "module",
+        {
+          "esm": true
+        }
+      ],
+      [
+        "typescript",
+        {
+          "project": "tsconfig.build.json"
+        }
+      ]
+    ]
+  },
+  "codegenConfig": {
+    "name": "DummyLibSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "com.dummylib"
+    }
+  },
+  "create-react-native-library": {
+    "languages": "kotlin-objc",
+    "type": "turbo-module",
+    "version": "0.50.2"
+  },
+  "dependencies": {
+    "uniffi-bindgen-react-native": "^0.29.0-0"
+  }
+}

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dummy-lib",
+  "name": "default-fixture",
   "version": "0.1.0",
   "description": "An automated test",
   "default": "./src/index.web.ts",
@@ -143,11 +143,11 @@
     ]
   },
   "codegenConfig": {
-    "name": "DummyLibSpec",
+    "name": "DefaultFixtureSpec",
     "type": "modules",
     "jsSrcsDir": "src",
     "android": {
-      "javaPackageName": "com.dummylib"
+      "javaPackageName": "com.defaultfixture"
     }
   },
   "create-react-native-library": {

--- a/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.monorepo.config.yaml
+++ b/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.monorepo.config.yaml
@@ -1,0 +1,8 @@
+rust:
+  directory: rust/shim
+  manifestPath: Cargo.toml
+web:
+  manifestPath: rust/crates/wasm-crate/Cargo.toml
+  features:
+    - wasm32_only
+  workspace: true

--- a/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.multifeature.config.yaml
+++ b/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.multifeature.config.yaml
@@ -1,0 +1,8 @@
+rust:
+  directory: rust/shim
+  manifestPath: Cargo.toml
+web:
+  manifestPath: rust/crates/wasm-crate/Cargo.toml
+  features:
+    - wasm32_only
+    - some_feature

--- a/crates/ubrn_cli/fixtures/defaults/ubrn.config.yaml
+++ b/crates/ubrn_cli/fixtures/defaults/ubrn.config.yaml
@@ -1,4 +1,3 @@
 rust:
-  repo: https://github.com/ianthetechie/uniffi-starter
-  branch: main
-  manifestPath: rust/foobar/Cargo.toml
+  directory: rust/shim
+  manifestPath: Cargo.toml

--- a/crates/ubrn_cli/fixtures/defaults/ubrn.config.yaml
+++ b/crates/ubrn_cli/fixtures/defaults/ubrn.config.yaml
@@ -1,0 +1,4 @@
+rust:
+  repo: https://github.com/ianthetechie/uniffi-starter
+  branch: main
+  manifestPath: rust/foobar/Cargo.toml

--- a/crates/ubrn_cli/src/cli.rs
+++ b/crates/ubrn_cli/src/cli.rs
@@ -12,9 +12,15 @@ use crate::{
 };
 
 #[derive(Parser)]
-pub(crate) struct CliArgs {
+pub struct CliArgs {
     #[command(subcommand)]
     pub(crate) cmd: CliCmd,
+}
+
+impl CliArgs {
+    pub fn run(&self) -> Result<()> {
+        self.cmd.run()
+    }
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -84,7 +84,7 @@ pub(crate) fn render_files(
         }
         let parent = path.parent().expect("Parent for path");
         mk_dir(parent)?;
-        std::fs::write(path, contents)?;
+        ubrn_common::write_file(path, contents)?;
     }
 
     Ok(())

--- a/crates/ubrn_cli/src/config/rust_crate.rs
+++ b/crates/ubrn_cli/src/config/rust_crate.rs
@@ -10,7 +10,7 @@ use anyhow::{Error, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Deserializer};
 
-use ubrn_common::CrateMetadata;
+use ubrn_common::{path_or_shim, CrateMetadata};
 
 use crate::{commands::checkout::GitRepoArgs, workspace};
 
@@ -101,7 +101,8 @@ impl CrateConfig {
     }
 
     pub(crate) fn manifest_path(&self) -> Result<Utf8PathBuf> {
-        Ok(self.directory()?.join(&self.manifest_path))
+        let manifest_path = path_or_shim(&self.directory()?.join(&self.manifest_path))?;
+        Ok(manifest_path)
     }
 
     pub(crate) fn crate_dir(&self) -> Result<Utf8PathBuf> {

--- a/crates/ubrn_cli/src/jsi/android/codegen.rs
+++ b/crates/ubrn_cli/src/jsi/android/codegen.rs
@@ -33,8 +33,8 @@ impl TemplateConfig {
             let project_root = self.project.project_root();
             let gradle_file = BuildGradle::new(self.clone()).path(project_root);
             if gradle_file.exists() {
-                let file =
-                    std::fs::read_to_string(gradle_file).expect("Cannot read build.gradle file");
+                let file = ubrn_common::read_to_string(gradle_file)
+                    .expect("Cannot read build.gradle file");
                 file.contains("kotlin")
             } else {
                 // assume that if the user blew away the gradle file,

--- a/crates/ubrn_cli/src/jsi/android/commands.rs
+++ b/crates/ubrn_cli/src/jsi/android/commands.rs
@@ -5,14 +5,13 @@
  */
 use std::{
     collections::{BTreeSet, HashMap},
-    fs,
     process::Command,
 };
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
-use ubrn_common::{mk_dir, rm_dir, run_cmd, CrateMetadata};
+use ubrn_common::{cp_file, mk_dir, rm_dir, run_cmd, CrateMetadata};
 use uniffi_bindgen::{
     bindings::KotlinBindingGenerator, cargo_metadata::CrateConfigSupplier,
     library_mode::generate_bindings,
@@ -180,7 +179,7 @@ impl AndroidBuildArgs {
 
             let dst_lib = dst_dir.join(metadata.library_file(Some(target.triple())));
             println!("cp {library} {dst_lib}");
-            fs::copy(library, &dst_lib)?;
+            cp_file(library, &dst_lib)?;
         }
         Ok(())
     }

--- a/crates/ubrn_cli/src/jsi/android/commands.rs
+++ b/crates/ubrn_cli/src/jsi/android/commands.rs
@@ -110,7 +110,6 @@ impl AndroidBuildArgs {
             let target =
                 self.cargo_build(target, &manifest_path, cargo_extras, api_level, &rust_dir)?;
             let library = metadata.library_path(Some(target.triple()), profile);
-            metadata.library_path_exists(&library)?;
             target_files.insert(target, library);
         }
         Ok(target_files)

--- a/crates/ubrn_cli/src/jsi/ios/commands.rs
+++ b/crates/ubrn_cli/src/jsi/ios/commands.rs
@@ -265,7 +265,7 @@ impl IosBuildArgs {
             contents.push_str("\n\n");
             std::fs::remove_file(path)?;
         }
-        std::fs::write(out_file, contents)?;
+        ubrn_common::write_file(out_file, contents)?;
         Ok(())
     }
 

--- a/crates/ubrn_cli/src/jsi/ios/commands.rs
+++ b/crates/ubrn_cli/src/jsi/ios/commands.rs
@@ -119,7 +119,6 @@ impl IosBuildArgs {
 
             // Now we need to get the path to the lib.a file, to feed to xcodebuild.
             let library = metadata.library_path(Some(&target.triple), self.common_args.profile());
-            metadata.library_path_exists(&library)?;
             target_files.insert(target.clone(), library);
         }
         Ok(target_files)

--- a/crates/ubrn_cli/src/jsi/ios/commands.rs
+++ b/crates/ubrn_cli/src/jsi/ios/commands.rs
@@ -260,10 +260,10 @@ impl IosBuildArgs {
             if !entry.file_type()?.is_file() || path.extension() != Some("modulemap") {
                 continue;
             }
-            let chunk = std::fs::read_to_string(path)?;
+            let chunk = ubrn_common::read_to_string(path)?;
             contents.push_str(&chunk);
             contents.push_str("\n\n");
-            std::fs::remove_file(path)?;
+            ubrn_common::rm_file(path)?;
         }
         ubrn_common::write_file(out_file, contents)?;
         Ok(())

--- a/crates/ubrn_cli/src/lib.rs
+++ b/crates/ubrn_cli/src/lib.rs
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+pub mod cli;
+pub(crate) mod codegen;
+pub(crate) mod commands;
+pub(crate) mod config;
+pub(crate) mod jsi;
+#[cfg(feature = "wasm")]
+pub(crate) mod wasm;
+pub(crate) mod workspace;
+
+pub use anyhow::{Error, Result};
+pub use camino::Utf8PathBuf;
+
+use config::ProjectConfig;
+use ubrn_bindgen::AbiFlavor;
+
+// Move the shared functionality here
+pub(crate) trait AsConfig<T>
+where
+    T: TryFrom<ProjectConfig, Error = Error>,
+{
+    fn config_file(&self) -> Option<Utf8PathBuf>;
+    fn get(&self) -> Option<T>;
+
+    fn as_config(&self) -> Result<T> {
+        if let Some(t) = self.get() {
+            Ok(t)
+        } else if let Some(f) = self.config_file() {
+            let config: ProjectConfig = f.try_into()?;
+            config.try_into()
+        } else {
+            anyhow::bail!("Could not find a suitable value")
+        }
+    }
+}
+
+impl TryFrom<Utf8PathBuf> for ProjectConfig {
+    type Error = Error;
+
+    fn try_from(value: Utf8PathBuf) -> Result<Self, Self::Error> {
+        ubrn_common::read_from_file(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Platform {
+    Android,
+    Ios,
+    #[cfg(feature = "wasm")]
+    Wasm,
+}
+
+impl From<&Platform> for AbiFlavor {
+    fn from(value: &Platform) -> Self {
+        match value {
+            #[cfg(feature = "wasm")]
+            Platform::Wasm => AbiFlavor::Wasm,
+            _ => AbiFlavor::Jsi,
+        }
+    }
+}

--- a/crates/ubrn_cli/src/lib.rs
+++ b/crates/ubrn_cli/src/lib.rs
@@ -13,6 +13,8 @@ pub(crate) mod jsi;
 pub(crate) mod wasm;
 pub(crate) mod workspace;
 
+pub mod test_utils;
+
 pub use anyhow::{Error, Result};
 pub use camino::Utf8PathBuf;
 

--- a/crates/ubrn_cli/src/test_utils.rs
+++ b/crates/ubrn_cli/src/test_utils.rs
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use std::fmt::Display;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use clap::Parser as _;
+
+use crate::cli;
+use ubrn_common::{run_cmd, CrateMetadata};
+
+pub fn root_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+pub fn integration_fixtures_dir() -> Utf8PathBuf {
+    root_dir().join("../../fixtures")
+}
+
+pub fn fixtures_dir() -> Utf8PathBuf {
+    root_dir().join("fixtures")
+}
+
+pub fn run_cli(command_line: impl Display) -> Result<()> {
+    let args = cli::CliArgs::try_parse_from(command_line.to_string().split_whitespace())?;
+    args.run()
+}
+
+pub fn cargo_build(fixture_name: &str, target: &str) -> Result<CrateMetadata> {
+    let mut command = std::process::Command::new("cargo");
+    let fixture = integration_fixtures_dir().join(fixture_name);
+    let manifest_path = fixture.join("Cargo.toml");
+    run_cmd(
+        command
+            .arg("build")
+            .arg("--manifest-path")
+            .arg(&manifest_path)
+            .args(["--target", target]),
+    )?;
+    CrateMetadata::try_from(manifest_path)
+}

--- a/crates/ubrn_cli/src/test_utils.rs
+++ b/crates/ubrn_cli/src/test_utils.rs
@@ -30,7 +30,7 @@ pub fn run_cli(command_line: impl Display) -> Result<()> {
     args.run()
 }
 
-pub fn cargo_build(fixture_name: &str, target: &str) -> Result<CrateMetadata> {
+pub fn cargo_build(fixture_name: &str) -> Result<CrateMetadata> {
     let mut command = std::process::Command::new("cargo");
     let fixture = integration_fixtures_dir().join(fixture_name);
     let manifest_path = fixture.join("Cargo.toml");
@@ -38,8 +38,7 @@ pub fn cargo_build(fixture_name: &str, target: &str) -> Result<CrateMetadata> {
         command
             .arg("build")
             .arg("--manifest-path")
-            .arg(&manifest_path)
-            .args(["--target", target]),
+            .arg(&manifest_path),
     )?;
     CrateMetadata::try_from(manifest_path)
 }

--- a/crates/ubrn_cli/tests/happy_path.rs
+++ b/crates/ubrn_cli/tests/happy_path.rs
@@ -11,8 +11,8 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 
 use ubrn_cli::cli;
-use ubrn_cli_testing::{assert_commands, shim_path, with_fixture, Command};
-use ubrn_common::run_cmd;
+use ubrn_cli_testing::{assert_commands, assert_files, shim_path, with_fixture, Command, File};
+use ubrn_common::{run_cmd, CrateMetadata};
 
 fn root_dir() -> Utf8PathBuf {
     Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -31,7 +31,7 @@ fn run_cli(command_line: impl Display) -> Result<()> {
     args.run()
 }
 
-fn cargo_buld(fixture_name: &str, target: &str) -> Result<Utf8PathBuf> {
+fn cargo_buld(fixture_name: &str, target: &str) -> Result<CrateMetadata> {
     let mut command = std::process::Command::new("cargo");
     let fixture = integration_fixtures_dir().join(fixture_name);
     let manifest_path = fixture.join("Cargo.toml");
@@ -39,15 +39,16 @@ fn cargo_buld(fixture_name: &str, target: &str) -> Result<Utf8PathBuf> {
         command
             .arg("build")
             .arg("--manifest-path")
-            .arg(manifest_path)
+            .arg(&manifest_path)
             .args(["--target", target]),
     )?;
-    Ok(fixture)
+    CrateMetadata::try_from(manifest_path)
 }
 
 #[test]
-fn test_build_command() -> Result<()> {
-    let rust_fixture = cargo_buld("arithmetic", "aarch64-apple-ios")?;
+fn test_build_command_ios() -> Result<()> {
+    let target = "aarch64-apple-ios";
+    let target_crate = cargo_buld("arithmetic", target)?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
         // Set up file shims
@@ -56,15 +57,182 @@ fn test_build_command() -> Result<()> {
             "ubrn.config.yaml",
             fixtures_dir.join("defaults/ubrn.config.yaml"),
         );
-        shim_path("rust/shim/Cargo.toml", rust_fixture.join("Cargo.toml"));
-        shim_path("rust/shim", rust_fixture);
+        shim_path("rust/shim/Cargo.toml", target_crate.manifest_path());
+        shim_path("rust/shim", target_crate.project_root());
+        shim_path(
+            "libarithmetical.a",
+            target_crate.library_path(Some(target), "debug"),
+        );
 
         // Run the command under test
         run_cli("ubrn build ios --and-generate --config ubrn.config.yaml")?;
 
         // Assert the expected commands were executed
         assert_commands(&[
-            Command::new("xcodebuild").arg_pair_suffix("-xcframework", ".xcframework")
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "arithmetic/Cargo.toml")
+                .arg_pair("--target", "aarch64-apple-ios"),
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "arithmetic/Cargo.toml")
+                .arg_pair("--target", "aarch64-apple-ios-sim"),
+            Command::new("xcodebuild")
+                .arg("-create-xcframework")
+                .arg_pair_suffix("-library", "aarch64-apple-ios/debug/libarithmetical.a")
+                .arg_pair_suffix("-library", "aarch64-apple-ios-sim/debug/libarithmetical.a")
+                .arg_pair_suffix("-output", "DefaultFixtureFramework.xcframework"),
+        ]);
+
+        assert_files(&[
+            // This is the entry point to the module. It calls into the generated installRustCrate()
+            // method.
+            File::new("src/index.tsx")
+                .contains("installer.installRustCrate()")
+                .contains("import * as arithmetic from './generated/arithmetic'")
+                .contains("export * from './generated/arithmetic'")
+                .contains("arithmetic.default.initialize()"),
+            // This is the file that specifies installRustCrate method.
+            // It is the entry point to the RN codegen.
+            File::new("src/NativeDefaultFixture.ts").contains(
+                "export default TurboModuleRegistry.getEnforcing<Spec>('DefaultFixture')",
+            ),
+            // These next two files hook into the RN codegen generated files
+            File::new("ios/DefaultFixture.h")
+                .contains("#import \"DefaultFixtureSpec.h\"")
+                .contains("@interface DefaultFixture : NSObject <NativeDefaultFixtureSpec>"),
+            File::new("ios/DefaultFixture.mm")
+                .contains("#import \"DefaultFixture.h\"")
+                .contains("__hostFunction_DefaultFixture_installRustCrate")
+                .contains("NativeDefaultFixtureSpecJS")
+                .contains("defaultfixture::installRustCrate"),
+            // These next two are the cross platform entrypoint to the bindings.
+            File::new("cpp/default-fixture.h").contains("namespace defaultfixture"),
+            File::new("cpp/default-fixture.cpp")
+                .contains("namespace defaultfixture")
+                .contains("#include \"default-fixture.h\"")
+                .contains("#include \"generated/arithmetic.hpp\"")
+                .contains("NativeArithmetic::registerModule"),
+            // Finally, the bindings. We have tested the content of these in other tests.
+            File::new("src/generated/arithmetic.ts"),
+            File::new("src/generated/arithmetic-ffi.ts"),
+            File::new("cpp/generated/arithmetic.cpp"),
+            File::new("cpp/generated/arithmetic.hpp"),
+            // Assorted build files
+            // This is the podspec that tells iOS about the Rust framework generated with xcodebuild.
+            File::new("DefaultFixture.podspec")
+                .contains("s.vendored_frameworks = \"DefaultFixtureFramework.xcframework\""),
+        ]);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_build_command_android() -> Result<()> {
+    let target = "aarch64-apple-ios";
+    let target_crate = cargo_buld("arithmetic", target)?;
+    let fixtures_dir = fixtures_dir();
+    with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
+        // Set up file shims
+        shim_path("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_path(
+            "ubrn.config.yaml",
+            fixtures_dir.join("defaults/ubrn.config.yaml"),
+        );
+        shim_path("rust/shim/Cargo.toml", target_crate.manifest_path());
+        shim_path("rust/shim", target_crate.project_root());
+        shim_path(
+            "libarithmetical.a",
+            target_crate.library_path(Some(target), "debug"),
+        );
+
+        // Run the command under test
+        run_cli("ubrn build android --and-generate --config ubrn.config.yaml")?;
+
+        // Assert the expected commands were executed
+        assert_commands(&[
+            Command::new("cargo")
+                .arg("ndk")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
+                .arg_pair_suffix("--target", "arm64-v8a")
+                .arg_pair("--platform", "23")
+                .arg("--no-strip")
+                .arg("--")
+                .arg("build"),
+            Command::new("cargo")
+                .arg("ndk")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
+                .arg_pair_suffix("--target", "armeabi-v7a")
+                .arg_pair("--platform", "23")
+                .arg("--no-strip")
+                .arg("--")
+                .arg("build"),
+            Command::new("cargo")
+                .arg("ndk")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
+                .arg_pair_suffix("--target", "x86")
+                .arg_pair("--platform", "23")
+                .arg("--no-strip")
+                .arg("--")
+                .arg("build"),
+            Command::new("cargo")
+                .arg("ndk")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
+                .arg_pair_suffix("--target", "x86_64")
+                .arg_pair("--platform", "23")
+                .arg("--no-strip")
+                .arg("--")
+                .arg("build"),
+        ]);
+
+        assert_files(&[
+            // This is the entry point to the module. It calls into the generated installRustCrate()
+            // method.
+            File::new("src/index.tsx")
+                .contains("installer.installRustCrate()")
+                .contains("import * as arithmetic from './generated/arithmetic'")
+                .contains("export * from './generated/arithmetic'")
+                .contains("arithmetic.default.initialize()"),
+            // This is the file that specifies installRustCrate method.
+            // It is the entry point to the RN codegen.
+            File::new("src/NativeDefaultFixture.ts").contains(
+                "export default TurboModuleRegistry.getEnforcing<Spec>('DefaultFixture')",
+            ),
+            // // These next two files hook into the RN codegen generated files
+            File::new("android/src/main/java/com/defaultfixture/DefaultFixturePackage.kt")
+                .contains("class DefaultFixturePackage")
+                .contains("DefaultFixtureModule.NAME"),
+            File::new("android/src/main/java/com/defaultfixture/DefaultFixtureModule.kt")
+                .contains("class DefaultFixtureModule")
+                .contains("System.loadLibrary(\"default-fixture\")"),
+            File::new("android/build.gradle")
+                .contains("jsRootDir = file(\"../src/\")")
+                .contains("libraryName = \"DefaultFixture\"")
+                .contains("codegenJavaPackageName = \"com.defaultfixture\""),
+            File::new("android/CMakeLists.txt")
+                .contains("../cpp/default-fixture.cpp")
+                .contains("../cpp/generated/arithmetic.cpp")
+                .contains("cpp-adapter.cpp"),
+            File::new("android/cpp-adapter.cpp")
+                .contains("Java_com_defaultfixture_DefaultFixtureModule_nativeInstallRustCrate")
+                .contains("defaultfixture::installRustCrate"),
+            // These next two are the cross platform entrypoint to the bindings.
+            File::new("cpp/default-fixture.h").contains("namespace defaultfixture"),
+            File::new("cpp/default-fixture.cpp")
+                .contains("namespace defaultfixture")
+                .contains("#include \"default-fixture.h\"")
+                .contains("#include \"generated/arithmetic.hpp\"")
+                .contains("NativeArithmetic::registerModule"),
+            // Finally, the bindings. We have tested the content of these in other tests.
+            File::new("src/generated/arithmetic.ts"),
+            File::new("src/generated/arithmetic-ffi.ts"),
+            File::new("cpp/generated/arithmetic.cpp"),
+            File::new("cpp/generated/arithmetic.hpp"),
+            // Assorted glue and build files.
+            // This is the AndroidManifest which tells the android app about this package.
+            File::new("android/src/main/AndroidManifest.xml")
+                .contains("package=\"com.defaultfixture\""),
         ]);
 
         Ok(())

--- a/crates/ubrn_cli/tests/happy_path.rs
+++ b/crates/ubrn_cli/tests/happy_path.rs
@@ -10,8 +10,7 @@ use ubrn_cli_testing::{assert_commands, assert_files, shim_path, with_fixture, C
 
 #[test]
 fn test_happy_path_ios() -> Result<()> {
-    let target = "aarch64-apple-ios";
-    let target_crate = cargo_build("arithmetic", target)?;
+    let target_crate = cargo_build("arithmetic")?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
@@ -24,11 +23,11 @@ fn test_happy_path_ios() -> Result<()> {
         shim_path("rust/shim", target_crate.project_root());
         shim_path(
             "libarithmetical.a",
-            target_crate.library_path(Some(target), "debug"),
+            target_crate.library_path(None, "debug"),
         );
 
         // Run the command under test
-        run_cli("ubrn build ios --and-generate --config ubrn.config.yaml")?;
+        run_cli("ubrn build ios --and-generate --config ubrn.config.yaml --targets aarch64-apple-ios,x86_64-apple-ios")?;
 
         // Assert the expected commands were executed
         assert_commands(&[
@@ -39,11 +38,11 @@ fn test_happy_path_ios() -> Result<()> {
             Command::new("cargo")
                 .arg("build")
                 .arg_pair_suffix("--manifest-path", "arithmetic/Cargo.toml")
-                .arg_pair("--target", "aarch64-apple-ios-sim"),
+                .arg_pair("--target", "x86_64-apple-ios"),
             Command::new("xcodebuild")
                 .arg("-create-xcframework")
                 .arg_pair_suffix("-library", "aarch64-apple-ios/debug/libarithmetical.a")
-                .arg_pair_suffix("-library", "aarch64-apple-ios-sim/debug/libarithmetical.a")
+                .arg_pair_suffix("-library", "x86_64-apple-ios/debug/libarithmetical.a")
                 .arg_pair_suffix("-output", "DefaultFixtureFramework.xcframework"),
         ]);
 
@@ -93,8 +92,7 @@ fn test_happy_path_ios() -> Result<()> {
 
 #[test]
 fn test_happy_path_android() -> Result<()> {
-    let target = "aarch64-apple-ios";
-    let target_crate = cargo_build("arithmetic", target)?;
+    let target_crate = cargo_build("arithmetic")?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
@@ -107,7 +105,7 @@ fn test_happy_path_android() -> Result<()> {
         shim_path("rust/shim", target_crate.project_root());
         shim_path(
             "libarithmetical.a",
-            target_crate.library_path(Some(target), "debug"),
+            target_crate.library_path(None, "debug"),
         );
 
         // Run the command under test
@@ -206,8 +204,7 @@ fn test_happy_path_android() -> Result<()> {
 
 #[test]
 fn test_happy_path_web() -> Result<()> {
-    let target = "aarch64-apple-ios";
-    let target_crate = cargo_build("arithmetic", target)?;
+    let target_crate = cargo_build("arithmetic")?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
@@ -222,7 +219,7 @@ fn test_happy_path_web() -> Result<()> {
         shim_path("rust_modules/wasm/Cargo.toml", target_crate.manifest_path());
         shim_path(
             "libarithmetical.a",
-            target_crate.library_path(Some(target), "debug"),
+            target_crate.library_path(None, "debug"),
         );
 
         // Run the command under test

--- a/crates/ubrn_cli/tests/happy_path.rs
+++ b/crates/ubrn_cli/tests/happy_path.rs
@@ -1,0 +1,45 @@
+use std::fmt::Display;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use clap::Parser;
+
+use ubrn_cli::cli;
+use ubrn_cli_testing::{assert_commands, shim_file, with_fixture, Command};
+
+fn root_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+}
+
+fn run_cli(command_line: impl Display) -> Result<()> {
+    let args = cli::CliArgs::try_parse_from(command_line.to_string().split_whitespace())?;
+    args.run()
+}
+
+#[test]
+fn test_build_command() -> anyhow::Result<()> {
+    let fixtures_dir = root_dir();
+    with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
+        // Set up file shims
+        shim_file("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_file(
+            "ubrn.config.yaml",
+            fixtures_dir.join("defaults/ubrn.config.yaml"),
+        );
+
+        // Run the command under test
+        run_cli("ubrn build ios --and-generate --config ubrn.config.yaml")?;
+
+        // Assert the expected commands were executed
+        assert_commands(&[
+            Command::new("xcodebuild").arg_pair_suffix("-xcframework", ".xcframework")
+        ]);
+
+        Ok(())
+    })
+}

--- a/crates/ubrn_cli/tests/happy_path.rs
+++ b/crates/ubrn_cli/tests/happy_path.rs
@@ -3,54 +3,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-
-use std::fmt::Display;
-
 use anyhow::Result;
-use camino::Utf8PathBuf;
-use clap::Parser;
 
-use ubrn_cli::cli;
+use ubrn_cli::test_utils::{cargo_build, fixtures_dir, run_cli};
 use ubrn_cli_testing::{assert_commands, assert_files, shim_path, with_fixture, Command, File};
-use ubrn_common::{run_cmd, CrateMetadata};
-
-fn root_dir() -> Utf8PathBuf {
-    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-fn integration_fixtures_dir() -> Utf8PathBuf {
-    root_dir().join("../../fixtures")
-}
-
-fn fixtures_dir() -> Utf8PathBuf {
-    root_dir().join("fixtures")
-}
-
-fn run_cli(command_line: impl Display) -> Result<()> {
-    let args = cli::CliArgs::try_parse_from(command_line.to_string().split_whitespace())?;
-    args.run()
-}
-
-fn cargo_build(fixture_name: &str, target: &str) -> Result<CrateMetadata> {
-    let mut command = std::process::Command::new("cargo");
-    let fixture = integration_fixtures_dir().join(fixture_name);
-    let manifest_path = fixture.join("Cargo.toml");
-    run_cmd(
-        command
-            .arg("build")
-            .arg("--manifest-path")
-            .arg(&manifest_path)
-            .args(["--target", target]),
-    )?;
-    CrateMetadata::try_from(manifest_path)
-}
 
 #[test]
-fn test_build_command_ios() -> Result<()> {
+fn test_happy_path_ios() -> Result<()> {
     let target = "aarch64-apple-ios";
     let target_crate = cargo_build("arithmetic", target)?;
     let fixtures_dir = fixtures_dir();
-    with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
         shim_path("package.json", fixtures_dir.join("defaults/package.json"));
         shim_path(
@@ -129,11 +92,11 @@ fn test_build_command_ios() -> Result<()> {
 }
 
 #[test]
-fn test_build_command_android() -> Result<()> {
+fn test_happy_path_android() -> Result<()> {
     let target = "aarch64-apple-ios";
     let target_crate = cargo_build("arithmetic", target)?;
     let fixtures_dir = fixtures_dir();
-    with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
         shim_path("package.json", fixtures_dir.join("defaults/package.json"));
         shim_path(
@@ -242,11 +205,11 @@ fn test_build_command_android() -> Result<()> {
 }
 
 #[test]
-fn test_build_command_web() -> Result<()> {
+fn test_happy_path_web() -> Result<()> {
     let target = "aarch64-apple-ios";
     let target_crate = cargo_build("arithmetic", target)?;
     let fixtures_dir = fixtures_dir();
-    with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
         shim_path("package.json", fixtures_dir.join("defaults/package.json"));
         shim_path(
@@ -279,7 +242,8 @@ fn test_build_command_web() -> Result<()> {
                 .arg_pair("--target", "web")
                 .arg("--omit-default-module-path")
                 .arg_pair("--out-name", "index")
-                .arg_pair_suffix("--out-dir", "src/generated/wasm-bindgen"),
+                .arg_pair_suffix("--out-dir", "src/generated/wasm-bindgen")
+                .arg_suffix("wasm32-unknown-unknown/debug/arithmetical.wasm"),
         ]);
 
         assert_files(&[

--- a/crates/ubrn_cli/tests/happy_path.rs
+++ b/crates/ubrn_cli/tests/happy_path.rs
@@ -1,19 +1,29 @@
-use std::fmt::Display;
-
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+
+use std::fmt::Display;
+
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::Parser;
 
 use ubrn_cli::cli;
-use ubrn_cli_testing::{assert_commands, shim_file, with_fixture, Command};
+use ubrn_cli_testing::{assert_commands, shim_path, with_fixture, Command};
+use ubrn_common::run_cmd;
 
 fn root_dir() -> Utf8PathBuf {
-    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn integration_fixtures_dir() -> Utf8PathBuf {
+    root_dir().join("../../fixtures")
+}
+
+fn fixtures_dir() -> Utf8PathBuf {
+    root_dir().join("fixtures")
 }
 
 fn run_cli(command_line: impl Display) -> Result<()> {
@@ -21,16 +31,33 @@ fn run_cli(command_line: impl Display) -> Result<()> {
     args.run()
 }
 
+fn cargo_buld(fixture_name: &str, target: &str) -> Result<Utf8PathBuf> {
+    let mut command = std::process::Command::new("cargo");
+    let fixture = integration_fixtures_dir().join(fixture_name);
+    let manifest_path = fixture.join("Cargo.toml");
+    run_cmd(
+        command
+            .arg("build")
+            .arg("--manifest-path")
+            .arg(manifest_path)
+            .args(["--target", target]),
+    )?;
+    Ok(fixture)
+}
+
 #[test]
-fn test_build_command() -> anyhow::Result<()> {
-    let fixtures_dir = root_dir();
+fn test_build_command() -> Result<()> {
+    let rust_fixture = cargo_buld("arithmetic", "aarch64-apple-ios")?;
+    let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "happy-path", |_fixture_dir| {
         // Set up file shims
-        shim_file("package.json", fixtures_dir.join("defaults/package.json"));
-        shim_file(
+        shim_path("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_path(
             "ubrn.config.yaml",
             fixtures_dir.join("defaults/ubrn.config.yaml"),
         );
+        shim_path("rust/shim/Cargo.toml", rust_fixture.join("Cargo.toml"));
+        shim_path("rust/shim", rust_fixture);
 
         // Run the command under test
         run_cli("ubrn build ios --and-generate --config ubrn.config.yaml")?;

--- a/crates/ubrn_cli/tests/mod.rs
+++ b/crates/ubrn_cli/tests/mod.rs
@@ -3,4 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+
 mod happy_path;
+mod web_variants;

--- a/crates/ubrn_cli/tests/mod.rs
+++ b/crates/ubrn_cli/tests/mod.rs
@@ -3,10 +3,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use clap::Parser;
-use ubrn_cli::{cli, Result};
-
-fn main() -> Result<()> {
-    let args = cli::CliArgs::parse();
-    args.run()
-}
+mod happy_path;

--- a/crates/ubrn_cli/tests/test_utils.rs
+++ b/crates/ubrn_cli/tests/test_utils.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/crates/ubrn_cli/tests/utils.rs
+++ b/crates/ubrn_cli/tests/utils.rs
@@ -1,0 +1,5 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */

--- a/crates/ubrn_cli/tests/web_variants.rs
+++ b/crates/ubrn_cli/tests/web_variants.rs
@@ -1,0 +1,159 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use anyhow::Result;
+
+use ubrn_cli::test_utils::{cargo_build, fixtures_dir, run_cli};
+use ubrn_cli_testing::{assert_commands, assert_files, shim_path, with_fixture, Command, File};
+
+#[test]
+fn test_release() -> Result<()> {
+    let target = "aarch64-apple-ios";
+    let target_crate = cargo_build("arithmetic", target)?;
+    let fixtures_dir = fixtures_dir();
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
+        // Set up file shims
+        shim_path("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_path(
+            "ubrn.config.yaml",
+            fixtures_dir.join("defaults/ubrn.config.yaml"),
+        );
+        shim_path("rust/shim/Cargo.toml", target_crate.manifest_path());
+        shim_path("rust/shim", target_crate.project_root());
+
+        shim_path("rust_modules/wasm/Cargo.toml", target_crate.manifest_path());
+        shim_path(
+            "libarithmetical.a",
+            target_crate.library_path(Some(target), "debug"),
+        );
+
+        // Run the command under test
+        run_cli("ubrn build web --config ubrn.config.yaml --release")?;
+
+        // Assert the expected commands were executed
+        assert_commands(&[
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml"),
+            Command::new("prettier"),
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "rust_modules/wasm/Cargo.toml")
+                .arg_pair("--target", "wasm32-unknown-unknown")
+                .arg_pair("--profile", "release"),
+            Command::new("wasm-bindgen")
+                .arg_pair("--target", "web")
+                .arg("--omit-default-module-path")
+                .arg_pair("--out-name", "index")
+                .arg_pair_suffix("--out-dir", "src/generated/wasm-bindgen")
+                .arg_suffix("wasm32-unknown-unknown/release/arithmetical.wasm"),
+        ]);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_monorepo() -> Result<()> {
+    let target = "aarch64-apple-ios"; // Still using this target for initial build
+    let target_crate = cargo_build("arithmetic", target)?;
+    let fixtures_dir = fixtures_dir();
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
+        // Set up file shims
+        shim_path("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_path(
+            "ubrn.config.yaml",
+            fixtures_dir.join("defaults/ubrn-wasm.monorepo.config.yaml"),
+        );
+        shim_path("rust/shim/Cargo.toml", target_crate.manifest_path());
+        shim_path("rust/shim", target_crate.project_root());
+
+        shim_path(
+            "rust/crates/wasm-crate/Cargo.toml",
+            target_crate.manifest_path(),
+        );
+        shim_path(
+            "libarithmetical.a",
+            target_crate.library_path(Some(target), "debug"),
+        );
+
+        run_cli("ubrn build web --config ubrn.config.yaml")?;
+
+        // Assert the expected commands were executed
+        assert_commands(&[
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
+                .arg_pair("--features", "wasm32_only"),
+            Command::new("prettier"),
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "rust/crates/wasm-crate/Cargo.toml")
+                .arg_pair("--target", "wasm32-unknown-unknown"),
+            Command::new("wasm-bindgen")
+                .arg_pair("--target", "web")
+                .arg("--omit-default-module-path")
+                .arg_pair("--out-name", "index")
+                .arg_pair_suffix("--out-dir", "src/generated/wasm-bindgen")
+                .arg_suffix("wasm32-unknown-unknown/debug/arithmetical.wasm"),
+        ]);
+
+        assert_files(&[
+            File::new("rust/crates/wasm-crate/Cargo.toml")
+                .does_not_contain("[workspace]")
+                .contains("uniffi-example-arithmetic = { path = \"../../shim\", features = [\"wasm32_only\"] }"),
+            // other files elided.
+        ]);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_multi_features() -> Result<()> {
+    let target = "aarch64-apple-ios"; // Still using this target for initial build
+    let target_crate = cargo_build("arithmetic", target)?;
+    let fixtures_dir = fixtures_dir();
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
+        // Set up file shims
+        shim_path("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_path(
+            "ubrn.config.yaml",
+            fixtures_dir.join("defaults/ubrn-wasm.multifeature.config.yaml"),
+        );
+        shim_path("rust/shim/Cargo.toml", target_crate.manifest_path());
+        shim_path("rust/shim", target_crate.project_root());
+
+        shim_path(
+            "rust/crates/wasm-crate/Cargo.toml",
+            target_crate.manifest_path(),
+        );
+        shim_path(
+            "libarithmetical.a",
+            target_crate.library_path(Some(target), "debug"),
+        );
+
+        run_cli("ubrn build web --config ubrn.config.yaml")?;
+
+        // Assert the expected commands were executed
+        assert_commands(&[
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
+                .arg_pair("--features", "wasm32_only,some_feature"),
+            // other commands elided.
+        ]);
+
+        assert_files(&[
+            File::new("rust/crates/wasm-crate/Cargo.toml")
+                .contains("[workspace]")
+                .contains("uniffi-example-arithmetic = { path = \"../../shim\", features = [\"wasm32_only\", \"some_feature\"] }"),
+            // other files elided.
+        ]);
+
+        Ok(())
+    })
+}

--- a/crates/ubrn_cli/tests/web_variants.rs
+++ b/crates/ubrn_cli/tests/web_variants.rs
@@ -11,8 +11,7 @@ use ubrn_cli_testing::{assert_commands, assert_files, shim_path, with_fixture, C
 
 #[test]
 fn test_release() -> Result<()> {
-    let target = "aarch64-apple-ios";
-    let target_crate = cargo_build("arithmetic", target)?;
+    let target_crate = cargo_build("arithmetic")?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
@@ -27,7 +26,7 @@ fn test_release() -> Result<()> {
         shim_path("rust_modules/wasm/Cargo.toml", target_crate.manifest_path());
         shim_path(
             "libarithmetical.a",
-            target_crate.library_path(Some(target), "debug"),
+            target_crate.library_path(None, "debug"),
         );
 
         // Run the command under test
@@ -58,8 +57,8 @@ fn test_release() -> Result<()> {
 
 #[test]
 fn test_monorepo() -> Result<()> {
-    let target = "aarch64-apple-ios"; // Still using this target for initial build
-    let target_crate = cargo_build("arithmetic", target)?;
+    // Still using this target for initial build
+    let target_crate = cargo_build("arithmetic")?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
@@ -77,7 +76,7 @@ fn test_monorepo() -> Result<()> {
         );
         shim_path(
             "libarithmetical.a",
-            target_crate.library_path(Some(target), "debug"),
+            target_crate.library_path(None, "debug"),
         );
 
         run_cli("ubrn build web --config ubrn.config.yaml")?;
@@ -114,8 +113,8 @@ fn test_monorepo() -> Result<()> {
 
 #[test]
 fn test_multi_features() -> Result<()> {
-    let target = "aarch64-apple-ios"; // Still using this target for initial build
-    let target_crate = cargo_build("arithmetic", target)?;
+    // Still using this target for initial build
+    let target_crate = cargo_build("arithmetic")?;
     let fixtures_dir = fixtures_dir();
     with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
         // Set up file shims
@@ -133,7 +132,7 @@ fn test_multi_features() -> Result<()> {
         );
         shim_path(
             "libarithmetical.a",
-            target_crate.library_path(Some(target), "debug"),
+            target_crate.library_path(None, "debug"),
         );
 
         run_cli("ubrn build web --config ubrn.config.yaml")?;

--- a/crates/ubrn_cli_testing/Cargo.toml
+++ b/crates/ubrn_cli_testing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ubrn_cli_testing"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+description = "Testing utilities for UBRN CLI tools"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+camino = { workspace = true }
+ubrn_common = { path = "../ubrn_common" }

--- a/crates/ubrn_cli_testing/Cargo.toml
+++ b/crates/ubrn_cli_testing/Cargo.toml
@@ -11,3 +11,6 @@ description = "Testing utilities for UBRN CLI tools"
 anyhow = "1.0"
 camino = { workspace = true }
 ubrn_common = { path = "../ubrn_common" }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/crates/ubrn_cli_testing/src/cli.rs
+++ b/crates/ubrn_cli_testing/src/cli.rs
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::process::Command as StdCommand;
+
+use anyhow::{Context, Result};
+
+/// Run a CLI command and return the result.
+///
+/// This function takes a command string, splits it into a program and arguments,
+/// and runs it. When recording is enabled, the command will be recorded but not executed.
+///
+/// # Arguments
+///
+/// * `cmd_str` - The command string to run (e.g., "build ios --config config.yaml")
+///
+/// # Returns
+///
+/// Returns a `Result` indicating success or failure
+///
+/// # Example
+///
+/// ```no_run
+/// use ubrn_cli_testing::run_cli;
+///
+/// fn test_cli_command() -> anyhow::Result<()> {
+///     run_cli("build ios --and-generate --config ubrn.config.yaml")?;
+///     Ok(())
+/// }
+/// ```
+pub fn run_cli(cmd_str: &str) -> Result<()> {
+    let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+
+    if parts.is_empty() {
+        return Err(anyhow::anyhow!("Empty command string"));
+    }
+
+    let program = parts[0];
+    let args = &parts[1..];
+    let mut cmd = StdCommand::new(program);
+    cmd.args(args);
+
+    // Use the ubrn_common command execution, which handles recording
+    ubrn_common::run_cmd(&mut cmd)
+        .with_context(|| format!("Failed to execute command: {}", cmd_str))
+}

--- a/crates/ubrn_cli_testing/src/command.rs
+++ b/crates/ubrn_cli_testing/src/command.rs
@@ -1,0 +1,94 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::path::{Path, PathBuf};
+
+/// A builder for command matchers to be used in tests
+#[derive(Debug, Clone)]
+pub struct Command {
+    program: String,
+    args: Vec<ArgMatcher>,
+    cwd: Option<PathBuf>,
+}
+
+impl Command {
+    /// Create a new command matcher for a given program name
+    pub fn new(program: &str) -> Self {
+        Self {
+            program: program.to_string(),
+            args: Vec::new(),
+            cwd: None,
+        }
+    }
+
+    /// Add an argument to match exactly
+    pub fn arg(mut self, arg: &str) -> Self {
+        self.args.push(ArgMatcher::Exact(arg.to_string()));
+        self
+    }
+
+    /// Set the working directory to match exactly
+    pub fn cwd<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.cwd = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set the working directory to match by suffix
+    pub fn cwd_suffix(mut self, suffix: &str) -> Self {
+        self.cwd = Some(PathBuf::from(suffix));
+        self
+    }
+
+    /// Add an argument to match by suffix
+    pub fn arg_suffix(mut self, suffix: &str) -> Self {
+        self.args.push(ArgMatcher::Suffix(suffix.to_string()));
+        self
+    }
+
+    /// Add a matching argument pair (two consecutive arguments)
+    pub fn arg_pair(mut self, key: &str, value: &str) -> Self {
+        self.args
+            .push(ArgMatcher::Pair(key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Add a matching argument pair where the value is matched by suffix
+    /// This is useful for arguments like file paths where only the end of the path matters
+    pub fn arg_pair_suffix(mut self, key: &str, value_suffix: &str) -> Self {
+        self.args.push(ArgMatcher::PairSuffix(
+            key.to_string(),
+            value_suffix.to_string(),
+        ));
+        self
+    }
+
+    /// Get the program name
+    pub(crate) fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// Get the working directory matcher
+    pub(crate) fn get_cwd(&self) -> Option<&PathBuf> {
+        self.cwd.as_ref()
+    }
+
+    /// Get the list of argument matchers
+    pub(crate) fn args(&self) -> &[ArgMatcher] {
+        &self.args
+    }
+}
+
+/// Types of argument matchers for command assertions
+#[derive(Debug, Clone)]
+pub enum ArgMatcher {
+    /// Match an exact argument string
+    Exact(String),
+    /// Match an argument that ends with a suffix
+    Suffix(String),
+    /// Match a key-value pair of arguments (two consecutive arguments)
+    Pair(String, String),
+    /// Match a key-value pair where the key is exact but value is matched by suffix
+    PairSuffix(String, String),
+}

--- a/crates/ubrn_cli_testing/src/command_assertions.rs
+++ b/crates/ubrn_cli_testing/src/command_assertions.rs
@@ -1,0 +1,186 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use ubrn_common::{get_recorded_commands, RecordedCommand};
+
+use crate::{command::ArgMatcher, Command};
+
+/// A helper function that checks if commands match and returns detailed error information
+fn check_commands(expected_commands: &[Command]) -> Result<(), String> {
+    let recorded = get_recorded_commands();
+
+    // If we have fewer recorded commands than expected, fail immediately
+    if recorded.len() < expected_commands.len() {
+        return Err(format!(
+            "Expected {} commands but only {} were recorded.\nExpected: {:?}\nRecorded: {:?}",
+            expected_commands.len(),
+            recorded.len(),
+            expected_commands,
+            recorded
+        ));
+    }
+
+    for (i, expected) in expected_commands.iter().enumerate() {
+        if let Some(mismatch) = command_mismatch(&recorded[i], expected) {
+            return Err(format!(
+                "Command mismatch at position {}:\n{}\nExpected: {:?}\nRecorded: {:?}",
+                i, mismatch, expected, recorded[i]
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Assert that a sequence of commands were run in the specified order
+/// Panics with a detailed error message if commands don't match
+pub fn assert_commands(expected_commands: &[Command]) {
+    if let Err(message) = check_commands(expected_commands) {
+        panic!("{}", message);
+    }
+}
+
+/// Check if executed commands match the expected ones
+/// Returns true if they match, false otherwise
+/// This is useful for tests that want to verify negative cases
+pub fn commands_match(expected_commands: &[Command]) -> bool {
+    check_commands(expected_commands).is_ok()
+}
+
+/// Check if a recorded command matches an expected command pattern
+/// Returns None if matching, or Some(error_message) with details about the mismatch
+fn command_mismatch(recorded: &RecordedCommand, expected: &Command) -> Option<String> {
+    // Check program name
+    if recorded.program != expected.program() {
+        return Some(format!(
+            "Program name mismatch: expected '{}', got '{}'",
+            expected.program(),
+            recorded.program
+        ));
+    }
+
+    // Check working directory if specified
+    if let Some(expected_dir) = expected.get_cwd() {
+        match &recorded.current_dir {
+            Some(actual_dir) => {
+                let expected_str = expected_dir.to_string_lossy();
+                let actual_str = actual_dir.to_string_lossy();
+
+                // If it's not an exact match, check if it's a suffix match
+                if expected_str != actual_str && !actual_str.contains(&expected_str.to_string()) {
+                    return Some(format!(
+                        "Working directory mismatch: expected path containing '{}', got '{}'",
+                        expected_str, actual_str
+                    ));
+                }
+            }
+            None => {
+                return Some(format!(
+                    "Working directory mismatch: expected path containing '{}', but no working directory was set",
+                    expected_dir.to_string_lossy()
+                ));
+            }
+        }
+    }
+
+    // Check arguments - we need to consider the order and the different matcher types
+    let mut arg_idx = 0;
+    let recorded_args = &recorded.args;
+
+    for matcher in expected.args().iter() {
+        match matcher {
+            ArgMatcher::Exact(expected_arg) => {
+                if arg_idx >= recorded_args.len() {
+                    return Some(format!(
+                        "Missing argument at position {}: expected '{}'",
+                        arg_idx, expected_arg
+                    ));
+                }
+                if recorded_args[arg_idx] != *expected_arg {
+                    return Some(format!(
+                        "Argument mismatch at position {}: expected '{}', got '{}'",
+                        arg_idx, expected_arg, recorded_args[arg_idx]
+                    ));
+                }
+                arg_idx += 1;
+            }
+            ArgMatcher::Suffix(suffix) => {
+                if arg_idx >= recorded_args.len() {
+                    return Some(format!(
+                        "Missing argument at position {}: expected argument ending with '{}'",
+                        arg_idx, suffix
+                    ));
+                }
+                if !recorded_args[arg_idx].ends_with(suffix) {
+                    return Some(format!(
+                        "Argument suffix mismatch at position {}: expected suffix '{}', got '{}'",
+                        arg_idx, suffix, recorded_args[arg_idx]
+                    ));
+                }
+                arg_idx += 1;
+            }
+            ArgMatcher::Pair(key, value) => {
+                if arg_idx >= recorded_args.len() {
+                    return Some(format!(
+                        "Missing argument pair at position {}: expected key '{}' with value '{}'",
+                        arg_idx, key, value
+                    ));
+                }
+                if arg_idx + 1 >= recorded_args.len() {
+                    return Some(format!(
+                        "Incomplete argument pair at position {}: got key '{}' but missing value (expected '{}')",
+                        arg_idx,
+                        recorded_args[arg_idx],
+                        value
+                    ));
+                }
+                if recorded_args[arg_idx] != *key {
+                    return Some(format!(
+                        "Argument pair key mismatch at position {}: expected '{}', got '{}'",
+                        arg_idx, key, recorded_args[arg_idx]
+                    ));
+                }
+                if recorded_args[arg_idx + 1] != *value {
+                    return Some(format!(
+                        "Argument pair value mismatch at position {}: for key '{}', expected '{}', got '{}'",
+                        arg_idx + 1, key, value, recorded_args[arg_idx + 1]
+                    ));
+                }
+                arg_idx += 2;
+            }
+            ArgMatcher::PairSuffix(key, value_suffix) => {
+                if arg_idx >= recorded_args.len() {
+                    return Some(format!(
+                        "Missing argument pair at position {}: expected key '{}' with value ending with '{}'",
+                        arg_idx, key, value_suffix
+                    ));
+                }
+                if arg_idx + 1 >= recorded_args.len() {
+                    return Some(format!(
+                        "Incomplete argument pair at position {}: got key '{}' but missing value (expected to end with '{}')",
+                        arg_idx,
+                        recorded_args[arg_idx],
+                        value_suffix
+                    ));
+                }
+                if recorded_args[arg_idx] != *key {
+                    return Some(format!(
+                        "Argument pair key mismatch at position {}: expected '{}', got '{}'",
+                        arg_idx, key, recorded_args[arg_idx]
+                    ));
+                }
+                if !recorded_args[arg_idx + 1].ends_with(value_suffix) {
+                    return Some(format!(
+                        "Argument pair value suffix mismatch at position {}: for key '{}', expected suffix '{}', got '{}'",
+                        arg_idx + 1, key, value_suffix, recorded_args[arg_idx + 1]
+                    ));
+                }
+                arg_idx += 2;
+            }
+        }
+    }
+
+    None
+}

--- a/crates/ubrn_cli_testing/src/command_assertions.rs
+++ b/crates/ubrn_cli_testing/src/command_assertions.rs
@@ -53,7 +53,7 @@ pub fn commands_match(expected_commands: &[Command]) -> bool {
 /// Returns None if matching, or Some(error_message) with details about the mismatch
 fn command_mismatch(recorded: &RecordedCommand, expected: &Command) -> Option<String> {
     // Check program name
-    if recorded.program != expected.program() {
+    if !recorded.program.ends_with(expected.program()) {
         return Some(format!(
             "Program name mismatch: expected '{}', got '{}'",
             expected.program(),

--- a/crates/ubrn_cli_testing/src/command_assertions.rs
+++ b/crates/ubrn_cli_testing/src/command_assertions.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use ubrn_common::{get_recorded_commands, RecordedCommand};
+use ubrn_common::{get_recorded_commands, Command as RecordedCommand};
 
 use crate::{command::ArgMatcher, Command};
 
@@ -14,7 +14,7 @@ fn check_commands(expected_commands: &[Command]) -> Result<(), String> {
     // If we have fewer recorded commands than expected, fail immediately
     if recorded.len() < expected_commands.len() {
         return Err(format!(
-            "Expected {} commands but only {} were recorded.\nExpected: {:?}\nRecorded: {:?}",
+            "Expected {} commands but only {} were recorded.\nExpected: {:?}\nObserved: {:?}",
             expected_commands.len(),
             recorded.len(),
             expected_commands,
@@ -25,7 +25,7 @@ fn check_commands(expected_commands: &[Command]) -> Result<(), String> {
     for (i, expected) in expected_commands.iter().enumerate() {
         if let Some(mismatch) = command_mismatch(&recorded[i], expected) {
             return Err(format!(
-                "Command mismatch at position {}:\n{}\nExpected: {:?}\nRecorded: {:?}",
+                "Command mismatch at position {}:\n{}\nExpected: {:?}\nObserved: {:?}",
                 i, mismatch, expected, recorded[i]
             ));
         }

--- a/crates/ubrn_cli_testing/src/file.rs
+++ b/crates/ubrn_cli_testing/src/file.rs
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::path::Path;
+
+use camino::Utf8PathBuf;
+
+/// A builder for file matchers to be used in tests
+#[derive(Debug, Clone)]
+pub struct File {
+    path: Utf8PathBuf,
+    content_matchers: Vec<ContentMatcher>,
+}
+
+/// Types of content matchers for files
+#[derive(Debug, Clone)]
+pub enum ContentMatcher {
+    /// Match file content that contains the specified substring
+    Contains(String),
+    /// Match file content that does not contain the specified substring
+    DoesNotContain(String),
+}
+
+impl File {
+    /// Create a new file matcher for a given file path
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            path: Utf8PathBuf::from(path.as_ref().to_string_lossy().to_string()),
+            content_matchers: Vec::new(),
+        }
+    }
+
+    /// Add a matcher to check if the file contains a substring
+    pub fn contains(mut self, substring: &str) -> Self {
+        self.content_matchers
+            .push(ContentMatcher::Contains(substring.to_string()));
+        self
+    }
+
+    /// Add a matcher to check if the file does not contain a substring
+    pub fn does_not_contain(mut self, substring: &str) -> Self {
+        self.content_matchers
+            .push(ContentMatcher::DoesNotContain(substring.to_string()));
+        self
+    }
+
+    /// Get the file path
+    pub fn path(&self) -> &Utf8PathBuf {
+        &self.path
+    }
+
+    /// Get the content matchers
+    pub fn content_matchers(&self) -> &[ContentMatcher] {
+        &self.content_matchers
+    }
+}

--- a/crates/ubrn_cli_testing/src/file_assertions.rs
+++ b/crates/ubrn_cli_testing/src/file_assertions.rs
@@ -1,0 +1,117 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use crate::file::{ContentMatcher, File};
+use ubrn_common::get_recorded_files;
+use ubrn_common::RecordedFile;
+
+/// Helper function to check if file matchers match the recorded files
+/// Returns Ok(()) if files match, Err(error_message) with detailed error otherwise
+fn check_files(expected_files: &[File]) -> Result<(), String> {
+    let recorded = get_recorded_files();
+
+    // If there are no expected files, just return success
+    if expected_files.is_empty() {
+        return Ok(());
+    }
+
+    // If we have no recorded files but expected some, fail
+    if recorded.is_empty() {
+        return Err(format!(
+            "Expected {} files but none were recorded.\nExpected: {:?}",
+            expected_files.len(),
+            expected_files
+        ));
+    }
+
+    // Track which files have been matched to handle files in any order
+    let mut unmatched_files: Vec<&File> = expected_files.iter().collect();
+    let mut matched_recorded_files = vec![false; recorded.len()];
+
+    // Try to match each expected file with a recorded file
+    for expected_file in expected_files {
+        let mut found_match = false;
+        let expected_path = expected_file.path().as_str();
+
+        for (i, recorded_file) in recorded.iter().enumerate() {
+            // Skip files that have already been matched
+            if matched_recorded_files[i] {
+                continue;
+            }
+
+            // Check if the recorded file path ends with the expected path (suffix match)
+            if recorded_file.path.ends_with(expected_path) {
+                // Check content matchers
+                if let Some(error) = check_file_content(recorded_file, expected_file) {
+                    return Err(error);
+                }
+
+                found_match = true;
+                matched_recorded_files[i] = true;
+
+                // Remove this file from the unmatched list
+                if let Some(pos) = unmatched_files
+                    .iter()
+                    .position(|f| f.path() == expected_file.path())
+                {
+                    unmatched_files.remove(pos);
+                }
+
+                break;
+            }
+        }
+
+        if !found_match {
+            return Err(format!(
+                "No matching file found for expected file: {}",
+                expected_path
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Helper function to check if file content matches the expected matchers
+/// Returns None if content matches, or Some(error_message) if there's a mismatch
+fn check_file_content(recorded: &RecordedFile, expected: &File) -> Option<String> {
+    for matcher in expected.content_matchers() {
+        match matcher {
+            ContentMatcher::Contains(substring) => {
+                if !recorded.content.contains(substring) {
+                    return Some(format!(
+                        "File '{}' should contain '{}' but it doesn't.\nContent: {}",
+                        recorded.path, substring, recorded.content
+                    ));
+                }
+            }
+            ContentMatcher::DoesNotContain(substring) => {
+                if recorded.content.contains(substring) {
+                    return Some(format!(
+                        "File '{}' should not contain '{}' but it does.\nContent: {}",
+                        recorded.path, substring, recorded.content
+                    ));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Assert that a set of files were written with expected content
+/// Panics with a detailed error message if files don't match
+pub fn assert_files(expected_files: &[File]) {
+    if let Err(message) = check_files(expected_files) {
+        panic!("{}", message);
+    }
+}
+
+/// Check if written files match the expected ones
+/// Returns true if they match, false otherwise
+/// This is useful for tests that want to verify negative cases
+pub fn files_match(expected_files: &[File]) -> bool {
+    check_files(expected_files).is_ok()
+}

--- a/crates/ubrn_cli_testing/src/fixture.rs
+++ b/crates/ubrn_cli_testing/src/fixture.rs
@@ -1,0 +1,159 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::env;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+
+use crate::recording::{start_recording, stop_recording};
+
+/// Run a test with a specific fixture.
+///
+/// This function:
+/// 1. Changes to the given fixture directory
+/// 2. Starts recording
+/// 3. Runs the given closure with the fixture directory path
+/// 4. Stops recording
+/// 5. Changes back to the original directory
+///
+/// # Arguments
+///
+/// * `root_dir` - The root directory of the project
+/// * `fixture_name` - The name/path of the fixture under test
+/// * `test_fn` - The test function to run
+///
+/// # Returns
+///
+/// Returns the result of the test function
+///
+/// # Example
+///
+/// ```no_run
+/// use ubrn_cli_testing::{with_fixture, Command, assert_commands, run_cli, shim_file};
+/// use camino::Utf8PathBuf;
+///
+/// fn test_build_command() -> anyhow::Result<()> {
+///     with_fixture(Utf8PathBuf::from("path/to/project"), "fixtures/my-fixture", |fixture_dir| {
+///         // Set up file shims
+///         shim_file("package.json", fixture_dir.join("basic/package.json"));
+///
+///         // Run the command under test
+///         run_cli("build ios --and-generate --config ubrn.config.yaml")?;
+///
+///         // Assert the expected commands were executed
+///         assert_commands(&[
+///             Command::new("xcodebuild")
+///                 .arg_pair_suffix("-xcframework", ".xcframework")
+///         ]);
+///
+///         Ok(())
+///     })
+/// }
+/// ```
+pub fn with_fixture<F, T>(root_dir: Utf8PathBuf, fixture_name: &str, test_fn: F) -> Result<T>
+where
+    F: FnOnce(Utf8PathBuf) -> Result<T>,
+{
+    // Save current directory so we can return to it
+    let current_dir = env::current_dir()?;
+
+    // Build the fixture directory path
+    let fixture_dir = root_dir.join(fixture_name);
+
+    // Change to the fixture directory
+    env::set_current_dir(&fixture_dir)?;
+
+    // Start recording
+    start_recording();
+
+    // Run the test function with the fixture directory
+    let result = test_fn(fixture_dir.clone());
+
+    // Stop recording
+    stop_recording();
+
+    // Change back to the original directory
+    env::set_current_dir(current_dir)?;
+
+    result
+}
+
+/// Find the root directory of the project.
+///
+/// This function looks for a Cargo.toml file in the current directory and its parent directories.
+/// It returns the directory containing the first Cargo.toml file found.
+///
+/// # Returns
+///
+/// Returns a `Result` with the root directory path.
+///
+/// # Errors
+///
+/// Returns an error if no Cargo.toml file is found.
+pub fn find_project_root() -> Result<Utf8PathBuf> {
+    let current_dir = env::current_dir()?;
+    let mut dir = current_dir.as_path();
+
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.exists() {
+            return Ok(Utf8PathBuf::try_from(dir.to_path_buf())?);
+        }
+
+        if let Some(parent) = dir.parent() {
+            dir = parent;
+        } else {
+            return Err(anyhow::anyhow!(
+                "Could not find Cargo.toml in any parent directory"
+            ));
+        }
+    }
+}
+
+/// Run a test with a specific fixture, automatically finding the project root.
+///
+/// This function is similar to `with_fixture`, but it automatically finds the project root
+/// by looking for a Cargo.toml file in the current directory or its parents.
+///
+/// # Arguments
+///
+/// * `fixture_name` - The name/path of the fixture under test
+/// * `test_fn` - The test function to run
+///
+/// # Returns
+///
+/// Returns the result of the test function
+///
+/// # Example
+///
+/// ```no_run
+/// use ubrn_cli_testing::{with_project_fixture, Command, assert_commands, run_cli, shim_file};
+///
+/// fn test_build_command() -> anyhow::Result<()> {
+///     with_project_fixture("fixtures/my-fixture", |fixture_dir| {
+///         // Set up file shims
+///         shim_file("package.json", fixture_dir.join("basic/package.json"));
+///
+///         // Run the command under test
+///         run_cli("build ios --and-generate --config ubrn.config.yaml")?;
+///
+///         // Assert the expected commands were executed
+///         assert_commands(&[
+///             Command::new("xcodebuild")
+///                 .arg_pair_suffix("-xcframework", ".xcframework")
+///         ]);
+///
+///         Ok(())
+///     })
+/// }
+/// ```
+pub fn with_project_fixture<F, T>(fixture_name: &str, test_fn: F) -> Result<T>
+where
+    F: FnOnce(Utf8PathBuf) -> Result<T>,
+{
+    let root_dir = find_project_root()?;
+    with_fixture(root_dir, fixture_name, test_fn)
+}

--- a/crates/ubrn_cli_testing/src/lib.rs
+++ b/crates/ubrn_cli_testing/src/lib.rs
@@ -18,3 +18,4 @@ pub use command_assertions::{assert_commands, commands_match};
 pub use file::File;
 pub use file_assertions::{assert_files, files_match};
 pub use recording::{start_recording, stop_recording};
+pub use ubrn_common::{shim_file, shim_file_str};

--- a/crates/ubrn_cli_testing/src/lib.rs
+++ b/crates/ubrn_cli_testing/src/lib.rs
@@ -3,19 +3,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+mod cli;
 mod command;
 mod command_assertions;
 mod file;
 mod file_assertions;
+mod fixture;
 mod recording;
 
 #[cfg(test)]
 mod tests;
 
-// Re-export command, file, and recording modules
+// Re-export modules
+pub use cli::run_cli;
 pub use command::Command;
 pub use command_assertions::{assert_commands, commands_match};
 pub use file::File;
 pub use file_assertions::{assert_files, files_match};
+pub use fixture::{find_project_root, with_fixture, with_project_fixture};
 pub use recording::{start_recording, stop_recording};
 pub use ubrn_common::{shim_file, shim_file_str};

--- a/crates/ubrn_cli_testing/src/lib.rs
+++ b/crates/ubrn_cli_testing/src/lib.rs
@@ -20,6 +20,6 @@ pub use command::Command;
 pub use command_assertions::{assert_commands, commands_match};
 pub use file::File;
 pub use file_assertions::{assert_files, files_match};
-pub use fixture::{find_project_root, with_fixture, with_project_fixture};
+pub use fixture::with_fixture;
 pub use recording::{start_recording, stop_recording};
-pub use ubrn_common::{shim_file, shim_file_str};
+pub use ubrn_common::{shim_file_str, shim_path};

--- a/crates/ubrn_cli_testing/src/lib.rs
+++ b/crates/ubrn_cli_testing/src/lib.rs
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+mod command;
+mod command_assertions;
+mod file;
+mod file_assertions;
+mod recording;
+
+#[cfg(test)]
+mod tests;
+
+// Re-export command, file, and recording modules
+pub use command::Command;
+pub use command_assertions::{assert_commands, commands_match};
+pub use file::File;
+pub use file_assertions::{assert_files, files_match};
+pub use recording::{start_recording, stop_recording};

--- a/crates/ubrn_cli_testing/src/recording.rs
+++ b/crates/ubrn_cli_testing/src/recording.rs
@@ -3,16 +3,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use ubrn_common::{clear_recorded_commands, disable_command_recording, enable_command_recording};
 
 /// Start recording commands (commands will be recorded but not executed)
 pub fn start_recording() {
-    enable_command_recording();
-    clear_recorded_commands();
+    ubrn_common::enable_command_recording();
+    ubrn_common::clear_recorded_commands();
+    ubrn_common::clear_recorded_files();
+    ubrn_common::clear_file_shims();
 }
 
 /// Stop recording commands and clear the recorded commands
 pub fn stop_recording() {
-    disable_command_recording();
-    clear_recorded_commands();
+    ubrn_common::disable_command_recording();
+    ubrn_common::clear_recorded_commands();
+    ubrn_common::clear_recorded_files();
+    ubrn_common::clear_file_shims();
 }

--- a/crates/ubrn_cli_testing/src/recording.rs
+++ b/crates/ubrn_cli_testing/src/recording.rs
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use ubrn_common::{clear_recorded_commands, disable_command_recording, enable_command_recording};
+
+/// Start recording commands (commands will be recorded but not executed)
+pub fn start_recording() {
+    enable_command_recording();
+    clear_recorded_commands();
+}
+
+/// Stop recording commands and clear the recorded commands
+pub fn stop_recording() {
+    disable_command_recording();
+    clear_recorded_commands();
+}

--- a/crates/ubrn_cli_testing/src/tests/command_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/command_tests.rs
@@ -1,0 +1,154 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::process;
+use ubrn_common::{get_recorded_commands, run_cmd};
+
+use crate::{assert_commands, commands_match, start_recording, stop_recording, Command};
+
+#[test]
+fn test_command_recording() {
+    // Start recording
+    start_recording();
+
+    // Run some commands through the common interface
+    let mut cmd1 = process::Command::new("cargo");
+    cmd1.arg("build")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown");
+    let _ = run_cmd(&mut cmd1);
+
+    let mut cmd2 = process::Command::new("npm");
+    cmd2.arg("install").current_dir("/path/to/project");
+    let _ = run_cmd(&mut cmd2);
+
+    // Verify recorded commands
+    let recorded = get_recorded_commands();
+    assert_eq!(recorded.len(), 2);
+    assert_eq!(recorded[0].program, "cargo");
+    assert_eq!(
+        recorded[0].args,
+        vec!["build", "--target", "wasm32-unknown-unknown"]
+    );
+    assert_eq!(recorded[1].program, "npm");
+    assert_eq!(recorded[1].args, vec!["install"]);
+
+    // Stop and clear recording
+    stop_recording();
+}
+
+#[test]
+fn test_command_assertions() {
+    // Start recording
+    start_recording();
+
+    // Run some commands
+    let mut cmd1 = process::Command::new("cargo");
+    cmd1.arg("build")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown");
+    let _ = run_cmd(&mut cmd1);
+
+    let mut cmd2 = process::Command::new("xcodebuild");
+    cmd2.arg("-create-xframework")
+        .arg("-output")
+        .arg("/path/to/output.xcframework");
+    let _ = run_cmd(&mut cmd2);
+
+    // Test exact command matching - this should not panic
+    assert_commands(&[
+        Command::new("cargo")
+            .arg("build")
+            .arg("--target")
+            .arg("wasm32-unknown-unknown"),
+        Command::new("xcodebuild")
+            .arg("-create-xframework")
+            .arg("-output")
+            .arg("/path/to/output.xcframework"),
+    ]);
+
+    // Test matching with argpair - this should not panic
+    assert_commands(&[
+        Command::new("cargo")
+            .arg("build")
+            .arg_pair("--target", "wasm32-unknown-unknown"),
+        Command::new("xcodebuild")
+            .arg("-create-xframework")
+            .arg_pair("-output", "/path/to/output.xcframework"),
+    ]);
+
+    // Test suffix matching - this should not panic
+    assert_commands(&[
+        Command::new("cargo")
+            .arg("build")
+            .arg("--target")
+            .arg_suffix("unknown"),
+        Command::new("xcodebuild")
+            .arg("-create-xframework")
+            .arg("-output")
+            .arg_suffix(".xcframework"),
+    ]);
+
+    // Test pair_suffix matching - this should not panic
+    assert_commands(&[
+        Command::new("cargo")
+            .arg("build")
+            .arg_pair_suffix("--target", "unknown"),
+        Command::new("xcodebuild")
+            .arg("-create-xframework")
+            .arg_pair_suffix("-output", ".xcframework"),
+    ]);
+
+    // Test with incorrect order (should fail)
+    assert!(!commands_match(&[
+        Command::new("xcodebuild"),
+        Command::new("cargo"),
+    ]));
+
+    stop_recording();
+}
+
+#[test]
+#[should_panic(expected = "Command mismatch at position 0")]
+fn test_command_mismatch_panic() {
+    // Start recording
+    start_recording();
+
+    // Run a cargo command
+    let mut cmd = process::Command::new("cargo");
+    cmd.arg("build").arg("--release");
+    let _ = run_cmd(&mut cmd);
+
+    // This should panic with a helpful error message
+    assert_commands(&[
+        Command::new("npm").arg("install"), // Wrong command
+    ]);
+
+    // We shouldn't get here
+    stop_recording();
+}
+
+#[test]
+fn test_arg_pair_suffix_mismatch() {
+    // Start recording
+    start_recording();
+
+    // Run a command with a path argument
+    let mut cmd = process::Command::new("xcodebuild");
+    cmd.arg("-output").arg("/path/to/file.framework");
+    let _ = run_cmd(&mut cmd);
+
+    // This should match
+    assert!(commands_match(&[
+        Command::new("xcodebuild").arg_pair_suffix("-output", ".framework"),
+    ]));
+
+    // This should not match - wrong suffix
+    assert!(!commands_match(&[
+        Command::new("xcodebuild").arg_pair_suffix("-output", ".xcframework"),
+    ]));
+
+    stop_recording();
+}

--- a/crates/ubrn_cli_testing/src/tests/file_shim_str_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/file_shim_str_tests.rs
@@ -1,0 +1,93 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use camino::Utf8PathBuf;
+use ubrn_common::read_to_string;
+
+use crate::{shim_file_str, start_recording, stop_recording};
+
+#[test]
+fn test_file_shim_str() -> anyhow::Result<()> {
+    // Create a temporary directory for test files
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+
+    // Create a file path that we'll shim with string content
+    let file_path = temp_path.join("config.json");
+
+    // The file doesn't exist on disk
+    assert!(!file_path.exists());
+
+    // Start recording and set up string content shim
+    start_recording();
+    shim_file_str(
+        "config.json",
+        r#"{"name": "test-package", "version": "1.0.0"}"#,
+    );
+
+    // Reading the file should return the shimmed string content
+    let content = read_to_string(&file_path)?;
+    assert_eq!(content, r#"{"name": "test-package", "version": "1.0.0"}"#);
+
+    // Clean up
+    stop_recording();
+    temp_dir.close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_file_shim_str_with_suffix() -> anyhow::Result<()> {
+    // Create a temporary directory for test files
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+
+    // Create a file path that we'll shim with string content
+    let file_path = temp_path.join("some/nested/path/suffix.json");
+
+    // Create the directory structure
+    std::fs::create_dir_all(file_path.parent().unwrap())?;
+
+    // Start recording and set up string content shim
+    start_recording();
+    shim_file_str("suffix.json", r#"{"foo": "bar"}"#);
+
+    // Reading the file should return the shimmed string content
+    let content = read_to_string(&file_path)?;
+    assert_eq!(content, r#"{"foo": "bar"}"#);
+
+    // Clean up
+    stop_recording();
+    temp_dir.close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_file_shim_str_multiline() -> anyhow::Result<()> {
+    // Start recording and set up string content shim with multiline string
+    start_recording();
+
+    // Use a multiline string with triple quotes
+    let json_content = r#"{
+  "name": "test-package",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}"#;
+
+    shim_file_str("package.json", json_content);
+
+    // Reading the file should return the shimmed string content
+    let content = read_to_string("some/path/package.json")?;
+    assert_eq!(content, json_content);
+
+    // Clean up
+    stop_recording();
+
+    Ok(())
+}

--- a/crates/ubrn_cli_testing/src/tests/file_shim_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/file_shim_tests.rs
@@ -1,0 +1,91 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::fs;
+
+use camino::Utf8PathBuf;
+use ubrn_common::read_to_string;
+
+use crate::{shim_file, start_recording, stop_recording};
+
+#[test]
+fn test_file_shim() -> anyhow::Result<()> {
+    // Create a temporary directory for test files
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+
+    // Create source and target files
+    let source_path = temp_path.join("source.txt");
+    let target_path = temp_path.join("target.txt");
+
+    fs::write(&source_path, "source content")?;
+    fs::write(&target_path, "target content")?;
+
+    // Start recording and set up shim
+    start_recording();
+    shim_file("source.txt", &target_path);
+
+    // Read source file - should give us target content
+    let content = read_to_string(&source_path)?;
+    assert_eq!(content, "target content");
+
+    // Clean up
+    stop_recording();
+    temp_dir.close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_file_shim_with_suffix() -> anyhow::Result<()> {
+    // Create a temporary directory for test files
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+
+    // Create source and target files
+    let source_path = temp_path.join("some/nested/path/package.json");
+    let target_path = temp_path.join("fixtures/basic/package.json");
+
+    // Create directory structure
+    fs::create_dir_all(source_path.parent().unwrap())?;
+    fs::create_dir_all(target_path.parent().unwrap())?;
+
+    fs::write(&source_path, r#"{"name": "source-package"}"#)?;
+    fs::write(&target_path, r#"{"name": "target-package"}"#)?;
+
+    // Start recording and set up shim
+    start_recording();
+    shim_file("package.json", &target_path);
+
+    // Read source file - should give us target content
+    let content = read_to_string(&source_path)?;
+    assert_eq!(content, r#"{"name": "target-package"}"#);
+
+    // Clean up
+    stop_recording();
+    temp_dir.close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_non_existent_shim_path() -> anyhow::Result<()> {
+    // Start recording
+    start_recording();
+
+    // Shim to a non-existent file
+    shim_file("config.json", "/path/that/does/not/exist.json");
+
+    // Read a non-existent file that matches the shim
+    let content = read_to_string("/some/path/config.json");
+
+    // When the shimmed path doesn't exist, we get an error.
+    assert!(content.is_err());
+
+    // Clean up
+    stop_recording();
+
+    Ok(())
+}

--- a/crates/ubrn_cli_testing/src/tests/file_shim_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/file_shim_tests.rs
@@ -8,7 +8,7 @@ use std::fs;
 use camino::Utf8PathBuf;
 use ubrn_common::read_to_string;
 
-use crate::{shim_file, start_recording, stop_recording};
+use crate::{shim_path, start_recording, stop_recording};
 
 #[test]
 fn test_file_shim() -> anyhow::Result<()> {
@@ -25,7 +25,7 @@ fn test_file_shim() -> anyhow::Result<()> {
 
     // Start recording and set up shim
     start_recording();
-    shim_file("source.txt", &target_path);
+    shim_path("source.txt", &target_path);
 
     // Read source file - should give us target content
     let content = read_to_string(&source_path)?;
@@ -57,7 +57,7 @@ fn test_file_shim_with_suffix() -> anyhow::Result<()> {
 
     // Start recording and set up shim
     start_recording();
-    shim_file("package.json", &target_path);
+    shim_path("package.json", &target_path);
 
     // Read source file - should give us target content
     let content = read_to_string(&source_path)?;
@@ -76,7 +76,7 @@ fn test_non_existent_shim_path() -> anyhow::Result<()> {
     start_recording();
 
     // Shim to a non-existent file
-    shim_file("config.json", "/path/that/does/not/exist.json");
+    shim_path("config.json", "/path/that/does/not/exist.json");
 
     // Read a non-existent file that matches the shim
     let content = read_to_string("/some/path/config.json");

--- a/crates/ubrn_cli_testing/src/tests/file_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/file_tests.rs
@@ -1,0 +1,99 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use crate::{assert_files, files_match, start_recording, stop_recording, File};
+use ubrn_common::{clear_recorded_files, get_recorded_files, write_file};
+
+#[test]
+fn test_file_recording() {
+    // Start recording
+    start_recording();
+
+    // Write some files
+    write_file("/path/to/file.kt", "This is a test file with some content").unwrap();
+    write_file(
+        "/another/path/example.txt",
+        "Another example\nwith multiple lines",
+    )
+    .unwrap();
+
+    // Get recorded files to verify they were captured
+    let recorded = get_recorded_files();
+    assert_eq!(recorded.len(), 2);
+    assert!(recorded[0].path.ends_with("file.kt"));
+    assert!(recorded[1].path.ends_with("example.txt"));
+
+    // Clean up
+    stop_recording();
+    clear_recorded_files();
+}
+
+#[test]
+fn test_file_assertions() {
+    start_recording();
+
+    write_file("/path/to/file.kt", "This is a test file with some content").unwrap();
+
+    // Test successful assertions
+    assert_files(&[File::new("file.kt")
+        .contains("test file")
+        .contains("content")
+        .does_not_contain("missing text")]);
+
+    // Test files_match function
+    assert!(files_match(&[File::new("file.kt").contains("test file")]));
+
+    assert!(!files_match(&[
+        File::new("file.kt").contains("non-existent content")
+    ]));
+
+    // Test suffix path matching
+    assert_files(&[File::new("/to/file.kt").contains("test file")]);
+
+    clear_recorded_files();
+    stop_recording();
+}
+
+#[test]
+#[should_panic(expected = "should contain")]
+fn test_file_assertion_fails_when_content_missing() {
+    start_recording();
+
+    write_file("/path/to/file.kt", "This is a test file with some content").unwrap();
+
+    // This should fail because the file doesn't contain "missing content"
+    assert_files(&[File::new("file.kt").contains("missing content")]);
+
+    clear_recorded_files();
+    stop_recording();
+}
+
+#[test]
+#[should_panic(expected = "should not contain")]
+fn test_file_assertion_fails_when_unwanted_content_present() {
+    start_recording();
+
+    write_file("/path/to/file.kt", "This is a test file with some content").unwrap();
+
+    // This should fail because the file contains "test file"
+    assert_files(&[File::new("file.kt").does_not_contain("test file")]);
+
+    clear_recorded_files();
+    stop_recording();
+}
+
+#[test]
+#[should_panic(expected = "No matching file found")]
+fn test_file_assertion_fails_when_file_missing() {
+    start_recording();
+
+    write_file("/path/to/file.kt", "This is a test file with some content").unwrap();
+
+    // This should fail because there's no file with this path
+    assert_files(&[File::new("nonexistent.txt").contains("anything")]);
+
+    clear_recorded_files();
+    stop_recording();
+}

--- a/crates/ubrn_cli_testing/src/tests/fixture_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/fixture_tests.rs
@@ -1,0 +1,130 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::{env, fs};
+
+use camino::Utf8PathBuf;
+use ubrn_common::{get_recorded_commands, read_to_string};
+
+use crate::{assert_commands, find_project_root, run_cli, shim_file_str, with_fixture, Command};
+
+#[test]
+fn test_with_fixture() -> anyhow::Result<()> {
+    // Create a temporary directory for test files
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+
+    // Create a mock fixture structure
+    let fixture_dir = temp_path.join("fixtures/test-fixture");
+    fs::create_dir_all(&fixture_dir)?;
+
+    // Create a mock file within the fixture
+    let config_path = fixture_dir.join("config.json");
+    fs::write(&config_path, r#"{"name": "test-fixture"}"#)?;
+
+    // Save current directory
+    let original_dir = env::current_dir()?;
+
+    // Run the test with our fixture
+    with_fixture(temp_path.clone(), "fixtures/test-fixture", |fixture_path| {
+        // Check that we're in the right directory
+        let current_dir = env::current_dir()?;
+        let current_dir_path = Utf8PathBuf::try_from(current_dir)?;
+        let normalized_current = current_dir_path.as_std_path().canonicalize()?;
+        let normalized_fixture = fixture_path.as_std_path().canonicalize()?;
+        assert_eq!(normalized_current, normalized_fixture);
+
+        // Test file shim functionality inside with_fixture
+        shim_file_str("sample.json", r#"{"foo": "bar"}"#);
+
+        // Read using the shim
+        let content = read_to_string("path/to/sample.json")?;
+        assert_eq!(content, r#"{"foo": "bar"}"#);
+
+        // Run a command and check that it's recorded
+        run_cli("echo test")?;
+
+        let recorded_commands = get_recorded_commands();
+        assert_eq!(recorded_commands.len(), 1);
+        assert_eq!(recorded_commands[0].program, "echo");
+        assert_eq!(recorded_commands[0].args, vec!["test"]);
+
+        Ok(())
+    })?;
+
+    // Verify we're back in the original directory
+    let final_dir = env::current_dir()?;
+    let normalized_final = final_dir.canonicalize()?;
+    let normalized_original = original_dir.canonicalize()?;
+    assert_eq!(normalized_final, normalized_original);
+
+    // Clean up
+    temp_dir.close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_find_project_root() -> anyhow::Result<()> {
+    // Create a temporary directory structure
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = temp_dir.path();
+
+    // Create a mock project structure with a Cargo.toml
+    let project_dir = temp_path.join("my-project");
+    fs::create_dir_all(&project_dir)?;
+    fs::write(
+        project_dir.join("Cargo.toml"),
+        "[package]\nname = \"test-project\"\n",
+    )?;
+
+    // Create a nested directory
+    let nested_dir = project_dir.join("src/nested");
+    fs::create_dir_all(&nested_dir)?;
+
+    // Save current directory
+    let original_dir = env::current_dir()?;
+
+    // Change to the nested directory
+    env::set_current_dir(&nested_dir)?;
+
+    // Finding the project root should give us the directory with Cargo.toml
+    let current_project_root = find_project_root()?;
+    let expected_project_root = Utf8PathBuf::try_from(project_dir.clone())?;
+
+    let normalized_current = current_project_root.as_std_path().canonicalize()?;
+    let normalized_expected = expected_project_root.as_std_path().canonicalize()?;
+
+    assert_eq!(normalized_current, normalized_expected);
+
+    // Change back to original directory
+    env::set_current_dir(original_dir)?;
+
+    // Clean up
+    temp_dir.close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_run_cli() -> anyhow::Result<()> {
+    // Start recording
+    crate::start_recording();
+
+    // Run a CLI command
+    run_cli("cargo build --release")?;
+
+    // Check the recorded command
+    let commands = get_recorded_commands();
+    assert_eq!(commands.len(), 1);
+
+    // Verify the command structure
+    assert_commands(&[Command::new("cargo").arg("build").arg("--release")]);
+
+    // Stop recording
+    crate::stop_recording();
+
+    Ok(())
+}

--- a/crates/ubrn_cli_testing/src/tests/fixture_tests.rs
+++ b/crates/ubrn_cli_testing/src/tests/fixture_tests.rs
@@ -8,7 +8,7 @@ use std::{env, fs};
 use camino::Utf8PathBuf;
 use ubrn_common::{get_recorded_commands, read_to_string};
 
-use crate::{assert_commands, find_project_root, run_cli, shim_file_str, with_fixture, Command};
+use crate::{assert_commands, run_cli, shim_file_str, with_fixture, Command};
 
 #[test]
 fn test_with_fixture() -> anyhow::Result<()> {
@@ -23,9 +23,6 @@ fn test_with_fixture() -> anyhow::Result<()> {
     // Create a mock file within the fixture
     let config_path = fixture_dir.join("config.json");
     fs::write(&config_path, r#"{"name": "test-fixture"}"#)?;
-
-    // Save current directory
-    let original_dir = env::current_dir()?;
 
     // Run the test with our fixture
     with_fixture(temp_path.clone(), "fixtures/test-fixture", |fixture_path| {
@@ -53,54 +50,6 @@ fn test_with_fixture() -> anyhow::Result<()> {
 
         Ok(())
     })?;
-
-    // Verify we're back in the original directory
-    let final_dir = env::current_dir()?;
-    let normalized_final = final_dir.canonicalize()?;
-    let normalized_original = original_dir.canonicalize()?;
-    assert_eq!(normalized_final, normalized_original);
-
-    // Clean up
-    temp_dir.close()?;
-
-    Ok(())
-}
-
-#[test]
-fn test_find_project_root() -> anyhow::Result<()> {
-    // Create a temporary directory structure
-    let temp_dir = tempfile::tempdir()?;
-    let temp_path = temp_dir.path();
-
-    // Create a mock project structure with a Cargo.toml
-    let project_dir = temp_path.join("my-project");
-    fs::create_dir_all(&project_dir)?;
-    fs::write(
-        project_dir.join("Cargo.toml"),
-        "[package]\nname = \"test-project\"\n",
-    )?;
-
-    // Create a nested directory
-    let nested_dir = project_dir.join("src/nested");
-    fs::create_dir_all(&nested_dir)?;
-
-    // Save current directory
-    let original_dir = env::current_dir()?;
-
-    // Change to the nested directory
-    env::set_current_dir(&nested_dir)?;
-
-    // Finding the project root should give us the directory with Cargo.toml
-    let current_project_root = find_project_root()?;
-    let expected_project_root = Utf8PathBuf::try_from(project_dir.clone())?;
-
-    let normalized_current = current_project_root.as_std_path().canonicalize()?;
-    let normalized_expected = expected_project_root.as_std_path().canonicalize()?;
-
-    assert_eq!(normalized_current, normalized_expected);
-
-    // Change back to original directory
-    env::set_current_dir(original_dir)?;
 
     // Clean up
     temp_dir.close()?;

--- a/crates/ubrn_cli_testing/src/tests/mod.rs
+++ b/crates/ubrn_cli_testing/src/tests/mod.rs
@@ -4,4 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 mod command_tests;
+mod file_shim_str_tests;
+mod file_shim_tests;
 mod file_tests;

--- a/crates/ubrn_cli_testing/src/tests/mod.rs
+++ b/crates/ubrn_cli_testing/src/tests/mod.rs
@@ -3,15 +3,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-mod commands;
-mod files;
-pub mod fmt;
-mod rust_crate;
-mod serde;
-mod testing;
-
-pub use commands::*;
-pub use files::*;
-pub use rust_crate::*;
-pub use serde::*;
-pub use testing::*;
+mod command_tests;
+mod file_tests;

--- a/crates/ubrn_cli_testing/src/tests/mod.rs
+++ b/crates/ubrn_cli_testing/src/tests/mod.rs
@@ -7,3 +7,4 @@ mod command_tests;
 mod file_shim_str_tests;
 mod file_shim_tests;
 mod file_tests;
+mod fixture_tests;

--- a/crates/ubrn_common/Cargo.toml
+++ b/crates/ubrn_common/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 anyhow = { workspace = true }
 camino = { workspace = true }
 cargo_metadata = { workspace = true }
+extend = { workspace = true }
 glob = "0.3.1"
 serde = { workspace = true }
 serde_json = "1.0.117"

--- a/crates/ubrn_common/src/commands.rs
+++ b/crates/ubrn_common/src/commands.rs
@@ -6,7 +6,19 @@
 use anyhow::Result;
 use std::process::{Command, Stdio};
 
+// Import needed for our is_recording_enabled and record_command functions
+// The actual implementation is in testing.rs
+use crate::testing::{is_recording_enabled, record_command};
+
 pub fn run_cmd(cmd: &mut Command) -> Result<()> {
+    // If we're in recording mode, just record the command and return success
+    if is_recording_enabled() {
+        record_command(cmd);
+        eprintln!("Recording command: {:?}", *cmd);
+        return Ok(());
+    }
+
+    // Otherwise, run the command as usual
     eprintln!("Running {:?}", *cmd);
     cmd.stdin(Stdio::inherit());
 
@@ -21,6 +33,13 @@ pub fn run_cmd(cmd: &mut Command) -> Result<()> {
 
 /// Run the given command, and only output if there is an error.
 pub fn run_cmd_quietly(cmd: &mut Command) -> Result<()> {
+    // If we're in recording mode, just record the command and return success
+    if is_recording_enabled() {
+        record_command(cmd);
+        return Ok(());
+    }
+
+    // Otherwise, run the command as usual
     cmd.stdin(Stdio::inherit());
     let output = cmd.output().expect("Failed to execute command");
 
@@ -32,4 +51,65 @@ pub fn run_cmd_quietly(cmd: &mut Command) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use crate::{
+        clear_recorded_commands, disable_command_recording, enable_command_recording,
+        get_recorded_commands, run_cmd,
+    };
+
+    fn assert_command_run_with_args(program: &str, args: &[&str]) -> bool {
+        get_recorded_commands().iter().any(|cmd| {
+            cmd.program == program && args.iter().all(|arg| cmd.args.iter().any(|a| a == arg))
+        })
+    }
+
+    fn assert_command_run_in_dir_containing(path_component: &str) -> bool {
+        get_recorded_commands().iter().any(|cmd| {
+            if let Some(dir) = &cmd.current_dir {
+                dir.to_string_lossy().contains(path_component)
+            } else {
+                false
+            }
+        })
+    }
+
+    #[test]
+    fn test_command_recording() {
+        // Setup recording mode
+        enable_command_recording();
+        clear_recorded_commands();
+
+        // Run some commands that would normally execute
+        let mut cmd1 = Command::new("cargo");
+        cmd1.arg("build");
+        run_cmd(&mut cmd1).expect("Should succeed in recording mode");
+
+        let mut cmd2 = Command::new("npm");
+        cmd2.args(["install", "--save-dev"]);
+        cmd2.current_dir("some/project/path");
+        run_cmd(&mut cmd2).expect("Should succeed in recording mode");
+
+        // Get the recorded commands
+        let commands = get_recorded_commands();
+
+        // Basic assertions
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].program, "cargo");
+        assert_eq!(commands[0].args, vec!["build"]);
+        assert_eq!(commands[1].program, "npm");
+        assert_eq!(commands[1].args, vec!["install", "--save-dev"]);
+
+        // More ergonomic helper assertions
+        assert!(assert_command_run_with_args("cargo", &["build"]));
+        assert!(assert_command_run_with_args("npm", &["install"]));
+        assert!(assert_command_run_in_dir_containing("some/project"));
+
+        // Cleanup
+        disable_command_recording();
+    }
 }

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -133,11 +133,7 @@ where
     for<'a> T: Deserialize<'a>,
 {
     let file = file.as_ref();
-    if !file.exists() {
-        anyhow::bail!("File {file} does not exist");
-    }
-    let s =
-        std::fs::read_to_string(file).with_context(|| format!("Failed to read from {file:?}"))?;
+    let s = read_to_string(file)?;
     Ok(if is_yaml(file) {
         serde_yaml::from_str(&s)
             .with_context(|| format!("Failed to read {file:?} as valid YAML"))?

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -151,6 +151,7 @@ where
 
     // If we're recording and a file shim exists, use it instead of the actual file
     if is_recording_enabled() {
+        eprintln!("Recording mode is enabled, using shimmed file");
         if let Some(shim_source) = crate::testing::get_shimmed_path(file) {
             match shim_source {
                 crate::testing::ShimSource::FilePath(path) => {
@@ -159,6 +160,8 @@ where
                         return fs::read_to_string(replacement_path).with_context(|| {
                             format!("Failed to read from shimmed file {replacement_path:?}")
                         });
+                    } else {
+                        anyhow::bail!("Shimmed file {replacement_path} does not exist");
                     }
                 }
                 crate::testing::ShimSource::StringContent(content) => {

--- a/crates/ubrn_common/src/fmt.rs
+++ b/crates/ubrn_common/src/fmt.rs
@@ -12,6 +12,10 @@ use crate::{file_paths, resolve};
 
 pub fn clang_format<P: AsRef<Utf8Path>>(path: P, check_only: bool) -> Result<Option<Command>> {
     if which("clang-format").is_err() {
+        use crate::testing::{is_recording_enabled, record_command};
+        if is_recording_enabled() {
+            record_command(&Command::new("clang-format"));
+        }
         return Ok(None);
     }
 
@@ -42,6 +46,10 @@ pub fn prettier<P: AsRef<Utf8Path>>(out_dir: P, check_only: bool) -> Result<Opti
         cmd.arg(".").current_dir(out_dir.as_ref());
         Some(cmd)
     } else {
+        use crate::testing::{is_recording_enabled, record_command};
+        if is_recording_enabled() {
+            record_command(&Command::new("prettier"));
+        }
         None
     })
 }

--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::{Metadata, MetadataCommand};
 
-use crate::run_cmd_quietly;
+use crate::{path_or_shim, run_cmd_quietly};
 
 #[derive(Debug, Clone)]
 pub struct CrateMetadata {
@@ -157,6 +157,7 @@ impl TryFrom<Utf8PathBuf> for CrateMetadata {
     type Error = anyhow::Error;
 
     fn try_from(manifest_path: Utf8PathBuf) -> Result<Self> {
+        let manifest_path = path_or_shim(&manifest_path)?;
         if !manifest_path.exists() {
             anyhow::bail!("Crate manifest doesn't exist");
         }

--- a/crates/ubrn_common/src/testing.rs
+++ b/crates/ubrn_common/src/testing.rs
@@ -181,6 +181,7 @@ pub(crate) fn get_shimmed_path(file_path: &Utf8Path) -> Option<ShimSource> {
     // Find a matching file suffix in the shims
     FILE_SHIMS.with(|shims| {
         for (suffix, source) in shims.borrow().iter() {
+            println!("Checking shim for suffix: {suffix} for {file_path_str}");
             if file_path_str.ends_with(suffix) {
                 return Some(source.clone());
             }

--- a/crates/ubrn_common/src/testing.rs
+++ b/crates/ubrn_common/src/testing.rs
@@ -124,8 +124,10 @@ pub(crate) fn record_file<P: AsRef<Utf8Path>, C: AsRef<[u8]>>(path: P, contents:
 
     // Try to convert the content to a string
     if let Ok(content) = std::str::from_utf8(contents.as_ref()) {
+        let path = path.as_ref().to_string();
+        println!("Recording file: {path}");
         let record = RecordedFile {
-            path: path.as_ref().to_string(),
+            path,
             content: content.to_string(),
         };
 
@@ -148,7 +150,7 @@ pub fn clear_recorded_files() {
 }
 
 /// Register a file shim - redirect file operations with a specific suffix to a different path
-pub fn shim_file<P1: AsRef<Utf8Path>, P2: AsRef<Utf8Path>>(file_suffix: P1, replacement_path: P2) {
+pub fn shim_path<P1: AsRef<Utf8Path>, P2: AsRef<Utf8Path>>(file_suffix: P1, replacement_path: P2) {
     FILE_SHIMS.with(|shims| {
         shims.borrow_mut().insert(
             file_suffix.as_ref().to_string(),
@@ -181,7 +183,6 @@ pub(crate) fn get_shimmed_path(file_path: &Utf8Path) -> Option<ShimSource> {
     // Find a matching file suffix in the shims
     FILE_SHIMS.with(|shims| {
         for (suffix, source) in shims.borrow().iter() {
-            println!("Checking shim for suffix: {suffix} for {file_path_str}");
             if file_path_str.ends_with(suffix) {
                 return Some(source.clone());
             }

--- a/crates/ubrn_common/src/testing.rs
+++ b/crates/ubrn_common/src/testing.rs
@@ -1,0 +1,136 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::{cell::RefCell, path::PathBuf, process::Command};
+
+use camino::Utf8Path;
+
+thread_local! {
+    // Track whether we're recording commands instead of running them
+    static RECORDING_MODE: RefCell<bool> = const { RefCell::new(false) };
+
+    // Store the recorded commands
+    static RECORDED_COMMANDS: RefCell<Vec<RecordedCommand>> = const { RefCell::new(Vec::new()) };
+
+    // Store the recorded file writes
+    static RECORDED_FILES: RefCell<Vec<RecordedFile>> = const { RefCell::new(Vec::new()) };
+}
+
+/// A record of a command that would have been executed
+#[derive(Debug, Clone)]
+pub struct RecordedCommand {
+    /// The executable name (like "cargo", "npm", etc.)
+    pub program: String,
+
+    /// The arguments that would have been passed
+    pub args: Vec<String>,
+
+    /// The working directory for the command, if specified
+    pub current_dir: Option<PathBuf>,
+}
+
+/// A record of a file that was written
+#[derive(Debug, Clone)]
+pub struct RecordedFile {
+    /// The path to the file
+    pub path: String,
+
+    /// The content that was written
+    pub content: String,
+}
+
+impl RecordedCommand {
+    /// Create a new RecordedCommand from a std::process::Command
+    fn from_command(cmd: &Command) -> Self {
+        // Extract program name
+        let program = cmd.get_program().to_string_lossy().to_string();
+
+        // Extract arguments
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        // Extract working directory if set
+        let current_dir = cmd.get_current_dir().map(|p| p.to_path_buf());
+
+        RecordedCommand {
+            program,
+            args,
+            current_dir,
+        }
+    }
+}
+
+/// Enable command recording mode (commands will be recorded but not executed)
+pub fn enable_command_recording() {
+    RECORDING_MODE.with(|mode| {
+        *mode.borrow_mut() = true;
+    });
+}
+
+/// Disable command recording mode (commands will be executed normally)
+pub fn disable_command_recording() {
+    RECORDING_MODE.with(|mode| {
+        *mode.borrow_mut() = false;
+    });
+}
+
+/// Check if command recording is currently enabled
+pub(crate) fn is_recording_enabled() -> bool {
+    RECORDING_MODE.with(|mode| *mode.borrow())
+}
+
+/// Record a command instead of executing it
+pub(crate) fn record_command(cmd: &Command) {
+    let record = RecordedCommand::from_command(cmd);
+    RECORDED_COMMANDS.with(|commands| {
+        commands.borrow_mut().push(record);
+    });
+}
+
+/// Get all recorded commands
+pub fn get_recorded_commands() -> Vec<RecordedCommand> {
+    RECORDED_COMMANDS.with(|commands| commands.borrow().clone())
+}
+
+/// Clear the list of recorded commands
+pub fn clear_recorded_commands() {
+    RECORDED_COMMANDS.with(|commands| {
+        commands.borrow_mut().clear();
+    });
+}
+
+/// Record a file write operation
+pub(crate) fn record_file<P: AsRef<Utf8Path>, C: AsRef<[u8]>>(path: P, contents: C) {
+    // Only record if recording is enabled
+    if !is_recording_enabled() {
+        return;
+    }
+
+    // Try to convert the content to a string
+    if let Ok(content) = std::str::from_utf8(contents.as_ref()) {
+        let record = RecordedFile {
+            path: path.as_ref().to_string(),
+            content: content.to_string(),
+        };
+
+        RECORDED_FILES.with(|files| {
+            files.borrow_mut().push(record);
+        });
+    }
+}
+
+/// Get all recorded file writes
+pub fn get_recorded_files() -> Vec<RecordedFile> {
+    RECORDED_FILES.with(|files| files.borrow().clone())
+}
+
+/// Clear the list of recorded files
+pub fn clear_recorded_files() {
+    RECORDED_FILES.with(|files| {
+        files.borrow_mut().clear();
+    });
+}

--- a/crates/ubrn_testing/Cargo.toml
+++ b/crates/ubrn_testing/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[dependencies]
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
 gloo-timers = { version = "0.3.0", features = ["futures"] }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Turbo-module Templates: Adding or changing](contributing/changing-turbo-module-templates.md)
 - [Documentation: Contributing or reviewing](contributing/documentation.md)
 - [Typescript or C++ templates: Changing](contributing/changing-bindings-templates.md)
+- [Unit Testing the command line](contributing/testing_the_command_line.md)
 - [Cutting a Release](./contributing/cutting-a-release.md)
 
 # Reference

--- a/docs/src/contributing/testing_the_command_line.md
+++ b/docs/src/contributing/testing_the_command_line.md
@@ -1,0 +1,98 @@
+# File Matching API
+
+## Overview
+
+The File Matching API provides a convenient way to test file operations in your code. It allows you to:
+
+- Record file writes during test execution
+- Assert on file content using flexible matchers
+- Match files by path suffix to handle variable paths
+- Provide detailed error messages for failed assertions
+
+## Usage
+
+### Basic Example
+
+```rust
+use ubrn_cli_testing::{start_recording, stop_recording, File, assert_files};
+use ubrn_common::write_file;
+
+#[test]
+fn test_my_function_writes_correct_files() {
+    // Start recording file operations
+    start_recording();
+
+    // Call your function that writes files
+    my_function_that_writes_files();
+
+    // Assert on the files that were written
+    assert_files(&[
+        // Match a file with exact path suffix
+        File::new("output.json")
+            .contains("\"status\": \"success\"")
+            .does_not_contain("error"),
+
+        // Match another file using path suffix
+        File::new("/src/generated/types.kt")
+            .contains("class User")
+    ]);
+
+    // Clean up recording state
+    stop_recording();
+}
+```
+
+### Available Matchers
+
+The API provides two content matchers:
+
+1. `.contains(substring)` - Asserts that the file content contains the specified substring
+2. `.does_not_contain(substring)` - Asserts that the file content does not contain the substring
+
+### Path Matching
+
+File paths are matched using suffix matching, which means you only need to provide the unique part of the path:
+
+```rust
+// This will match any file ending with "/src/main.kt"
+File::new("/src/main.kt")
+
+// This will match any file named "config.json"
+File::new("config.json")
+```
+
+### Functions
+
+- `start_recording()` - Begins recording file operations
+- `stop_recording()` - Stops recording and clears recorded files
+- `assert_files(files)` - Asserts that files matching the provided patterns were written
+- `files_match(files)` - Returns true if files match the patterns, false otherwise
+
+## Integration with Command Recording
+
+The file matching API integrates seamlessly with the existing command recording functionality:
+
+```rust
+use ubrn_cli_testing::{start_recording, stop_recording, Command, assert_commands, File, assert_files};
+
+#[test]
+fn test_function_generates_files_and_runs_commands() {
+    start_recording();
+
+    my_function();
+
+    // Assert on commands
+    assert_commands(&[
+        Command::new("npm").arg("install"),
+        Command::new("cargo").arg("build")
+    ]);
+
+    // Assert on files
+    assert_files(&[
+        File::new("package.json").contains("\"name\": \"my-package\""),
+        File::new("src/index.js").contains("export default")
+    ]);
+
+    stop_recording();
+}
+```

--- a/xtask/src/bootstrap/hermes.rs
+++ b/xtask/src/bootstrap/hermes.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::{fs, process::Command};
+use std::process::Command;
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
@@ -52,7 +52,7 @@ impl HermesCmd {
         }
         let parent = dir.parent().expect("Hermes directory has no parent");
 
-        fs::create_dir_all(parent)?;
+        ubrn_common::mk_dir(parent)?;
         let repo = format!("https://github.com/{}.git", self.repo);
 
         run_cmd(
@@ -85,7 +85,7 @@ impl Bootstrap for HermesCmd {
         let src = Self::src_dir()?;
         let dir = Self::build_dir()?;
 
-        fs::create_dir_all(&dir)?;
+        ubrn_common::mk_dir(&dir)?;
 
         let mut cmd = Command::new("cmake");
         run_cmd(

--- a/xtask/src/bootstrap/test_runner.rs
+++ b/xtask/src/bootstrap/test_runner.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::{fs, process::Command};
+use std::process::Command;
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
@@ -75,7 +75,7 @@ impl Bootstrap for TestRunnerCmd {
 
         let src_dir = TestRunnerCmd::src_dir()?;
 
-        fs::create_dir_all(&dir)?;
+        ubrn_common::mk_dir(&dir)?;
 
         let mut cmd = Command::new("cmake");
         cmd.current_dir(&dir)

--- a/xtask/src/run/cpp_bindings.rs
+++ b/xtask/src/run/cpp_bindings.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::{fs, process::Command};
+use std::process::Command;
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -58,7 +58,7 @@ impl CppBindingArg {
         if clean {
             rm_dir(&build_dir)?;
         }
-        fs::create_dir_all(&build_dir)?;
+        ubrn_common::mk_dir(&build_dir)?;
 
         let src_dir = TestRunnerCmd::hermes_rust_extension_src_dir()?;
 
@@ -102,7 +102,7 @@ impl CppBindingArg {
         if clean {
             rm_dir(&build_dir)?;
         }
-        fs::create_dir_all(&build_dir)?;
+        ubrn_common::mk_dir(&build_dir)?;
 
         let src_dir = TestRunnerCmd::hermes_extension_src_dir()?;
 

--- a/xtask/src/run/generate_bindings.rs
+++ b/xtask/src/run/generate_bindings.rs
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::fs;
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -77,6 +76,6 @@ pub(crate) fn render_entrypoint(
     modules: &Vec<ModuleMetadata>,
 ) -> Result<()> {
     let string = ubrn_bindgen::generate_entrypoint(switches, crate_, modules)?;
-    fs::write(path, string)?;
+    ubrn_common::write_file(path, string)?;
     Ok(())
 }

--- a/xtask/src/run/typescript.rs
+++ b/xtask/src/run/typescript.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::{fs, process::Command};
+use std::process::Command;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -74,7 +74,7 @@ impl EntryArg {
         if use_template_tsconfig {
             let template_file = typescript_dir()?.join("tsconfig.template.json");
             let root = diff_utf8_paths(root, dir).expect("A path between the file and the repo");
-            let contents = fs::read_to_string(template_file)?;
+            let contents = ubrn_common::read_to_string(template_file)?;
             let contents = contents.replace("{{repository_root}}", root.as_str());
             ubrn_common::write_file(&tsconfig, contents)?;
         }
@@ -82,7 +82,7 @@ impl EntryArg {
         let outdir = ts_out_dir()?.join(bundle_name);
         let result = self.compile_ts(&outdir, dir, &tsconfig);
         if use_template_tsconfig {
-            fs::remove_file(tsconfig)?;
+            ubrn_common::rm_file(tsconfig)?;
         }
         result?;
         let entry = find(&outdir, &format!("{stem}.js")).expect("just made this js file");
@@ -91,7 +91,7 @@ impl EntryArg {
 
     pub(crate) fn bundle(&self, file: &Utf8Path, bundle_name: &str) -> Result<Utf8PathBuf> {
         let dir = bundles_dir()?;
-        fs::create_dir_all(&dir)?;
+        ubrn_common::mk_dir(&dir)?;
 
         let bundle_path = dir.join(format!("{bundle_name}.bundle.js"));
 

--- a/xtask/src/run/typescript.rs
+++ b/xtask/src/run/typescript.rs
@@ -76,7 +76,7 @@ impl EntryArg {
             let root = diff_utf8_paths(root, dir).expect("A path between the file and the repo");
             let contents = fs::read_to_string(template_file)?;
             let contents = contents.replace("{{repository_root}}", root.as_str());
-            fs::write(&tsconfig, contents)?;
+            ubrn_common::write_file(&tsconfig, contents)?;
         }
 
         let outdir = ts_out_dir()?.join(bundle_name);

--- a/xtask/src/run/wasm.rs
+++ b/xtask/src/run/wasm.rs
@@ -1,10 +1,10 @@
-use std::{fs, process::Command};
-
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+use std::process::Command;
+
 use anyhow::{Context, Ok, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use ubrn_common::{run_cmd_quietly, CrateMetadata};
@@ -106,7 +106,7 @@ impl Wasm {
                     .as_str(),
             );
 
-        fs::write(&cargo_toml, cargo_toml_src)?;
+        ubrn_common::write_file(&cargo_toml, cargo_toml_src)?;
         Ok(cargo_toml)
     }
 


### PR DESCRIPTION
This PR adds functionality to record commands and files written by commands run using `ubrn_common::run_cmd` and `ubrn_command::write_to_file`.

It also allows tests to shim files read by `ubrn_common::read_to_string`.

Finally, it adds some tests testing the `ubrn build` commands for different `ubrn.config.yaml` files. This is not complete testing, but will serve as a base to add to.