### PR TITLE
Convert Windows back slash paths to forward slashes for CMakeLists.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1660,7 @@ dependencies = [
  "globset",
  "heck",
  "paste",
+ "path-slash",
  "pathdiff",
  "serde",
  "serde-toml-merge",

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -36,6 +36,7 @@ ubrn_bindgen = { path = "../ubrn_bindgen", features = ["wasm"] }
 ubrn_common = { path = "../ubrn_common" }
 uniffi_bindgen = { workspace = true }
 uniffi_meta = { workspace = true }
+path-slash = "0.2.1"
 
 [dev-dependencies]
 ubrn_cli_testing = { path = "../ubrn_cli_testing" }

--- a/crates/ubrn_cli/src/jsi/android/codegen.rs
+++ b/crates/ubrn_cli/src/jsi/android/codegen.rs
@@ -6,6 +6,7 @@
 use std::rc::Rc;
 
 use camino::{Utf8Path, Utf8PathBuf};
+use path_slash::PathExt;
 
 use crate::codegen::{RenderedFile, TemplateConfig};
 use crate::templated_file;

--- a/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
+++ b/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
@@ -4,9 +4,9 @@ project({{ self.config.project.module_cpp() }})
 
 {%- let root = self.project_root() %}
 {%- let dir = self.config.project.bindings.cpp_path(root) %}
-{%- let bindings_dir = self.relative_to(root, dir) %}
+{%- let bindings_dir = Utf8PathBuf::from(&self.relative_to(root, dir).as_std_path().to_slash_lossy()) %}
 {%- let dir = self.config.project.tm.cpp_path(root) %}
-{%- let tm_dir = self.relative_to(root, dir) %}
+{%- let tm_dir = Utf8PathBuf::from(&self.relative_to(root, dir).as_std_path().to_slash_lossy()) %}
 {%- let is_so_lib = self.config.project.android.use_shared_library %}
 {%- let is_static_lib = !is_so_lib %}
 
@@ -51,7 +51,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
 
 {%- let dir = self.config.project.android.jni_libs(root) %}
-{%- let jni_libs_dir = self.relative_to(root, dir) %}
+{%- let jni_libs_dir = Utf8PathBuf::from(&self.relative_to(root, dir).as_std_path().to_slash_lossy()) %}
 
 cmake_path(
   SET MY_RUST_LIB


### PR DESCRIPTION
See #348, resolves a bug that was preventing me from generating uniffi bindings on windows.

- Introduces path_slash as a dependency for crates/ubrn_cli
- Tested as well as I could figure out how to on Windows (I'm unable to run the run-tests.sh script without completely reverse engineering it), seems to be working fine now.