### PR TITLE
Convert Windows back slash paths to forward slashes

### DIFF
--- a/crates/ubrn_cli/src/codegen/mod.rs
+++ b/crates/ubrn_cli/src/codegen/mod.rs
@@ -8,6 +8,7 @@ use std::{cell::OnceCell, collections::BTreeMap, rc::Rc};
 use anyhow::Result;
 use askama::DynTemplate;
 use camino::{Utf8Path, Utf8PathBuf};
+use path_slash::PathExt;
 
 use ubrn_bindgen::ModuleMetadata;
 use ubrn_common::{mk_dir, CrateMetadata};
@@ -21,7 +22,10 @@ pub(crate) trait RenderedFile: DynTemplate {
         let from = file
             .parent()
             .expect("Expected this file to have a directory");
-        pathdiff::diff_utf8_paths(to, from).expect("Should be able to find a relative path")
+        let rel =
+            pathdiff::diff_utf8_paths(to, from).expect("Should be able to find a relative path");
+        // Normalize to forward slashes so templates produce valid paths on Windows.
+        Utf8PathBuf::from(rel.as_std_path().to_slash_lossy().as_ref())
     }
     fn filter_by(&self) -> bool {
         true

--- a/crates/ubrn_cli/src/jsi/android/codegen.rs
+++ b/crates/ubrn_cli/src/jsi/android/codegen.rs
@@ -6,7 +6,6 @@
 use std::rc::Rc;
 
 use camino::{Utf8Path, Utf8PathBuf};
-use path_slash::PathExt;
 
 use crate::codegen::{RenderedFile, TemplateConfig};
 use crate::templated_file;

--- a/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
+++ b/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
@@ -4,9 +4,9 @@ project({{ self.config.project.module_cpp() }})
 
 {%- let root = self.project_root() %}
 {%- let dir = self.config.project.bindings.cpp_path(root) %}
-{%- let bindings_dir = Utf8PathBuf::from(&self.relative_to(root, dir).as_std_path().to_slash_lossy()) %}
+{%- let bindings_dir = self.relative_to(root, dir) %}
 {%- let dir = self.config.project.tm.cpp_path(root) %}
-{%- let tm_dir = Utf8PathBuf::from(&self.relative_to(root, dir).as_std_path().to_slash_lossy()) %}
+{%- let tm_dir = self.relative_to(root, dir) %}
 {%- let is_so_lib = self.config.project.android.use_shared_library %}
 {%- let is_static_lib = !is_so_lib %}
 
@@ -51,7 +51,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
 
 {%- let dir = self.config.project.android.jni_libs(root) %}
-{%- let jni_libs_dir = Utf8PathBuf::from(&self.relative_to(root, dir).as_std_path().to_slash_lossy()) %}
+{%- let jni_libs_dir = self.relative_to(root, dir) %}
 
 cmake_path(
   SET MY_RUST_LIB


### PR DESCRIPTION
#352 already touched on this for CMakeLists.txt, but the issue is still present in all of the other users of `relative_to`. This PR moves the fix from that to the `relative_to` function itself