### PR TITLE
Declare the package as CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "name": "James Hugman",
     "email": "james@hugman.tv"
   },
-  "type": "module",
+  "type": "commonjs",
   "main": "./typescript/dist/index.js",
   "types": "./typescript/dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
This allows exported values to be imported in Node.

Fixes #370

---

This is a simpler alternative to #325 which avoids having to add file extensions on imports.  It also works without having to re-emit JS with `tsc`.

The reason this works is because, as was noted in #324, the `tsconfig.json` is configured to emit CommonJS, and the `package.json`'s `type` field may simply be updated to match that.