### PR TITLE
Fixup clippy: allow(large_enum_variant)

### DIFF
--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -247,6 +247,7 @@ pub struct DictWithDefaults {
     integer: u64,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum MaybeSimpleDict {
     Yeah { d: SimpleDict },


### PR DESCRIPTION
Fixup a clippy warning that has appeared in a test.

If this were production code, I wouldn't do this.