### PR TITLE
Change `module` compiler option to `nodenext`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs", 
+    "module": "nodenext", 
     "declaration": true,
     "outDir": "./typescript/dist",                                   /* Specify what module code is generated. */
     "paths": {

--- a/typescript/src/async-callbacks.ts
+++ b/typescript/src/async-callbacks.ts
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { CALL_ERROR, CALL_UNEXPECTED_ERROR } from "./rust-call";
-import { type UniffiHandle, UniffiHandleMap } from "./handle-map";
-import { type UniffiByteArray } from "./ffi-types";
+import { CALL_ERROR, CALL_UNEXPECTED_ERROR } from "./rust-call.js";
+import { type UniffiHandle, UniffiHandleMap } from "./handle-map.js";
+import { type UniffiByteArray } from "./ffi-types.js";
 
 // Some additional data we hold for each in-flight promise.
 type PromiseHelper = {

--- a/typescript/src/async-rust-call.ts
+++ b/typescript/src/async-rust-call.ts
@@ -3,14 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { UniffiInternalError } from "./errors";
-import { type UniffiByteArray } from "./ffi-types";
-import { UniffiHandleMap, type UniffiHandle } from "./handle-map";
+import { UniffiInternalError } from "./errors.js";
+import { type UniffiByteArray } from "./ffi-types.js";
+import { UniffiHandleMap, type UniffiHandle } from "./handle-map.js";
 import {
   type UniffiErrorHandler,
   type UniffiRustCallStatus,
   UniffiRustCaller,
-} from "./rust-call";
+} from "./rust-call.js";
 
 const UNIFFI_RUST_FUTURE_POLL_READY = 0;
 const UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1;

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -3,18 +3,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { type FfiConverter, FfiConverterUInt64 } from "./ffi-converters";
-import { type UniffiByteArray, RustBuffer } from "./ffi-types";
+import { type FfiConverter, FfiConverterUInt64 } from "./ffi-converters.js";
+import { type UniffiByteArray, RustBuffer } from "./ffi-types.js";
 import {
   type UniffiHandle,
   UniffiHandleMap,
   defaultUniffiHandle,
-} from "./handle-map";
+} from "./handle-map.js";
 import {
   CALL_ERROR,
   CALL_UNEXPECTED_ERROR,
   type UniffiRustCallStatus,
-} from "./rust-call";
+} from "./rust-call.js";
 
 const handleConverter = FfiConverterUInt64;
 

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-import { uniffiTypeNameSymbol } from "./symbols";
+import { uniffiTypeNameSymbol } from "./symbols.js";
 
 // The top level error class for all uniffi-wrapped errors.
 //

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { UniffiInternalError } from "./errors";
-import { type UniffiByteArray, RustBuffer } from "./ffi-types";
+import { UniffiInternalError } from "./errors.js";
+import { type UniffiByteArray, RustBuffer } from "./ffi-types.js";
 
 // https://github.com/mozilla/uniffi-rs/blob/main/docs/manual/src/internals/lifting_and_lowering.md
 export interface FfiConverter<FfiType, TsType> {

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { UniffiInternalError } from "./errors";
+import { UniffiInternalError } from "./errors.js";
 
 export type UniffiByteArray = Uint8Array;
 

--- a/typescript/src/handle-map.ts
+++ b/typescript/src/handle-map.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { UniffiInternalError } from "./errors";
+import { UniffiInternalError } from "./errors.js";
 
 export type UniffiHandle = bigint;
 export const defaultUniffiHandle = BigInt("0");

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,17 +6,17 @@
 // Entry point for the runtime for uniffi-bindgen-react-native.
 // This modules is not needed directly, but is imported from generated code.
 //
-export * from "./async-callbacks";
-export * from "./async-rust-call";
-export * from "./callbacks";
-export * from "./enums";
-export * from "./errors";
-export * from "./ffi-converters";
-export * from "./ffi-types";
-export * from "./handle-map";
-export * from "./objects";
-export * from "./records";
-export * from "./result";
-export * from "./rust-call";
-export * from "./symbols";
-export * from "./type-utils";
+export * from "./async-callbacks.js";
+export * from "./async-rust-call.js";
+export * from "./callbacks.js";
+export * from "./enums.js";
+export * from "./errors.js";
+export * from "./ffi-converters.js";
+export * from "./ffi-types.js";
+export * from "./handle-map.js";
+export * from "./objects.js";
+export * from "./records.js";
+export * from "./result.js";
+export * from "./rust-call.js";
+export * from "./symbols.js";
+export * from "./type-utils.js";

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -8,11 +8,11 @@ import {
   AbstractFfiConverterByteArray,
   type FfiConverter,
   FfiConverterUInt64,
-} from "./ffi-converters";
-import { RustBuffer } from "./ffi-types";
-import type { UniffiGcObject } from "./rust-call";
-import { type UniffiHandle, UniffiHandleMap } from "./handle-map";
-import { UniffiInternalError, UniffiThrownObject } from "./errors";
+} from "./ffi-converters.js";
+import { RustBuffer } from "./ffi-types.js";
+import type { UniffiGcObject } from "./rust-call.js";
+import { type UniffiHandle, UniffiHandleMap } from "./handle-map.js";
+import { UniffiInternalError, UniffiThrownObject } from "./errors.js";
 
 /**
  * Marker interface for all `interface` objects that cross the FFI.

--- a/typescript/src/result.ts
+++ b/typescript/src/result.ts
@@ -4,9 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
-import { type UniffiByteArray } from "./ffi-types";
-import { type UniffiReferenceHolder } from "./callbacks";
-import { type UniffiRustCallStatus } from "./rust-call";
+import { type UniffiByteArray } from "./ffi-types.js";
+import { type UniffiReferenceHolder } from "./callbacks.js";
+import { type UniffiRustCallStatus } from "./rust-call.js";
 
 // This Result combines RustCallStatus and ReferenceHolder.
 // This is principally so we can _return_ something from calling from native into typescript.

--- a/typescript/src/rust-call.ts
+++ b/typescript/src/rust-call.ts
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { UniffiInternalError } from "./errors";
-import { type UniffiByteArray } from "./ffi-types";
+import { UniffiInternalError } from "./errors.js";
+import { type UniffiByteArray } from "./ffi-types.js";
 
 export const CALL_SUCCESS = 0;
 export const CALL_ERROR = 1;


### PR DESCRIPTION
See #324 for background.

The TS
[documentation](https://www.typescriptlang.org/docs/handbook/modules/theory.html#the-module-output-format) states that:

"Node.js’s rules for module format detection and interoperability make it incorrect to specify module as esnext or commonjs for projects that run in Node.js, even if all files emitted by tsc are ESM or CJS, respectively. The only correct module settings for projects that intend to run in Node.js are node16 and nodenext. While the emitted JavaScript for an all-ESM Node.js project might look identical between compilations using esnext and nodenext, the type checking can differ. See the reference section on nodenext for more details."

This change makes the project runnable in Node.js by changing the module compiler option to "nodenext", and fixing the imports accordingly.