### PR TITLE
Have prettier only format JS and TS files

### DIFF
--- a/crates/ubrn_common/src/fmt.rs
+++ b/crates/ubrn_common/src/fmt.rs
@@ -43,7 +43,8 @@ pub fn prettier<P: AsRef<Utf8Path>>(out_dir: P, check_only: bool) -> Result<Opti
         } else {
             cmd.arg("--write");
         }
-        cmd.arg(".").current_dir(out_dir.as_ref());
+        cmd.args(["**/*.js", "**/*.ts"])
+            .current_dir(out_dir.as_ref());
         Some(cmd)
     } else {
         use crate::testing::{is_recording_enabled, record_command};

--- a/crates/ubrn_common/src/fmt.rs
+++ b/crates/ubrn_common/src/fmt.rs
@@ -43,8 +43,13 @@ pub fn prettier<P: AsRef<Utf8Path>>(out_dir: P, check_only: bool) -> Result<Opti
         } else {
             cmd.arg("--write");
         }
-        cmd.args(["**/*.js", "**/*.ts", "**/*.json", "--no-error-on-unmatched-pattern"])
-            .current_dir(out_dir.as_ref());
+        cmd.args([
+            "**/*.js",
+            "**/*.ts",
+            "**/*.json",
+            "--no-error-on-unmatched-pattern",
+        ])
+        .current_dir(out_dir.as_ref());
         Some(cmd)
     } else {
         use crate::testing::{is_recording_enabled, record_command};

--- a/crates/ubrn_common/src/fmt.rs
+++ b/crates/ubrn_common/src/fmt.rs
@@ -43,7 +43,7 @@ pub fn prettier<P: AsRef<Utf8Path>>(out_dir: P, check_only: bool) -> Result<Opti
         } else {
             cmd.arg("--write");
         }
-        cmd.args(["**/*.js", "**/*.ts"])
+        cmd.args(["**/*.js", "**/*.ts", "**/*.json", "--no-error-on-unmatched-pattern"])
             .current_dir(out_dir.as_ref());
         Some(cmd)
     } else {


### PR DESCRIPTION
`prettier` was being called to run on every file from where it was invoked. This includes the `rust_modules/wasm/target/` directory, which contains large binary files (1.5gb) that exceed Node's string length limit, causing the build to fail with `Invalid string length`.

This shouldn't be reproducible with the default config, as the folder layout prevents it. My `ubrn.config.yaml` is as follows:
```yaml
rust:
  directory: .
  manifestPath: crates/foo-ffi/Cargo.toml
web:
  ts: generated/web
  manifestPath: generated/web/rust_modules/wasm/Cargo.toml
  entrypoint: generated/web/index.web.ts
bindings:
  cpp: generated/cpp
  ts: generated/src
turboModule:
  cpp: generated/cpp
  ts: generated/src
  entrypoint: generated/src/index.tsx
android:
  directory: generated/android
  packageName: com.bar.foo
ios:
  directory: generated/ios
```