### PR TITLE
Remove public access modifier for the TypeScript bindings

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ErrorTemplate.ts
@@ -30,7 +30,7 @@ export const {{ decl_type_name }} = (() => {
          */
         readonly [variantOrdinalSymbol] = {{ loop.index }};
 
-        public readonly tag = {{ type_name__Tags }}.{{ variant|variant_name }};
+        readonly tag = {{ type_name__Tags }}.{{ variant|variant_name }};
 
         constructor(message: string) {
             super("{{ type_name }}", "{{ variant_name }}", message);

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ObjectTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ObjectTemplate.ts
@@ -40,7 +40,7 @@ export class {{ impl_class_name }} extends UniffiAbstractObject implements {{ pr
     {%- call private_ctor() %}
 
     // Async primary constructor declared for this class.
-    {%-   call ts::method_decl("public static", obj_factory, cons, 4) %}
+    {%-   call ts::method_decl("static", obj_factory, cons, 4) %}
     {%- endif %}
     {%- when None %}
     // No primary constructor declared for this class.
@@ -48,11 +48,11 @@ export class {{ impl_class_name }} extends UniffiAbstractObject implements {{ pr
     {%- endmatch %}
 
     {% for cons in obj.alternate_constructors() %}
-    {%- call ts::method_decl("public static", obj_factory, cons, 4) %}
+    {%- call ts::method_decl("static", obj_factory, cons, 4) %}
     {% endfor %}
 
     {% for meth in obj.methods() -%}
-    {%- call ts::method_decl("public", obj_factory, meth, 4) %}
+    {%- call ts::method_decl("", obj_factory, meth, 4) %}
     {% endfor %}
 
     {%- for tm in obj.uniffi_traits() %}


### PR DESCRIPTION
Fixes https://github.com/jhugman/uniffi-bindgen-react-native/issues/306

This removes the public access modifier for method declarations and the error tag.
Because public is the default modifier, this should not change behavior.

This is only tested with a example project, not the project tests, see notes for details.

## Note for tests
- Platform: `macOS`
- Installed for bootstrap `cmake` and `ninja`
- Error during bootstrap `ld: library 'hermes' not found`
- Same error for `./scripts/run-tests.sh`