### PR TITLE
Resolve correct `node_modules` binary on Windows

### DIFF
--- a/crates/ubrn_common/src/files.rs
+++ b/crates/ubrn_common/src/files.rs
@@ -20,6 +20,25 @@ pub fn resolve<P: AsRef<Utf8Path>>(directory: P, file_suffix: &str) -> Result<Op
     resolve_from_canonical(full_path, file_suffix)
 }
 
+/// Resolve a `node_modules/.bin/<name>` binary, handling Windows where the
+/// actual file is `<name>.cmd` (npm/yarn/pnpm) or `<name>.exe` (bun).
+pub fn resolve_node_bin<P: AsRef<Utf8Path>>(
+    directory: P,
+    name: &str,
+) -> Result<Option<Utf8PathBuf>> {
+    if cfg!(target_os = "windows") {
+        for ext in [".cmd", ".exe", ""] {
+            let suffixed = format!("node_modules/.bin/{name}{ext}");
+            if let Some(path) = resolve(&directory, &suffixed)? {
+                return Ok(Some(path));
+            }
+        }
+        Ok(None)
+    } else {
+        resolve(&directory, &format!("node_modules/.bin/{name}"))
+    }
+}
+
 fn resolve_from_canonical<P: AsRef<Utf8Path>>(
     path: P,
     file_suffix: &str,

--- a/crates/ubrn_common/src/fmt.rs
+++ b/crates/ubrn_common/src/fmt.rs
@@ -8,7 +8,7 @@ use camino::Utf8Path;
 use std::process::Command;
 use which::which;
 
-use crate::{file_paths, resolve};
+use crate::{file_paths, resolve_node_bin};
 
 pub fn clang_format<P: AsRef<Utf8Path>>(path: P, check_only: bool) -> Result<Option<Command>> {
     if which("clang-format").is_err() {
@@ -35,11 +35,7 @@ pub fn clang_format<P: AsRef<Utf8Path>>(path: P, check_only: bool) -> Result<Opt
 }
 
 pub fn prettier<P: AsRef<Utf8Path>>(out_dir: P, check_only: bool) -> Result<Option<Command>> {
-    let prettier = if cfg!(windows) {
-        resolve(&out_dir, "node_modules/.bin/prettier.cmd")?
-    } else {
-        resolve(&out_dir, "node_modules/.bin/prettier")?
-    };
+    let prettier = resolve_node_bin(&out_dir, "prettier")?;
 
     Ok(if let Some(prettier) = prettier {
         let mut cmd = Command::new(prettier);

--- a/crates/ubrn_fixture_testing/src/lib.rs
+++ b/crates/ubrn_fixture_testing/src/lib.rs
@@ -118,7 +118,7 @@ pub(crate) fn write_fixture_tsconfig(
 
 /// Run a test script with tsx and experimental WASM module support.
 pub(crate) fn run_tsx(test_script: &camino::Utf8Path) {
-    let tsx = paths::node_modules_bin().join("tsx");
+    let tsx = paths::node_bin("tsx");
     run_cmd_quietly(
         Command::new(&tsx)
             .arg("--experimental-wasm-modules")

--- a/crates/ubrn_fixture_testing/src/paths.rs
+++ b/crates/ubrn_fixture_testing/src/paths.rs
@@ -25,6 +25,21 @@ pub(crate) fn node_modules_bin() -> Utf8PathBuf {
     repo_root().join("node_modules").join(".bin")
 }
 
+/// Resolve a binary under `node_modules/.bin`, handling Windows where the
+/// actual file is `<name>.cmd` (npm/yarn/pnpm) or `<name>.exe` (bun).
+pub(crate) fn node_bin(name: &str) -> Utf8PathBuf {
+    let bin_dir = node_modules_bin();
+    if cfg!(target_os = "windows") {
+        for ext in [".cmd", ".exe", ""] {
+            let candidate = bin_dir.join(format!("{name}{ext}"));
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+    bin_dir.join(name)
+}
+
 pub(crate) fn hermes_src_dir() -> Utf8PathBuf {
     repo_root().join("cpp_modules").join("hermes")
 }

--- a/crates/ubrn_fixture_testing/src/typescript.rs
+++ b/crates/ubrn_fixture_testing/src/typescript.rs
@@ -112,7 +112,7 @@ fn prepare_tsconfig(
 /// The test script is listed in the tsconfig's `"files"` array and `outDir` is
 /// set in the tsconfig, so no extra CLI flags are needed beyond `--project`.
 fn compile_ts(tsconfig: &Utf8Path) {
-    let tsc = paths::node_modules_bin().join("tsc");
+    let tsc = paths::node_bin("tsc");
     run_cmd_quietly(Command::new(&tsc).arg("--project").arg(tsconfig));
 }
 
@@ -254,7 +254,7 @@ fn find_file_recursive(dir: &Utf8Path, filename: &str) -> Option<Utf8PathBuf> {
 /// discover files that live under `target/` (which watchman normally ignores
 /// because it is listed in `.gitignore`).
 fn bundle_with_metro(js_file: &Utf8Path, bundle_path: &Utf8Path, tsc_dir: &Utf8Path) {
-    let metro = paths::node_modules_bin().join("metro");
+    let metro = paths::node_bin("metro");
     let repo_root = paths::repo_root();
 
     // Generate a metro config that:

--- a/xtask/src/fmt/mod.rs
+++ b/xtask/src/fmt/mod.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use ubrn_common::{run_cmd, run_cmd_quietly};
+use ubrn_common::{resolve_node_bin, run_cmd, run_cmd_quietly};
 
 use crate::{
     bootstrap::{Bootstrap, YarnCmd},
@@ -192,13 +192,17 @@ impl CodeFormatter for LicenceArgs {
         }
         YarnCmd.ensure_ready()?;
         let root = repository_root()?;
-        run_cmd_quietly(
-            Command::new("./node_modules/.bin/source-licenser")
-                .arg(".")
-                .arg("--config-file")
-                .arg(".licence-config.yaml")
-                .current_dir(root),
-        )?;
+        if let Some(source_licenser) = resolve_node_bin(&root, "source-licenser")? {
+            run_cmd_quietly(
+                Command::new(source_licenser)
+                    .arg(".")
+                    .arg("--config-file")
+                    .arg(".licence-config.yaml")
+                    .current_dir(root),
+            )?;
+        } else {
+            unreachable!("Is source-licenser in package.json dependencies?")
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
On Windows, binaries under `node_modules/.bin/` (e.g. `prettier`, `source-licenser`) are shell scripts that Windows cannot natively execute. The actual executables are `.cmd` (npm/yarn/pnpm) or `.exe` (bun). `resolve_node_bin` handles this by trying each extension.

Fixes #302 