### PR TITLE
Add support for cdylib builds on Android instead of static

### DIFF
--- a/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
+++ b/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
@@ -53,7 +53,7 @@ cmake_path(
   ${CMAKE_SOURCE_DIR}/{{ jni_libs_dir }}/${ANDROID_ABI}/{{ self.config.rust_crate.library_file(Some("android")) }}
   NORMALIZE
 )
-add_library(my_rust_lib STATIC IMPORTED)
+add_library(my_rust_lib SHARED IMPORTED)
 set_target_properties(my_rust_lib PROPERTIES IMPORTED_LOCATION ${MY_RUST_LIB})
 
 # Add ReactAndroid libraries, being careful to account for different versions.

--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -35,7 +35,7 @@ impl CrateMetadata {
 
     pub fn library_path_exists(&self, path: &Utf8Path) -> Result<()> {
         if !path.exists() {
-            anyhow::bail!("Library doesn't exist. This may be because `staticlib` is not in the `crate-type` list in the [lib] entry of Cargo.toml: {}", self.manifest_path());
+            anyhow::bail!("Library doesn't exist. This may be because `cdylib` is not in the `crate-type` list in the [lib] entry of Cargo.toml: {}", self.manifest_path());
         }
         Ok(())
     }
@@ -132,8 +132,8 @@ fn so_extension_from_target<'a>(target: &str) -> &'a str {
     } else if target.contains("ios") {
         "a"
     } else if target.contains("android") {
-        // We're using staticlib files here. cargo ndk use .so files.
-        "a"
+        // We're using shared library files here. cargo ndk builds .so files.
+        "so"
     } else if target.contains("wasm") {
         "wasm"
     } else {

--- a/docs/src/reference/commandline.md
+++ b/docs/src/reference/commandline.md
@@ -117,13 +117,13 @@ This is useful as some generated files use the targets specified in this command
 Once the library files (one for each target) are created, they are copied into the `jniLibs` specified by the YAML configuration.
 
 ```admonish note
-React Native requires that the Rust library be built as a static library. The CMake based build will combine the C++ with the static library into a shared object.
+React Native requires that the Rust library be built as a shared library. This allows the same Rust core to be shared between React Native and Kotlin bindings, avoiding code duplication.
 
-To configure Rust to build a static library, you should ensure `staticlib` is in the `crate-type` list in the `[lib]` section of the `Cargo.toml` file. Minimally, this should be in the `Cargo.toml` manifest file:
+To configure Rust to build a shared library, you should ensure `cdylib` is in the `crate-type` list in the `[lib]` section of the `Cargo.toml` file. Minimally, this should be in the `Cargo.toml` manifest file:
 
 <pre>
 <code class="hljs">[lib]
-crate-type = ["staticlib"]
+crate-type = ["cdylib"]
 </code>
 </pre>
 ```


### PR DESCRIPTION
I'm trying to share both Kotlin and React-Native bindings in the same project.  Took at stab at using a dynamic link to the rust crate to see if that would work.