### PR TITLE
Release 0.30.0-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.30.0-0...main
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.30.0-1...main
 
 ---
 
-# 0.30.0-0
+# 0.30.0-1
 
 ## ✨ What's New ✨
 
@@ -28,7 +28,7 @@
 
 - `UniffiRustArcPtr` renamed to `UniffiGcObject` and `UnsafeMutableRawPointer` renamed to `UniffiHandle` in generated TypeScript bindings. Regenerate your bindings to pick up the new names.
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...0.30.0-0
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...0.30.0-1
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,14 +1595,14 @@ dependencies = [
  "clap",
  "uniffi_bindgen",
  "uniffi_build",
- "uniffi_core 0.30.0",
+ "uniffi_core",
  "uniffi_macros",
  "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi-bindgen-react-native"
-version = "0.30.0-0"
+version = "0.30.0-1"
 dependencies = [
  "anyhow",
  "askama",
@@ -1864,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-javascript"
-version = "0.30.0-0"
+version = "0.30.0-1"
 dependencies = [
- "uniffi_core 0.29.3",
+ "uniffi_core",
  "wasm-bindgen",
 ]
 
@@ -1906,18 +1906,6 @@ dependencies = [
  "anyhow",
  "camino",
  "uniffi_bindgen",
-]
-
-[[package]]
-name = "uniffi_core"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e3b997192dc15ef1778c842001811ec7f241a093a693ac864e1fc938e64fa9"
-dependencies = [
- "anyhow",
- "bytes",
- "once_cell",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8.22"
 uniffi = "=0.30.0"
 uniffi_bindgen = "=0.30.0"
+uniffi_core = { version = "=0.30.0", default-features = false }
 uniffi_meta = "=0.30.0"

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.30.0-0"
+version = "0.30.0-1"
 edition = "2021"
 
 [lib]

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -156,6 +156,6 @@
     "version": "0.50.2"
   },
   "dependencies": {
-    "uniffi-bindgen-react-native": "^0.30.0-0"
+    "uniffi-bindgen-react-native": "^0.30.0-1"
   }
 }

--- a/crates/uniffi-runtime-javascript/Cargo.toml
+++ b/crates/uniffi-runtime-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-runtime-javascript"
-version = "0.30.0-0"
+version = "0.30.0-1"
 edition = "2021"
 authors = ["James Hugman <james@hugman.tv>"]
 description = "Javascript runtime for UniFFI-generated bindings"
@@ -11,7 +11,7 @@ keywords = ["ffi", "code-generation", "javascript", "wasm"]
 categories = ["api-bindings", "development-tools::ffi"]
 
 [dependencies]
-uniffi_core = { version = "0.29", default-features = false }
+uniffi_core = { workspace = true, default-features = false }
 wasm-bindgen = { version = "0.2.97", optional = true }
 
 [features]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.30.0-0",
+  "version": "0.30.0-1",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {


### PR DESCRIPTION

## ✨ What's New ✨

- Add support for 16KB page size alignment on android (as required by Android 15 + Google Play by Nov 1, 2025) ([#294](https://github.com/jhugman/uniffi-bindgen-react-native/pull/294)). Thank you [@zzorba](https://github.com/zzorba)!
- Uniffi traits `Display`, `Debug`, `Eq`, `Hash`, and `Ord` now generate corresponding TypeScript methods for records and enums (they already worked for objects; `Ord`/`compareTo()` is also new for objects).
- Custom types can now be used as `Result` error types when wrapping enums or objects.
- Function/method argument defaults now work correctly for custom types (e.g. `Option<CustomType>` parameters can have `= None`).

## 🦊 What's Changed

- Build TS to JS before publish; ship compiled JS + types to avoid strict TS errors. Inspired by [#198](https://github.com/jhugman/uniffi-bindgen-react-native/pull/198) ([@hassankhan](https://github.com/hassankhan)); implemented in [#297](https://github.com/jhugman/uniffi-bindgen-react-native/pull/297) ([@EthanShoeDev](https://github.com/EthanShoeDev)).
- Bump `uniffi-rs` to [0.30.0](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md).
- Changed RustBuffer `capacity` and `len` to `uint64_t`, fixing a crasher on 32-bit devices. ([#313](https://github.com/jhugman/uniffi-bindgen-react-native/pull/313)). Thank you [@sfourdrinier](https://github.com/sfourdrinier)!

## ⚠️ Breaking Changes

- `UniffiRustArcPtr` renamed to `UniffiGcObject` and `UnsafeMutableRawPointer` renamed to `UniffiHandle` in generated TypeScript bindings. Regenerate your bindings to pick up the new names.

**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.29.3-1...0.30.0-1
