### PR TITLE
Add RUSTFLAGS command for web builds

### DIFF
--- a/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.rustflags.config.yaml
+++ b/crates/ubrn_cli/fixtures/defaults/ubrn-wasm.rustflags.config.yaml
@@ -1,0 +1,6 @@
+rust:
+  directory: rust/shim
+  manifestPath: Cargo.toml
+
+wasm:
+  rustflags: ['--cfg', 'web_sys_unstable_apis', '-C', 'target-feature=+atomics']

--- a/crates/ubrn_cli/src/wasm/commands.rs
+++ b/crates/ubrn_cli/src/wasm/commands.rs
@@ -66,6 +66,7 @@ impl WebBuildArgs {
                 &config.wasm.cargo_extras,
                 &target,
                 &crate_dir,
+                &config.wasm.rustflags,
             )?;
             CrateMetadata::try_from(manifest_path.to_path_buf())?
         };
@@ -124,6 +125,7 @@ impl WebBuildArgs {
         cargo_extras: &ExtraArgs,
         target: &Target,
         rust_dir: &Utf8Path,
+        rustflags: &ExtraArgs,
     ) -> Result<()> {
         let mut cmd = Command::new("cargo");
         cmd.arg("build")
@@ -136,6 +138,14 @@ impl WebBuildArgs {
             cmd.arg("--profile").arg(profile);
         }
         cmd.args(cargo_extras.clone()).current_dir(rust_dir);
+
+        // Apply RUSTFLAGS if specified
+        let rustflags_vec: Vec<String> = rustflags.clone().into_iter().collect();
+        if !rustflags_vec.is_empty() {
+            let rustflags_str = rustflags_vec.join(" ");
+            cmd.env("RUSTFLAGS", rustflags_str);
+        }
+
         run_cmd(&mut cmd)?;
         Ok(())
     }

--- a/crates/ubrn_cli/src/wasm/config.rs
+++ b/crates/ubrn_cli/src/wasm/config.rs
@@ -62,6 +62,9 @@ pub(crate) struct WasmConfig {
     #[serde(default = "WasmConfig::default_entrypoint")]
     #[serde(deserialize_with = "ProjectConfig::relative_path")]
     pub(crate) entrypoint: String,
+
+    #[serde(default = "WasmConfig::default_rustflags")]
+    pub(crate) rustflags: ExtraArgs,
 }
 
 impl Default for WasmConfig {
@@ -99,6 +102,10 @@ impl WasmConfig {
         package_json
             .browser_entrypoint()
             .unwrap_or_else(|| "src/index.web.ts".to_string())
+    }
+    fn default_rustflags() -> ExtraArgs {
+        let args: &[&str] = &[];
+        args.into()
     }
 }
 

--- a/crates/ubrn_cli/tests/web_variants.rs
+++ b/crates/ubrn_cli/tests/web_variants.rs
@@ -308,3 +308,51 @@ fn test_merged_cargo_toml_patch() -> Result<()> {
         Ok(())
     })
 }
+
+#[test]
+fn test_rustflags() -> Result<()> {
+    let target_crate = cargo_build("arithmetic")?;
+    let fixtures_dir = fixtures_dir();
+    with_fixture(fixtures_dir.clone(), "defaults", |_fixture_dir| {
+        // Set up file shims
+        shim_path("package.json", fixtures_dir.join("defaults/package.json"));
+        shim_path(
+            "ubrn.config.yaml",
+            fixtures_dir.join("defaults/ubrn-wasm.rustflags.config.yaml"),
+        );
+        shim_path("rust/shim/Cargo.toml", target_crate.manifest_path());
+        shim_path("rust/shim", target_crate.project_root());
+
+        shim_path("rust_modules/wasm/Cargo.toml", target_crate.manifest_path());
+        shim_path(
+            "libarithmetical.a",
+            target_crate.library_path(None, "debug"),
+        );
+
+        run_cli("ubrn build web --config ubrn.config.yaml")?;
+
+        // Assert the expected commands were executed, including RUSTFLAGS
+        assert_commands(&[
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml"),
+            Command::new("prettier"),
+            Command::new("cargo")
+                .arg("build")
+                .arg_pair_suffix("--manifest-path", "rust_modules/wasm/Cargo.toml")
+                .arg_pair("--target", "wasm32-unknown-unknown")
+                .env(
+                    "RUSTFLAGS",
+                    "--cfg web_sys_unstable_apis -C target-feature=+atomics",
+                ),
+            Command::new("wasm-bindgen")
+                .arg_pair("--target", "web")
+                .arg("--omit-default-module-path")
+                .arg_pair("--out-name", "index")
+                .arg_pair_suffix("--out-dir", "src/generated/wasm-bindgen")
+                .arg_suffix("wasm32-unknown-unknown/debug/arithmetical.wasm"),
+        ]);
+
+        Ok(())
+    })
+}

