### PR TITLE
Add Cargo.toml extras

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ paste = "1.0.14"
 pathdiff = { version = "0.2.1", features = ["camino"] }
 rinja = "0.3.5"
 serde = { version = "1", features = ["derive"] }
+toml = "0.8.22"
 uniffi = "=0.29.0"
 uniffi_bindgen = "=0.29.0"
 uniffi_meta = "=0.29.0"

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -28,7 +28,9 @@ heck = { workspace = true }
 paste = { workspace = true }
 pathdiff = { workspace = true }
 serde = { workspace = true }
+serde-toml-merge = "0.3.9"
 textwrap = "0.16.1"
+toml = { workspace = true, features = ["display"] }
 topological-sort = "0.2.2"
 ubrn_bindgen = { path = "../ubrn_bindgen", features = ["wasm"] }
 ubrn_common = { path = "../ubrn_common" }

--- a/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.multifeature.config.yaml
+++ b/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.multifeature.config.yaml
@@ -6,3 +6,4 @@ web:
   features:
     - wasm32_only
     - some_feature
+  defaultFeatures: false

--- a/crates/ubrn_cli/fixtures/merging-toml/Cargo.patch.toml
+++ b/crates/ubrn_cli/fixtures/merging-toml/Cargo.patch.toml
@@ -1,0 +1,9 @@
+[dependencies]
+foo = "PATCHED"
+uniffi-example-arithmetic = { no-default-features = true }
+wasm-bindgen = "PATCHED"
+zzz = "PATCHED"
+
+
+[patch]
+patch = { patch = "patch" }

--- a/crates/ubrn_cli/fixtures/merging-toml/package.json
+++ b/crates/ubrn_cli/fixtures/merging-toml/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "default-fixture",
+  "version": "0.1.0",
+  "description": "An automated test",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jhugman/dummy-lib.git"
+  },
+  "author": "James <noop@nomail.com> (https://nowhere.com/james)"
+}

--- a/crates/ubrn_cli/fixtures/merging-toml/ubrn.config.yaml
+++ b/crates/ubrn_cli/fixtures/merging-toml/ubrn.config.yaml
@@ -1,0 +1,6 @@
+rust:
+  directory: rust/shim
+  manifestPath: Cargo.toml
+web:
+  manifestPath: rust_modules/wasm/Cargo.toml
+  manifestPatchFile: config/Cargo.patch.toml

--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -31,6 +31,10 @@ pub(crate) trait RenderedFile: DynTemplate {
     fn filter_by(&self) -> bool {
         true
     }
+    /// Optional hook to transform the text after rendered from the Askama template.
+    fn transform_str(&self, _project_root: &Utf8Path, contents: String) -> Result<String> {
+        Ok(contents)
+    }
 }
 
 pub(crate) struct TemplateConfig {
@@ -98,7 +102,7 @@ fn render_templates(
     for f in files {
         let text = f.dyn_render()?;
         let path = f.path(project_root);
-        map.insert(path, text);
+        map.insert(path, f.transform_str(project_root, text)?);
     }
     Ok(map)
 }

--- a/crates/ubrn_cli/src/wasm/config.rs
+++ b/crates/ubrn_cli/src/wasm/config.rs
@@ -31,6 +31,9 @@ pub(crate) struct WasmConfig {
     #[serde(default)]
     pub(crate) features: Option<Vec<String>>,
 
+    #[serde(default)]
+    pub(crate) default_features: Option<bool>,
+
     /// Has this crate been added to a workspace. Default is false.
     #[serde(default = "WasmConfig::default_is_workspace")]
     pub(crate) workspace: bool,

--- a/crates/ubrn_cli/src/wasm/config.rs
+++ b/crates/ubrn_cli/src/wasm/config.rs
@@ -21,6 +21,10 @@ pub(crate) struct WasmConfig {
     #[serde(deserialize_with = "CrateConfig::validate_manifest_path")]
     pub(crate) manifest_path: String,
 
+    #[serde(default)]
+    #[serde(deserialize_with = "ProjectConfig::opt_relative_path")]
+    pub(crate) manifest_patch_file: Option<String>,
+
     #[serde(default = "WasmConfig::default_wasm_crate_name")]
     pub(crate) wasm_crate_name: String,
 

--- a/crates/ubrn_cli/templates/wasm/Cargo.toml
+++ b/crates/ubrn_cli/templates/wasm/Cargo.toml
@@ -22,6 +22,10 @@ default = []
         {%- endfor -%}
     ]
     {%- else %}
+    {%- endmatch %}
+    {%- match config.project.wasm.default_features %}
+    {%- when Some(flag) %}, default-features = {{ flag }}
+    {%- else %}
     {%- endmatch %} }
 # We want to ensure that the version of wasm-bindgen is selected by the
 # uniffi-runtime-javascript crate.

--- a/crates/ubrn_cli/tests/web_variants.rs
+++ b/crates/ubrn_cli/tests/web_variants.rs
@@ -142,14 +142,15 @@ fn test_multi_features() -> Result<()> {
             Command::new("cargo")
                 .arg("build")
                 .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
-                .arg_pair("--features", "wasm32_only,some_feature"),
+                .arg_pair("--features", "wasm32_only,some_feature")
+                .arg("--no-default-features"),
             // other commands elided.
         ]);
 
         assert_files(&[
             File::new("rust/crates/wasm-crate/Cargo.toml")
                 .contains("[workspace]")
-                .contains("uniffi-example-arithmetic = { path = \"../../shim\", features = [\"wasm32_only\", \"some_feature\"] }"),
+                .contains("uniffi-example-arithmetic = { path = \"../../shim\", features = [\"wasm32_only\", \"some_feature\"], default-features = false }"),
             // other files elided.
         ]);
 

--- a/crates/ubrn_common/Cargo.toml
+++ b/crates/ubrn_common/Cargo.toml
@@ -13,4 +13,5 @@ glob = "0.3.1"
 serde = { workspace = true }
 serde_json = "1.0.117"
 serde_yaml = "0.9.34"
+toml = { workspace = true }
 which = "6.0.1"

--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -138,6 +138,8 @@ where
     Ok(if is_yaml(file) {
         serde_yaml::from_str(&s)
             .with_context(|| format!("Failed to read {file:?} as valid YAML"))?
+    } else if is_toml(file) {
+        toml::from_str(&s).with_context(|| format!("Failed to read {file:?} as valid TOML"))?
     } else {
         serde_json::from_str(&s)
             .with_context(|| format!("Failed to read {file:?} as valid YAML or JSON"))?
@@ -184,6 +186,14 @@ where
 {
     let ext = file.as_ref().extension().unwrap_or_default();
     ext == "yaml" || ext == "yml"
+}
+
+fn is_toml<P>(file: P) -> bool
+where
+    P: AsRef<Utf8Path>,
+{
+    let ext = file.as_ref().extension().unwrap_or_default();
+    ext == "toml"
 }
 
 pub fn write_file<P: AsRef<Utf8Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {


### PR DESCRIPTION
- Added a manifest patch file option, `manifestPatchFile`, to `ubrn.config.yaml`. If present, it will be loaded and used to patch over the generated `Cargo.toml`.
- Added default features boolean, `defaultFeatures` to `ubrn.config.yaml`. If present, it works in the same way as `features`: used to build the rlib, then put into the generated `Cargo.toml`.