### PR TITLE
fix: improve error handling for flat enum serialization and error buffer decoding

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts
@@ -32,10 +32,16 @@ const {{ ffi_converter_name }} = (() => {
                 {%- for variant in e.variants() %}
                 case {{ type_name }}.{{ variant|variant_name }}: return ordinalConverter.write({{ loop.index0 + 1 }}, into);
                 {%- endfor %}
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
         }
         allocationSize(value: TypeName): number {
-            return ordinalConverter.allocationSize(0);
+            switch (value) {
+                {%- for variant in e.variants() %}
+                case {{ type_name }}.{{ variant|variant_name }}: return ordinalConverter.allocationSize(0);
+                {%- endfor %}
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
         }
     }
     return new FFIConverter();

--- a/typescript/src/rust-call.ts
+++ b/typescript/src/rust-call.ts
@@ -72,6 +72,20 @@ function uniffiCheckCallStatus(
   liftString: StringLifter,
   errorHandler?: UniffiErrorHandler,
 ) {
+  // The C++ bridge wraps ArrayBuffer in {buffer: ArrayBuffer}, so we
+  // need to unwrap it to get the actual byte data. This applies to both
+  // CALL_ERROR and CALL_UNEXPECTED_ERROR cases.
+  const errorBuf = callStatus.errorBuf;
+  if (
+    errorBuf &&
+    !(errorBuf instanceof Uint8Array) &&
+    (errorBuf as any).buffer instanceof ArrayBuffer
+  ) {
+    callStatus.errorBuf = new Uint8Array(
+      (errorBuf as any).buffer,
+    ) as UniffiByteArray;
+  }
+
   switch (callStatus.code) {
     case CALL_SUCCESS:
       return;


### PR DESCRIPTION
## Summary
Two fixes for error handling in the generated TypeScript bindings:

1. **Add `default` case to flat enum `write()` and `allocationSize()` methods** — The `read()` method already throws `UnexpectedEnumCase` for invalid ordinals, but `write()` and `allocationSize()` were missing this. Invalid enum values (e.g. passing a string name instead of the numeric enum value) silently fell through the switch, corrupting the serialization buffer and producing misleading "Rust panic" errors downstream.

2. **Unwrap error buffer wrapper in `uniffiCheckCallStatus`** — The C++ bridge wraps `ArrayBuffer` in `{buffer: ArrayBuffer}` when passing `RustCallStatus.errorBuf` to JavaScript. The error handler checked `errorBuf.byteLength` directly, which is `undefined` on the wrapper object, causing all unexpected errors to lose their actual error message and be reported as generic "Rust panic".

## Reproduction
- Use a TypeScript numeric enum (e.g. `enum MessageStatus { Active, Deleted }`)
- Pass the string name `'Active'` instead of `MessageStatus.Active` (which is `0`) to a UniFFI record field
- Before this fix: generic "Rust panic" error with no useful information
- After fix 1 alone: actual Rust error message shown (e.g. "Invalid MessageStatus enum value: 36")
- After both fixes: JS-side `UnexpectedEnumCase` error thrown before data reaches Rust

## Changes
- `crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts` — add `default: throw` to flat enum `write()` and `allocationSize()` for parity with `read()`
- `typescript/src/rust-call.ts` — unwrap `{buffer: ArrayBuffer}` wrapper before checking `byteLength`