### PR TITLE
fix: Use uint64_t for RustBuffer fields to fix 32-bit ARM crash

### DIFF
--- a/cpp/includes/RustBuffer.h
+++ b/cpp/includes/RustBuffer.h
@@ -11,7 +11,7 @@
 #include <jsi/jsi.h>
 
 struct RustBuffer {
-  size_t capacity;
-  size_t len;
+  uint64_t capacity;
+  uint64_t len;
   uint8_t *data;
 };


### PR DESCRIPTION
## Summary
Fixes segfault on 32-bit ARM (armeabi-v7a) during argument marshalling when calling UniFFI functions that accept RustBuffer parameters.

## Problem
- Generated `RustBuffer` struct uses `size_t` for capacity/len fields
- UniFFI's C ABI uses **`uint64_t`** (8 bytes) on ALL platforms
- On 32-bit ARM, `size_t` is 4 bytes → ABI mismatch → stack corruption → crash

## Root Cause
The crash occurred in constructor marshalling on Amazon Fire TV (armeabi-v7a) before any Rust code ran. The C++ JSI wrapper called `uniffi_metric_engine_wasm_fn_constructor_metricengine_new` with a `RustBuffer` parameter, but the field size mismatch caused stack corruption.

## Impact
- ❌ **Crashes**: 32-bit ARM devices (armeabi-v7a) - confirmed on Amazon Fire TV with Expo SDK 54
- ✅ **Should work**: 64-bit platforms where size_t == uint64_t (not explicitly tested in this PR)

## Fix
Changed `RustBuffer` struct definition in `cpp/includes/RustBuffer.h` to use **`uint64_t`** explicitly for capacity/len fields, matching UniFFI's documented C ABI specification.

## Testing
- ✅ Amazon Fire TV (armeabi-v7a, Expo SDK 54): **Crash fixed** - app now launches successfully and MetricEngine constructor works

## References
- UniFFI RustBuffer ABI: https://mozilla.github.io/uniffi-rs/0.27/internals/api/uniffi/struct.RustBuffer.html
- Related UniFFI issue: https://github.com/mozilla/uniffi-rs/issues/2681

## Changed Files
- `cpp/includes/RustBuffer.h` - Changed `size_t capacity` and `size_t len` to `uint64_t`