### PR TITLE
Build TypeScript to JavaScript before publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
     "email": "james@hugman.tv"
   },
   "type": "module",
-  "main": "./typescript/src/index.ts",
+  "main": "./typescript/dist/index.js",
+  "types": "./typescript/dist/index.d.ts",
   "bin": {
     "ubrn": "./bin/cli.cjs",
     "uniffi-bindgen-react-native": "./bin/cli.cjs"
   },
   "scripts": {
+    "build": "tsc",
+    "prepare": "yarn build",
     "test": "./scripts/run-tests.sh"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs", 
+    "declaration": true,
+    "outDir": "./typescript/dist",                                   /* Specify what module code is generated. */
     "paths": {
       "uniffi-bindgen-react-native": ["./typescript/src/index"],/* Specify a set of entries that re-map imports to additional lookup locations. */
       "@/*": ["./typescript/testing/*"],


### PR DESCRIPTION
This PR reopens the work started in #198, which was closed due to CI issues and testing challenges that I believe are now resolved.

## The Problem

After following the RN getting started guide to create a lib, and depending on that lib in a RN app, type checking the app will fail with certain compiler options.

```sh
Found 17 errors in 8 files.

Errors  Files
     2  ../../node_modules/uniffi-bindgen-react-native/typescript/src/async-callbacks.ts:26
     1  ../../node_modules/uniffi-bindgen-react-native/typescript/src/async-rust-call.ts:16
     2  ../../node_modules/uniffi-bindgen-react-native/typescript/src/callbacks.ts:16
     1  ../../node_modules/uniffi-bindgen-react-native/typescript/src/enums.ts:7
     1  ../../node_modules/uniffi-bindgen-react-native/typescript/src/errors.ts:41
     3  ../../node_modules/uniffi-bindgen-react-native/typescript/src/ffi-converters.ts:68
     5  ../../node_modules/uniffi-bindgen-react-native/typescript/src/objects.ts:16
     2  ../../node_modules/uniffi-bindgen-react-native/typescript/src/rust-call.ts:15
```

Currently, this library ships raw TypeScript files to npm. When consuming applications have stricter TypeScript compiler options in their `tsconfig.json` than what this library was built with, compilation fails. I encountered this when trying to use this library in my app - I needed to disable `noUnusedLocals`, `noUnusedParameters`, and `noImplicitOverride` in my `tsconfig.json` to make my app build.

According to the Microsoft TypeScript team: 
> If you have a .ts file in your project where that .ts file isn't under your control (e.g. it's coming from node_modules in someone else's package), that's a configuration error, either on your part or the package author's.

[Reference](https://github.com/microsoft/TypeScript/issues/41883#issuecomment-1758692340)

Also, using `"exclude": ["node_modules"]` and `"skipLibCheck": true` does not fix this problem (that's what the TypeScript issue above is about).

**To reproduce this issue:**
1. Follow the [getting-started guide](https://jhugman.github.io/uniffi-bindgen-react-native/guides/rn/getting-started.html) exactly
2. Run:
   ```bash
   cd example
   yarn add typescript
   yarn exec tsc
   ```

This will produce TypeScript errors from this library's source files.

## The Solution

I copied @hassankhan's approach from #198 and double checked all the concerns raised in that discussion:

- Using `typescript/dist/` as @jhugman suggested
- Using the `prepare` script so compilation happens automatically before publish (no CI workflow changes needed)
- Apps continue to use TypeScript - they just import compiled JS + type definitions instead of raw TypeScript source

### Addressing the `require.resolve` Concern

@jhugman [mentioned](https://github.com/jhugman/uniffi-bindgen-react-native/pull/198#issuecomment-2563214788) there are places using `require.resolve` that might break. I checked:

- **`crates/ubrn_cli/templates/jsi/android/CMakeLists.txt:18`**: Uses `require.resolve('uniffi-bindgen-react-native/package.json')`
- This should continue to work because we're not moving or changing `package.json` only changing what the `main` field points to


## Testing

I've tested this approach by:
- Depending directly on my fork in my app's package.json:
  ```json
  "dependencies": {
    "uniffi-bindgen-react-native": "github:EthanShoeDev/uniffi-bindgen-react-native#build-ts"
  }
  ```
  Before depending on the fork, I needed to disable the strict compiler options mentioned above. Afterwards I could re-enable them without hitting an error.

- The existing CI will handle this automatically since `scripts/test-turbo-modules.sh` copies the current repo into `node_modules` and runs the full build process

## Optional: Modify test to typecheck in example app

To prevent this regression in the future, we could add a test case to `scripts/test-turbo-modules.sh` that creates a strict `tsconfig.json` and verifies `tsc --noEmit` passes. The existing test infrastructure should catch any major issues with this change.

Let me know if you would want that behavior and I can change this PR.
