### PR TITLE
fix: parse native_bindings as boolean flag

### DIFF
--- a/crates/ubrn_cli/src/commands/generate.rs
+++ b/crates/ubrn_cli/src/commands/generate.rs
@@ -98,6 +98,7 @@ pub(crate) struct GenerateAllArgs {
     lib_file: Utf8PathBuf,
 
     /// Whether to generate native bindings or not.
+    #[clap(long, default_value = "false")]
     native_bindings: bool,
 }
 


### PR DESCRIPTION
The `native_bindings` argument in the `GenerateAllArgs` struct is defined as a positional argument while using `action = SetTrue` internally via `clap`.

This leads to a panic at runtime with commands such as:

`CARGO_FEATURE_NO_NEON=1 ubrn build ios --config ubrn.yaml --native-bindings --release`

with the message:
```
thread 'main' panicked at /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.42/src/builder/debug_asserts.rs:732:9:
Argument 'native_bindings' is positional and it must take a value but action is SetTrue
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Process completed with exit code 1.
```

[Link to full log](https://github.com/unomed-dev/react-native-matrix-sdk/actions/runs/16651743903/job/47126062347)

### Changes

This PR updates the `native_bindings` field in `generate.rs` to:

```rust
#[clap(long, default_value = "false")]
native_bindings: bool
```

declaring it as a proper optional boolean flag (`--native-bindings`) and setting its default value to `false`.