### PR TITLE
Don't prepend `lib` to dlls

### DIFF
--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -47,7 +47,7 @@ impl CrateMetadata {
 
     pub fn library_file(&self, target: Option<&str>, use_shared_library: Option<bool>) -> String {
         let ext = so_extension(target, use_shared_library);
-        if ext == "wasm" {
+        if ext == "wasm" || ext == "dll" {
             format!("{}.{ext}", &self.library_name)
         } else {
             format!("lib{}.{ext}", &self.library_name)


### PR DESCRIPTION
On Windows, Rust's cdylib output doesn't prefix DLL filenames with `lib`. This issue was noticeable running `ubrn build web`, as the tool searched for `libfoo.dll` instead of `foo.dll`.