### PR TITLE
feat: optional record fields

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/filters.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/filters.rs
@@ -203,3 +203,19 @@ pub fn docstring(docstring: &str, spaces: &i32) -> Result<String, askama::Error>
     let spaces = usize::try_from(*spaces).unwrap_or_default();
     Ok(textwrap::indent(&wrapped, &" ".repeat(spaces)))
 }
+
+pub(super) fn is_optional_type(
+    as_type: &impl AsType,
+    types: &TypeRenderer,
+) -> Result<bool, askama::Error> {
+    let type_ = types.as_type(as_type);
+    Ok(matches!(type_, Type::Optional { .. }))
+}
+
+pub(super) fn type_name_without_undefined(
+    as_type: &impl AsType,
+    types: &TypeRenderer,
+) -> Result<String, askama::Error> {
+    let og_type_name = type_name(as_type, types)?;
+    Ok(og_type_name.replace(" | undefined", ""))
+}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
@@ -5,7 +5,7 @@
 export type {{ type_name }} = {
     {%- for field in rec.fields() %}
     {%- call ts::docstring(field, 4) %}
-    {{ field.name()|var_name }}: {{ field|type_name(self) }}
+    {{ field.name()|var_name }}{% if field|is_optional_type(self) %}?{% endif %}: {{ field|type_name_without_undefined(self) }}
     {%- if !loop.last %},{% endif %}
     {%- endfor %}
 }


### PR DESCRIPTION
Currently `Optional` types in records are required fields in the generated typescript. This PR replaces the `undefined` union with a `?` to indicate that the field is optional. This results in more idiomatic TypeScript. 

The diff of the generated TypeScript can be seen in this commit: https://github.com/algorandfoundation/algokit-core/commit/30d9488366c67a55e39fbca1deaf99ff5c7e8982