### PR TITLE
Remove --no-strip argument to cargo-ndk

### DIFF
--- a/crates/ubrn_cli/src/jsi/android/commands.rs
+++ b/crates/ubrn_cli/src/jsi/android/commands.rs
@@ -141,9 +141,6 @@ impl AndroidBuildArgs {
             .arg("--platform")
             .arg(format!("{api_level}"));
         let profile = self.common_args.profile();
-        if profile != "release" {
-            cmd.arg("--no-strip");
-        }
         cmd.arg("--").arg("build");
         if profile != "debug" {
             cmd.args(["--profile", profile]);

--- a/crates/ubrn_cli/tests/happy_path.rs
+++ b/crates/ubrn_cli/tests/happy_path.rs
@@ -118,7 +118,6 @@ fn test_happy_path_android() -> Result<()> {
                 .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
                 .arg_pair_suffix("--target", "arm64-v8a")
                 .arg_pair("--platform", "23")
-                .arg("--no-strip")
                 .arg("--")
                 .arg("build"),
             Command::new("cargo")
@@ -126,7 +125,6 @@ fn test_happy_path_android() -> Result<()> {
                 .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
                 .arg_pair_suffix("--target", "armeabi-v7a")
                 .arg_pair("--platform", "23")
-                .arg("--no-strip")
                 .arg("--")
                 .arg("build"),
             Command::new("cargo")
@@ -134,7 +132,6 @@ fn test_happy_path_android() -> Result<()> {
                 .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
                 .arg_pair_suffix("--target", "x86")
                 .arg_pair("--platform", "23")
-                .arg("--no-strip")
                 .arg("--")
                 .arg("build"),
             Command::new("cargo")
@@ -142,7 +139,6 @@ fn test_happy_path_android() -> Result<()> {
                 .arg_pair_suffix("--manifest-path", "fixtures/arithmetic/Cargo.toml")
                 .arg_pair_suffix("--target", "x86_64")
                 .arg_pair("--platform", "23")
-                .arg("--no-strip")
                 .arg("--")
                 .arg("build"),
             Command::new("prettier"),


### PR DESCRIPTION
This was removed in cargo-ndk 4 with https://github.com/bbqsrc/cargo-ndk/commit/b91ae0dfcf1f85d774b749185c40f1d003592792. Apparently the Android Gradle plugin already handles stripping which made this unnecessary.

Relates to: #292