### PR TITLE
Release 0.29.3-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,24 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-0...main
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...main
 
 ---
+
+# 0.29.3-1
+
+## ✨ What's New ✨
+
+- Support for dynamic libraries on Android ([#285](https://github.com/jhugman/uniffi-bindgen-react-native/pull/285)). Thank you [@exploIF](https://github.com/exploIF)!
+- Add `RUSTFLAGS` command for web build ([#276](https://github.com/jhugman/uniffi-bindgen-react-native/pull/276)). Thank you [@zzorba](https://github.com/zzorba)!
+
+## 🦊 What's Changed
+
+- A fix for generating native Kotlin bindings ([#283](https://github.com/jhugman/uniffi-bindgen-react-native/pull/283))
+- `serde-toml-merge` is version pinned ([#280](https://github.com/jhugman/uniffi-bindgen-react-native/pull/280))
+- Export `FFIConverters` for errors ([#279](https://github.com/jhugman/uniffi-bindgen-react-native/pull/279))
+
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-0...0.29.3-1
 
 # 0.29.3-0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-react-native"
-version = "0.29.3-0"
+version = "0.29.3-1"
 dependencies = [
  "anyhow",
  "askama",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-javascript"
-version = "0.29.3-0"
+version = "0.29.3-1"
 dependencies = [
  "uniffi_core",
  "wasm-bindgen",

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.29.3-0"
+version = "0.29.3-1"
 edition = "2021"
 
 [lib]

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -156,6 +156,6 @@
     "version": "0.50.2"
   },
   "dependencies": {
-    "uniffi-bindgen-react-native": "^0.29.3-0"
+    "uniffi-bindgen-react-native": "^0.29.3-1"
   }
 }

--- a/crates/uniffi-runtime-javascript/Cargo.toml
+++ b/crates/uniffi-runtime-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-runtime-javascript"
-version = "0.29.3-0"
+version = "0.29.3-1"
 edition = "2021"
 authors = ["James Hugman <james@hugman.tv>"]
 description = "Javascript runtime for UniFFI-generated bindings"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.29.3-0",
+  "version": "0.29.3-1",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {


### PR DESCRIPTION
# 0.29.3-1

## ✨ What's New ✨

- Support for dynamic libraries on Android ([#285](https://github.com/jhugman/uniffi-bindgen-react-native/pull/285)). Thank you [@exploIF](https://github.com/exploIF)!
- Add `RUSTFLAGS` command for web build ([#276](https://github.com/jhugman/uniffi-bindgen-react-native/pull/276)). Thank you [@zzorba](https://github.com/zzorba)!

## 🦊 What's Changed

- A fix for generating native Kotlin bindings ([#283](https://github.com/jhugman/uniffi-bindgen-react-native/pull/283))
- `serde-toml-merge` is version pinned ([#280](https://github.com/jhugman/uniffi-bindgen-react-native/pull/280))
- Export `FFIConverters` for errors ([#279](https://github.com/jhugman/uniffi-bindgen-react-native/pull/279))
