### PR TITLE
Have typescript generate ESM code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs", 
+    "module": "es2022", 
     "declaration": true,
     "outDir": "./typescript/dist",                                   /* Specify what module code is generated. */
     "paths": {


### PR DESCRIPTION
Possible that I'm missing something here but when I try to use the module I receive an error that it contains CommonJS files inside a module that's `type: "module"`. And indeed that seems to be the case. I've tweaked the tsconfig to output ESM and everything is working fine for me locally.