### PR TITLE
chore: rm unused import

### DIFF
--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::Metadata;
-use clap::{command, Args};
+use clap::Args;
 use ubrn_common::{mk_dir, path_or_shim, CrateMetadata, Utf8PathBufExt as _};
 use uniffi_bindgen::{cargo_metadata::CrateConfigSupplier, BindingGenerator};
 


### PR DESCRIPTION
In rust 1.92 this unused import was raising a warning, breaking CI in downstream projects which forbid warnings.