### PR TITLE
Release 0.30.0-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.30.0-0...main
+
+---
+
+# 0.30.0-0
+
 ## ✨ What's New ✨
 
 - Add support for 16KB page size alignment on android (as required by Android 15 + Google Play by Nov 1, 2025) ([#294](https://github.com/jhugman/uniffi-bindgen-react-native/pull/294)). Thank you [@zzorba](https://github.com/zzorba)!
@@ -22,7 +28,7 @@
 
 - `UniffiRustArcPtr` renamed to `UniffiGcObject` and `UnsafeMutableRawPointer` renamed to `UniffiHandle` in generated TypeScript bindings. Regenerate your bindings to pick up the new names.
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...main
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...0.30.0-0
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-react-native"
-version = "0.29.3-1"
+version = "0.30.0-0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-javascript"
-version = "0.29.3-1"
+version = "0.30.0-0"
 dependencies = [
  "uniffi_core 0.29.3",
  "wasm-bindgen",

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.29.3-1"
+version = "0.30.0-0"
 edition = "2021"
 
 [lib]

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -156,6 +156,6 @@
     "version": "0.50.2"
   },
   "dependencies": {
-    "uniffi-bindgen-react-native": "^0.29.3-1"
+    "uniffi-bindgen-react-native": "^0.30.0-0"
   }
 }

--- a/crates/uniffi-runtime-javascript/Cargo.toml
+++ b/crates/uniffi-runtime-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-runtime-javascript"
-version = "0.29.3-1"
+version = "0.30.0-0"
 edition = "2021"
 authors = ["James Hugman <james@hugman.tv>"]
 description = "Javascript runtime for UniFFI-generated bindings"

--- a/docs/src/contributing/cutting-a-release.md
+++ b/docs/src/contributing/cutting-a-release.md
@@ -4,6 +4,11 @@
    - the [`package.json`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/package.json#L3)
    - the [`crates/ubrn_cli/Cargo.toml`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/crates/ubrn_cli/Cargo.toml#L3).
    - the [`crates/uniffi-runtime-javascript`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/crates/uniffi-runtime-javascript/Cargo.toml#L3)
+1. Update the CHANGELOG. If the CHANGELOG is up-to-date, then this should be minimal.
+   - Add a new version title at the top
+   - Update the Full Changelog link to go from new release to main
+   - Move the bottom of the "upcoming release" section to the top
+   - Update the Full Changelog link to go from previous release to new release
 1. Push as a PR as usual, with subject: `Release ${VERSION_NUMBER}`.
 1. Once this has landed, [draft a new release](https://github.com/jhugman/uniffi-bindgen-react-native/releases/new).
 1. Create a new tag (in the choose a new tag dialog) with the version number (without a `v`).

--- a/docs/src/contributing/local-development.md
+++ b/docs/src/contributing/local-development.md
@@ -61,6 +61,12 @@ The `run-tests.sh` script also runs the Typescript-only tests in the `typescript
 
 These have been useful to prototype generated Typescript before moving them into templates.
 
+`run-tests.sh` also runs the same fixtures with WASM:
+
+```sh
+./scripts/run-tests.sh --flavor wasm
+```
+
 ### Running rust only unit tests
 
 Rust unit tests are encouraged! They can be run as usual with:
@@ -83,4 +89,14 @@ Running with the `--check` does not change the files, just finishes abnormally i
 
 ```sh
 cargo xtask fmt --check
+```
+
+## Before pushing a PR
+
+Ensure that the following all run cleanly:
+
+```sh
+cargo xtask fmt
+./scripts/run-tests.sh --flavor jsi
+./scripts/run-tests.sh --flavor wasm
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.29.3-1",
+  "version": "0.30.0-0",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {

--- a/xtask/src/fmt/mod.rs
+++ b/xtask/src/fmt/mod.rs
@@ -126,6 +126,8 @@ impl CodeFormatter for RustArgs {
                 .arg("--all")
                 .arg("--all-targets")
                 .arg("--no-deps")
+                .arg("--workspace")
+                .arg("--tests")
                 .arg("--manifest-path")
                 .arg("Cargo.toml")
                 .current_dir(root);
@@ -136,6 +138,7 @@ impl CodeFormatter for RustArgs {
                 );
                 run_cmd_quietly(&mut cmd)?;
             } else {
+                cmd.arg("--allow-dirty").arg("--fix");
                 run_cmd(&mut cmd)?;
             }
         }


### PR DESCRIPTION
# 0.30.0-0

## ✨ What's New ✨

- Add support for 16KB page size alignment on android (as required by Android 15 + Google Play by Nov 1, 2025) ([#294](https://github.com/jhugman/uniffi-bindgen-react-native/pull/294)). Thank you [@zzorba](https://github.com/zzorba)!
- Uniffi traits `Display`, `Debug`, `Eq`, `Hash`, and `Ord` now generate corresponding TypeScript methods for records and enums (they already worked for objects; `Ord`/`compareTo()` is also new for objects).
- Custom types can now be used as `Result` error types when wrapping enums or objects.
- Function/method argument defaults now work correctly for custom types (e.g. `Option<CustomType>` parameters can have `= None`).

## 🦊 What's Changed

- Build TS to JS before publish; ship compiled JS + types to avoid strict TS errors. Inspired by [#198](https://github.com/jhugman/uniffi-bindgen-react-native/pull/198) ([@hassankhan](https://github.com/hassankhan)); implemented in [#297](https://github.com/jhugman/uniffi-bindgen-react-native/pull/297) ([@EthanShoeDev](https://github.com/EthanShoeDev)).
- Bump `uniffi-rs` to [0.30.0](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md).
- Changed RustBuffer `capacity` and `len` to `uint64_t`, fixing a crasher on 32-bit devices. ([#313](https://github.com/jhugman/uniffi-bindgen-react-native/pull/313)). Thank you [@sfourdrinier](https://github.com/sfourdrinier)!

## ⚠️ Breaking Changes

- `UniffiRustArcPtr` renamed to `UniffiGcObject` and `UnsafeMutableRawPointer` renamed to `UniffiHandle` in generated TypeScript bindings. Regenerate your bindings to pick up the new names.

**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...0.30.0-0
