### PR TITLE
Stop checking for jsRootDir & friends (?)

### DIFF
--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -308,7 +308,6 @@ check_lines() {
 
   check_line_unchanged "./android/CMakeLists.txt" "^project"
   check_line_unchanged "./android/CMakeLists.txt" "^add_library.*SHARED"
-  check_line_unchanged "./android/build.gradle" "codegenJavaPackageName ="
   check_line_unchanged "./android/src/*/*Package.*" "package"
   check_line_unchanged "./android/src/*/*Package.*" "package"
   check_line_unchanged "./android/src/*/*Module.java" "System.loadLibrary"

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -308,7 +308,6 @@ check_lines() {
 
   check_line_unchanged "./android/CMakeLists.txt" "^project"
   check_line_unchanged "./android/CMakeLists.txt" "^add_library.*SHARED"
-  check_line_unchanged "./android/build.gradle" "libraryName ="
   check_line_unchanged "./android/build.gradle" "codegenJavaPackageName ="
   check_line_unchanged "./android/src/*/*Package.*" "package"
   check_line_unchanged "./android/src/*/*Package.*" "package"

--- a/scripts/test-turbo-modules.sh
+++ b/scripts/test-turbo-modules.sh
@@ -308,7 +308,6 @@ check_lines() {
 
   check_line_unchanged "./android/CMakeLists.txt" "^project"
   check_line_unchanged "./android/CMakeLists.txt" "^add_library.*SHARED"
-  check_line_unchanged "./android/build.gradle" "jsRootDir ="
   check_line_unchanged "./android/build.gradle" "libraryName ="
   check_line_unchanged "./android/build.gradle" "codegenJavaPackageName ="
   check_line_unchanged "./android/src/*/*Package.*" "package"


### PR DESCRIPTION
Once https://github.com/jhugman/uniffi-bindgen-react-native/pull/309 has landed, this should "fix" the Compat tests. I'm not sure if this is a good fix though. Apparently CRNL doesn't use `jsRootDir` anymore when generating libraries which means we cannot really check for it remaining untouched anymore. As a corollary, this may mean that we shouldn't use `jsRootDir` ourselves either when generating `build.gradle`. I'm not aware of this causing any issues, however, so just dropping the check might be ok-ish for now?

Edit: Apparently the `libraryName` and `codegenJavaPackageName` properties cause the same problem making this even less of a great fix. 🫤 