--- a/crates/ubrn_cli_testing/src/command.rs
+++ b/crates/ubrn_cli_testing/src/command.rs
@@ -3,7 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 /// A builder for command matchers to be used in tests
 #[derive(Debug, Clone)]
@@ -11,6 +14,7 @@ pub struct Command {
     program: String,
     args: Vec<ArgMatcher>,
     cwd: Option<PathBuf>,
+    env: HashMap<String, String>,
 }
 
 impl Command {
@@ -20,6 +24,7 @@ impl Command {
             program: program.to_string(),
             args: Vec::new(),
             cwd: None,
+            env: HashMap::new(),
         }
     }
 
@@ -64,6 +69,12 @@ impl Command {
         self
     }
 
+    /// Add an environment variable to match exactly
+    pub fn env(mut self, key: &str, value: &str) -> Self {
+        self.env.insert(key.to_string(), value.to_string());
+        self
+    }
+
     /// Get the program name
     pub(crate) fn program(&self) -> &str {
         &self.program
@@ -77,6 +88,11 @@ impl Command {
     /// Get the list of argument matchers
     pub(crate) fn args(&self) -> &[ArgMatcher] {
         &self.args
+    }
+
+    /// Get the environment variables
+    pub(crate) fn get_env(&self) -> &HashMap<String, String> {
+        &self.env
     }
 }
 

--- a/crates/ubrn_cli_testing/src/command_assertions.rs
+++ b/crates/ubrn_cli_testing/src/command_assertions.rs
@@ -84,6 +84,26 @@ fn command_mismatch(recorded: &RecordedCommand, expected: &Command) -> Option<St
         }
     }
 
+    // Check environment variables
+    for (expected_key, expected_value) in expected.get_env() {
+        match recorded.env.get(expected_key) {
+            Some(actual_value) => {
+                if actual_value != expected_value {
+                    return Some(format!(
+                        "Environment variable mismatch: for key '{}', expected '{}', got '{}'",
+                        expected_key, expected_value, actual_value
+                    ));
+                }
+            }
+            None => {
+                return Some(format!(
+                    "Missing environment variable: expected '{}' with value '{}'",
+                    expected_key, expected_value
+                ));
+            }
+        }
+    }
+
     // Check arguments - we need to consider the order and the different matcher types
     let mut arg_idx = 0;
     let recorded_args = &recorded.args;

--- a/crates/ubrn_cli_testing/src/command_assertions.rs
+++ b/crates/ubrn_cli_testing/src/command_assertions.rs
@@ -90,15 +90,13 @@ fn command_mismatch(recorded: &RecordedCommand, expected: &Command) -> Option<St
             Some(actual_value) => {
                 if actual_value != expected_value {
                     return Some(format!(
-                        "Environment variable mismatch: for key '{}', expected '{}', got '{}'",
-                        expected_key, expected_value, actual_value
+                        "Environment variable mismatch: for key '{expected_key}', expected '{expected_value}', got '{actual_value}'"
                     ));
                 }
             }
             None => {
                 return Some(format!(
-                    "Missing environment variable: expected '{}' with value '{}'",
-                    expected_key, expected_value
+                    "Missing environment variable: expected '{expected_key}' with value '{expected_value}'"
                 ));
             }
         }

--- a/crates/ubrn_common/src/testing.rs
+++ b/crates/ubrn_common/src/testing.rs
@@ -41,6 +41,9 @@ pub struct Command {
 
     /// The working directory for the command, if specified
     pub current_dir: Option<PathBuf>,
+
+    /// The environment variables for the command
+    pub env: HashMap<String, String>,
 }
 
 /// A record of a file that was written
@@ -68,10 +71,24 @@ impl Command {
         // Extract working directory if set
         let current_dir = cmd.get_current_dir().map(|p| p.to_path_buf());
 
+        // Extract environment variables
+        let env = cmd
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|v| {
+                    (
+                        key.to_string_lossy().to_string(),
+                        v.to_string_lossy().to_string(),
+                    )
+                })
+            })
+            .collect();
+
         Command {
             program,
             args,
             current_dir,
+            env,
         }
     }
 }


### PR DESCRIPTION
To get around an issue with getrandom + wasm, I need to be able to specify rustflags for the phase 2 build. Claude wrote this code, but that seems okay?