### PR TITLE
Optimizing strings and bytes over the FFI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,16 @@ jobs:
     name: 🧩 Integration tests (WASM bindings)
     runs-on: ubuntu-latest
     steps:
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Installing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-benchmark"
+version = "0.1.0"
+dependencies = [
+ "ubrn_fixture_testing",
+ "ubrn_macros",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-callbacks"
 version = "0.22.0"
 dependencies = [

--- a/cpp/includes/UniffiString.h
+++ b/cpp/includes/UniffiString.h
@@ -12,9 +12,23 @@ namespace uniffi_jsi {
 using namespace facebook;
 
 template <> struct Bridging<std::string> {
-  static jsi::Value arraybuffer_to_string(jsi::Runtime &rt,
-                                          const jsi::Value &value) {
+  static jsi::Value string_from_buffer(jsi::Runtime &rt,
+                                       const jsi::Value &value) {
     try {
+      auto obj = value.asObject(rt);
+      // Handle both Uint8Array views (with byteOffset/byteLength) and
+      // plain {buffer: ArrayBuffer} wrappers.
+      if (obj.hasProperty(rt, "byteOffset")) {
+        // TypedArray (e.g. Uint8Array view) — respect offset and length.
+        auto buffer = obj.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
+        auto byteOffset =
+            static_cast<size_t>(obj.getProperty(rt, "byteOffset").asNumber());
+        auto byteLength =
+            static_cast<size_t>(obj.getProperty(rt, "byteLength").asNumber());
+        auto string = jsi::String::createFromUtf8(
+            rt, buffer.data(rt) + byteOffset, byteLength);
+        return jsi::Value(rt, string);
+      }
       auto buffer =
           uniffi_jsi::Bridging<jsi::ArrayBuffer>::value_to_arraybuffer(rt,
                                                                        value);
@@ -26,8 +40,8 @@ template <> struct Bridging<std::string> {
     }
   }
 
-  static jsi::Value string_to_arraybuffer(jsi::Runtime &rt,
-                                          const jsi::Value &value) {
+  static jsi::Value string_to_buffer(jsi::Runtime &rt,
+                                     const jsi::Value &value) {
     try {
       // Get the string out of the Value.
       auto string = value.asString(rt).utf8(rt);
@@ -55,6 +69,34 @@ template <> struct Bridging<std::string> {
       auto string = value.asString(rt).utf8(rt);
       auto v = static_cast<double>(string.size());
       return jsi::Value(rt, v);
+    } catch (const std::logic_error &e) {
+      throw jsi::JSError(rt, e.what());
+    }
+  }
+
+  /// Read a string directly from an ArrayBuffer at the given byte offset and
+  /// length. No JS-side Uint8Array view allocation, no property lookups for
+  /// byteOffset/byteLength — significantly faster than
+  /// string_from_buffer(view) for array-of-strings workloads.
+  ///
+  ///   args[0]: source object (with .arrayBuffer or .buffer property)
+  ///   args[1]: byte offset (number)
+  ///   args[2]: byte length (number)
+  static jsi::Value read_string_from_buffer(jsi::Runtime &rt,
+                                            const jsi::Value &bufValue,
+                                            const jsi::Value &offsetValue,
+                                            const jsi::Value &lengthValue) {
+    try {
+      auto obj = bufValue.asObject(rt);
+      jsi::ArrayBuffer buffer =
+          obj.hasProperty(rt, "arrayBuffer")
+              ? obj.getPropertyAsObject(rt, "arrayBuffer").getArrayBuffer(rt)
+              : obj.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
+      auto offset = static_cast<size_t>(offsetValue.asNumber());
+      auto length = static_cast<size_t>(lengthValue.asNumber());
+      auto string =
+          jsi::String::createFromUtf8(rt, buffer.data(rt) + offset, length);
+      return jsi::Value(rt, string);
     } catch (const std::logic_error &e) {
       throw jsi::JSError(rt, e.what());
     }

--- a/crates/ubrn_bindgen/src/bindings/extensions.rs
+++ b/crates/ubrn_bindgen/src/bindings/extensions.rs
@@ -21,10 +21,10 @@ use uniffi_bindgen::{
 
 #[ext]
 pub(crate) impl ComponentInterface {
-    fn ffi_function_string_to_arraybuffer(&self) -> FfiFunction {
+    fn ffi_function_string_to_buffer(&self) -> FfiFunction {
         let meta = uniffi_meta::FnMetadata {
             module_path: "internal".to_string(),
-            name: "ffi__string_to_arraybuffer".to_owned(),
+            name: "ffi__string_to_buffer".to_owned(),
             is_async: false,
             inputs: Default::default(),
             return_type: None,
@@ -41,10 +41,10 @@ pub(crate) impl ComponentInterface {
         ffi.clone()
     }
 
-    fn ffi_function_arraybuffer_to_string(&self) -> FfiFunction {
+    fn ffi_function_string_from_buffer(&self) -> FfiFunction {
         let meta = uniffi_meta::FnMetadata {
             module_path: "internal".to_string(),
-            name: "ffi__arraybuffer_to_string".to_owned(),
+            name: "ffi__string_from_buffer".to_owned(),
             is_async: false,
             inputs: Default::default(),
             return_type: None,
@@ -81,11 +81,36 @@ pub(crate) impl ComponentInterface {
         ffi.clone()
     }
 
+    fn ffi_function_read_string_from_buffer(&self) -> FfiFunction {
+        let meta = uniffi_meta::FnMetadata {
+            module_path: "internal".to_string(),
+            name: "ffi__read_string_from_buffer".to_owned(),
+            is_async: false,
+            inputs: Default::default(),
+            return_type: None,
+            throws: None,
+            checksum: None,
+            docstring: None,
+        };
+        let func: Function = meta.into();
+        let mut ffi = func.ffi_func().clone();
+        ffi.init(
+            Some(FfiType::RustBuffer(None)),
+            vec![
+                FfiArgument::new("buffer", FfiType::ForeignBytes),
+                FfiArgument::new("offset", FfiType::Int32),
+                FfiArgument::new("length", FfiType::Int32),
+            ],
+        );
+        ffi.clone()
+    }
+
     fn iter_ffi_functions_js_to_cpp_and_back(&self) -> impl Iterator<Item = FfiFunction> {
         vec![
             self.ffi_function_string_to_bytelength(),
-            self.ffi_function_string_to_arraybuffer(),
-            self.ffi_function_arraybuffer_to_string(),
+            self.ffi_function_string_to_buffer(),
+            self.ffi_function_string_from_buffer(),
+            self.ffi_function_read_string_from_buffer(),
         ]
         .into_iter()
     }

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/StringHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/StringHelper.cpp
@@ -6,12 +6,17 @@
     return {{ ci.cpp_namespace_includes() }}::Bridging<std::string>::string_to_bytelength(rt, args[0]);
 }
 
-{% let func = ci.ffi_function_string_to_arraybuffer() %}
+{% let func = ci.ffi_function_string_to_buffer() %}
 {%- call cpp::cpp_fn_from_js_decl(func) %} {
-    return {{ ci.cpp_namespace_includes() }}::Bridging<std::string>::string_to_arraybuffer(rt, args[0]);
+    return {{ ci.cpp_namespace_includes() }}::Bridging<std::string>::string_to_buffer(rt, args[0]);
 }
 
-{% let func = ci.ffi_function_arraybuffer_to_string() %}
+{% let func = ci.ffi_function_string_from_buffer() %}
 {%- call cpp::cpp_fn_from_js_decl(func) %} {
-    return {{ ci.cpp_namespace_includes() }}::Bridging<std::string>::arraybuffer_to_string(rt, args[0]);
+    return {{ ci.cpp_namespace_includes() }}::Bridging<std::string>::string_from_buffer(rt, args[0]);
+}
+
+{% let func = ci.ffi_function_read_string_from_buffer() %}
+{%- call cpp::cpp_fn_from_js_decl(func) %} {
+    return {{ ci.cpp_namespace_includes() }}::Bridging<std::string>::read_string_from_buffer(rt, args[0], args[1], args[2]);
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -24,7 +24,10 @@ use crate::{
     AbiFlavor,
 };
 pub(crate) use config::RustConfig as Config;
-use extensions::{ComponentInterfaceExt as _, FfiCallbackFunction2, FfiDefinition2, FfiStruct2};
+use extensions::{
+    ComponentInterfaceExt as _, FfiCallbackFunction2, FfiDefinition2, FfiStruct2,
+    RustFfiCallbackFunctionExt as _,
+};
 
 #[allow(unused_variables)]
 pub(crate) fn generate_rs(
@@ -472,7 +475,7 @@ impl<'a> ComponentTemplate<'a> {
 
         let cb_ident = cb.module_ident();
         let non_snake_case = if_or_default(
-            cb.callback().is_free_callback(),
+            cb.callback().is_free_callback() || cb.callback().is_clone_callback(),
             quote! {
                 #[allow(non_snake_case)]
             },

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -65,9 +65,11 @@ pub(super) fn build_string_helper(flavor: &AbiFlavor) -> TsStringHelper {
     let supports_text_encoder = flavor.supports_text_encoder();
     TsStringHelper {
         supports_text_encoder,
-        ffi_string_to_arraybuffer: "ubrn_uniffi_internal_fn_func_ffi__string_to_arraybuffer".into(),
-        ffi_arraybuffer_to_string: "ubrn_uniffi_internal_fn_func_ffi__arraybuffer_to_string".into(),
+        ffi_string_to_buffer: "ubrn_uniffi_internal_fn_func_ffi__string_to_buffer".into(),
+        ffi_string_from_buffer: "ubrn_uniffi_internal_fn_func_ffi__string_from_buffer".into(),
         ffi_string_to_bytelength: "ubrn_uniffi_internal_fn_func_ffi__string_to_byte_length".into(),
+        ffi_read_string_from_buffer: "ubrn_uniffi_internal_fn_func_ffi__read_string_from_buffer"
+            .into(),
     }
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -64,9 +64,11 @@ pub(super) fn build_string_helper(flavor: &AbiFlavor) -> TsStringHelper {
     let supports_text_encoder = flavor.supports_text_encoder();
     TsStringHelper {
         supports_text_encoder,
-        ffi_string_to_arraybuffer: "ubrn_uniffi_internal_fn_func_ffi__string_to_arraybuffer".into(),
-        ffi_arraybuffer_to_string: "ubrn_uniffi_internal_fn_func_ffi__arraybuffer_to_string".into(),
+        ffi_string_to_buffer: "ubrn_uniffi_internal_fn_func_ffi__string_to_buffer".into(),
+        ffi_string_from_buffer: "ubrn_uniffi_internal_fn_func_ffi__string_from_buffer".into(),
         ffi_string_to_bytelength: "ubrn_uniffi_internal_fn_func_ffi__string_to_byte_length".into(),
+        ffi_read_string_from_buffer: "ubrn_uniffi_internal_fn_func_ffi__read_string_from_buffer"
+            .into(),
     }
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -196,7 +196,9 @@ impl ImportAccumulator {
         self.add_infra_value("AbstractFfiConverterByteArray");
         self.add_infra_value("FfiConverterInt32");
         self.add_infra_value("UniffiInternalError");
-
+        if !e.is_flat {
+            self.add_infra_value("uniffiTypeNameSymbol");
+        }
         if e.is_error {
             self.add_infra_value("UniffiError");
             self.add_infra_value("uniffiTypeNameSymbol");

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
@@ -28,9 +28,10 @@ pub(crate) struct TsSimpleWrapper {
 
 pub(crate) struct TsStringHelper {
     pub supports_text_encoder: bool,
-    pub ffi_string_to_arraybuffer: String,
-    pub ffi_arraybuffer_to_string: String,
+    pub ffi_string_to_buffer: String,
+    pub ffi_string_from_buffer: String,
     pub ffi_string_to_bytelength: String,
+    pub ffi_read_string_from_buffer: String,
 }
 
 pub(crate) struct TsCustomType {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module/builder.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module/builder.rs
@@ -152,7 +152,7 @@ impl TsFfiModule {
                 return_type: Some("number".into()),
             },
             FfiFunctionDecl {
-                name: "ubrn_uniffi_internal_fn_func_ffi__string_to_arraybuffer".into(),
+                name: "ubrn_uniffi_internal_fn_func_ffi__string_to_buffer".into(),
                 arguments: vec![
                     FfiArgDecl {
                         name: "string".into(),
@@ -166,7 +166,7 @@ impl TsFfiModule {
                 return_type: Some("Uint8Array".into()),
             },
             FfiFunctionDecl {
-                name: "ubrn_uniffi_internal_fn_func_ffi__arraybuffer_to_string".into(),
+                name: "ubrn_uniffi_internal_fn_func_ffi__string_from_buffer".into(),
                 arguments: vec![
                     FfiArgDecl {
                         name: "buffer".into(),
@@ -175,6 +175,24 @@ impl TsFfiModule {
                     FfiArgDecl {
                         name: "uniffi_out_err".into(),
                         type_name: "UniffiRustCallStatus".into(),
+                    },
+                ],
+                return_type: Some("string".into()),
+            },
+            FfiFunctionDecl {
+                name: "ubrn_uniffi_internal_fn_func_ffi__read_string_from_buffer".into(),
+                arguments: vec![
+                    FfiArgDecl {
+                        name: "buffer".into(),
+                        type_name: "any".into(),
+                    },
+                    FfiArgDecl {
+                        name: "offset".into(),
+                        type_name: "number".into(),
+                    },
+                    FfiArgDecl {
+                        name: "length".into(),
+                        type_name: "number".into(),
                     },
                 ],
                 return_type: Some("string".into()),

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -306,11 +306,16 @@ console.debug(`-- {{ prefix }}{{ middle }}{{ suffix }}`);
 {%- endif %}
 {%- endmacro %}
 
+{#- Render a single named field declaration: `name?: T` when optional, else `name: T`. -#}
+{%- macro field_decl(field) -%}
+{{ field.name }}{% if field.is_optional %}?{% endif %}: {{ field.ts_type }}
+{%- endmacro %}
+
 {#- Variant inner type shape: Readonly<{ name: Type; ... }> or Readonly<[Type, ...]>. -#}
 {%- macro variant_inner_type(variant) %}
 Readonly<{%- if !variant.has_nameless_fields %}{
 {%-   for field in variant.fields %}
-{{-     field.name }}: {{ field.ts_type }}
+{%-     call field_decl(field) %}
 {%-     if !loop.last %}; {% endif -%}
 {%- endfor %}}
 {%- else %}
@@ -326,7 +331,7 @@ Readonly<{%- if !variant.has_nameless_fields %}{
 {#- Variant inner value shape for constructor parameters: { name: Type; ... } or unnamed positional args. -#}
 {%- macro variant_fields_decl(variant) %}
 {%- if !variant.has_nameless_fields %}
-inner: { {%- for field in variant.fields %}{{ field.name }}: {{ field.ts_type }}{%- if !loop.last %}; {% endif %}{%- endfor %} }
+inner: { {%- for field in variant.fields %}{% call field_decl(field) %}{%- if !loop.last %}; {% endif %}{%- endfor %} }
 {%- else %}
 {%- for field in variant.fields %}v{{ loop.index0 }}: {{ field.ts_type }}{%- if !loop.last %}, {% endif %}{%- endfor %}
 {%- endif %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
@@ -8,12 +8,7 @@ export type {{ rec.ts_name }} = {
     {%- if let Some(ds) = field.docstring %}
 {{ ds }}
     {%- endif %}
-    {%- if field.is_optional %}
-    {{ field.name }}?: {{ field.ts_type }}
-    {%- else %}
-    {{ field.name }}: {{ field.ts_type }}
-    {%- endif %}
-    {%- if !loop.last %},{% endif %}
+    {% call cb::field_decl(field) %}{% if !loop.last %},{% endif %}
     {%- endfor %}
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelperTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelperTemplate.ts
@@ -10,14 +10,56 @@ const stringConverter = (() => {
     };
 })();
 {%- else %}
-const stringConverter = {
-    stringToBytes: (s: string) =>
-        uniffiCaller.rustCall((status) => nativeModule().{{ helper.ffi_string_to_arraybuffer }}(s, status)),
-    bytesToString: (ab: UniffiByteArray) =>
-        uniffiCaller.rustCall((status) => nativeModule().{{ helper.ffi_arraybuffer_to_string }}(ab, status)),
-    stringByteLength: (s: string) =>
-        uniffiCaller.rustCall((status) => nativeModule().{{ helper.ffi_string_to_bytelength }}(s, status)),
-};
+// Hermes (React Native ≥ 0.74) ships TextEncoder and encodeInto, but not
+// TextDecoder. For single-string decode (bytesToString), we polyfill via the
+// C++ string_from_buffer helper using a duck-typed object matching the
+// standard TextDecoder.decode signature. Once Hermes ships a real
+// TextDecoder, the `typeof` check will pick it up automatically.
+//
+// For array-of-strings decode (readStringFromBuffer), we keep a dedicated C++
+// helper: the polyfill path (new Uint8Array view + decode) measured ~40%
+// slower on getStringArray benchmarks than a direct (buf, offset, length)
+// call, due to the per-read view allocation and extra property lookups in
+// string_from_buffer.
+const stringConverter = (() => {
+    const encoder = new TextEncoder();
+    const decoder: { decode(input: UniffiByteArray): string } =
+        typeof TextDecoder !== "undefined"
+            ? new TextDecoder()
+            : {
+                  decode: (bytes: UniffiByteArray) =>
+                      nativeModule().{{ helper.ffi_string_from_buffer }}(
+                          bytes,
+                          undefined as any,
+                      ) as string,
+              };
+    return {
+        // Single-string lower() uses the C++ helper — TextEncoder.encode
+        // measured ~43% slower on takeString benchmarks.
+        stringToBytes: (s: string) =>
+            nativeModule().{{ helper.ffi_string_to_buffer }}(s, undefined as any),
+        bytesToString: (ab: UniffiByteArray) => decoder.decode(ab),
+        // Direct C++ call — bypasses uniffiCaller.rustCall() overhead.
+        // Matters for N-element arrays.
+        stringByteLength: (s: string) =>
+            nativeModule().{{ helper.ffi_string_to_bytelength }}(s, undefined as any) as number,
+        // Encode directly into the RustBuffer backing store via
+        // TextEncoder.encodeInto — zero intermediate allocation. Replaces
+        // the old C++ write_string_into_buffer helper.
+        writeStringIntoBuffer: (s: string, buf: any, offset: number): number => {
+            const view = new Uint8Array(
+                buf.arrayBuffer,
+                offset,
+                buf.arrayBuffer.byteLength - offset,
+            );
+            return encoder.encodeInto(s, view).written;
+        },
+        // Dedicated C++ helper — avoids per-read Uint8Array allocation and
+        // the double property-lookup in string_from_buffer.
+        readStringFromBuffer: (buf: any, offset: number, length: number): string =>
+            nativeModule().{{ helper.ffi_read_string_from_buffer }}(buf, offset, length) as string,
+    };
+})();
 {%- endif %}
 const FfiConverterString = uniffiCreateFfiConverterString(stringConverter);
 {%- endmacro %}

--- a/crates/ubrn_fixture_testing/src/Cargo.template.toml
+++ b/crates/ubrn_fixture_testing/src/Cargo.template.toml
@@ -1,5 +1,5 @@
 [package]
-name = "my-test-crate"
+name = "{{wasm_pkg_name}}"
 version = "0.1.0"
 authors = ["James Hugman <james@hugman.tv>"]
 edition = "2018"

--- a/crates/ubrn_fixture_testing/src/wasm.rs
+++ b/crates/ubrn_fixture_testing/src/wasm.rs
@@ -32,6 +32,12 @@ pub fn run_test(crate_name: &str, test_script: &str, target_tmpdir: &str) {
         Utf8PathBuf::from(target_tmpdir).join(format!("ubrn-tests/{crate_name}-{test_stem}-wasm"));
     std::fs::create_dir_all(&out_dir).expect("failed to create output dir");
 
+    // Shared target dir across every fixture's wasm-crate: lets cargo reuse
+    // rlibs for common dependencies (uniffi_*, serde, wasm-bindgen, …) instead
+    // of rebuilding them once per fixture, which filled the CI runner's disk.
+    let shared_target_dir = Utf8PathBuf::from(target_tmpdir).join("ubrn-tests-shared/wasm-target");
+    std::fs::create_dir_all(&shared_target_dir).expect("failed to create shared target dir");
+
     // Step 1: Build the fixture crate (native, for metadata extraction)
     crate::cargo_build(crate_name);
 
@@ -60,20 +66,27 @@ pub fn run_test(crate_name: &str, test_script: &str, target_tmpdir: &str) {
             .expect("failed to canonicalize wasm-crate dir"),
     )
     .expect("non-UTF-8 path");
+    // The wasm-crate package gets a per-fixture name so multiple fixtures can
+    // share the target dir without overwriting each other's artifacts.
+    let wasm_pkg_name = format!("{crate_name}-wasm-test");
+    let wasm_lib_stem = wasm_pkg_name.replace('-', "_");
     generate_cargo_toml(
         &canonical_wasm_crate,
         crate_name,
         &fixture_dir,
         &wasm_crate_src,
+        &wasm_pkg_name,
     );
 
     // Step 5: Build for wasm32-unknown-unknown
     let cargo_toml = wasm_crate_dir.join("Cargo.toml");
-    compile_wasm32(&cargo_toml);
+    compile_wasm32(&cargo_toml, &shared_target_dir);
 
     // Step 6: Run wasm-bindgen
     // Output goes next to the TypeScript bindings so imports resolve correctly.
-    let wasm_file = wasm_crate_dir.join("target/wasm32-unknown-unknown/debug/my_test_crate.wasm");
+    let wasm_file = shared_target_dir
+        .join("wasm32-unknown-unknown/debug")
+        .join(format!("{wasm_lib_stem}.wasm"));
     let wasm_bindgen_dir = ts_dir.join("wasm-bindgen");
     std::fs::create_dir_all(&wasm_bindgen_dir).expect("failed to create wasm-bindgen dir");
     run_wasm_bindgen(&wasm_file, &wasm_bindgen_dir);
@@ -159,6 +172,7 @@ fn generate_cargo_toml(
     crate_name: &str,
     package_dir: &Utf8Path,
     src_dir: &Utf8Path,
+    wasm_pkg_name: &str,
 ) {
     let repo_root = paths::repo_root();
     let uniffi_runtime_javascript = repo_root.join("crates/uniffi-runtime-javascript");
@@ -171,6 +185,7 @@ fn generate_cargo_toml(
         .expect("cannot compute relative path to lib.rs");
 
     let cargo_toml_content = CARGO_TEMPLATE
+        .replace("{{wasm_pkg_name}}", wasm_pkg_name)
         .replace("{{crate_name}}", crate_name)
         .replace("{{crate_path}}", crate_path.as_str())
         .replace("{{uniffi_runtime_javascript}}", runtime_path.as_str())
@@ -181,9 +196,10 @@ fn generate_cargo_toml(
 }
 
 /// `cargo build --target wasm32-unknown-unknown --manifest-path <path>`
-fn compile_wasm32(cargo_toml: &Utf8Path) {
+fn compile_wasm32(cargo_toml: &Utf8Path, target_dir: &Utf8Path) {
     run_cmd_quietly(
         Command::new("cargo")
+            .env("CARGO_TARGET_DIR", target_dir.as_str())
             .arg("build")
             .arg("--target")
             .arg("wasm32-unknown-unknown")

--- a/fixtures/benchmark/Cargo.toml
+++ b/fixtures/benchmark/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uniffi-fixture-benchmark"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_benchmark"
+
+[dependencies]
+uniffi = { workspace = true }
+
+[dev-dependencies]
+ubrn_macros = { workspace = true }
+ubrn_fixture_testing = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/benchmark/src/lib.rs
+++ b/fixtures/benchmark/src/lib.rs
@@ -1,0 +1,43 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+/// Accept a string argument (measures string lowering overhead).
+#[uniffi::export]
+pub fn take_string(s: String) {
+    let _ = s;
+}
+
+/// Return a string of the given byte length (measures string lifting overhead).
+#[uniffi::export]
+pub fn get_string(length: u32) -> String {
+    "x".repeat(length as usize)
+}
+
+/// Accept a byte array argument (measures bytes lowering overhead).
+#[uniffi::export]
+pub fn take_bytes(bytes: Vec<u8>) {
+    let _ = bytes;
+}
+
+/// Return a byte array of the given length (measures bytes lifting overhead).
+#[uniffi::export]
+pub fn get_bytes(length: u32) -> Vec<u8> {
+    vec![0u8; length as usize]
+}
+
+/// Return a Vec of `repeats` copies of `s` (measures sequence + string lifting).
+#[uniffi::export]
+pub fn get_string_array(repeats: u32, s: String) -> Vec<String> {
+    std::iter::repeat_n(s, repeats as usize).collect()
+}
+
+/// Accept a Vec of strings (measures sequence + string lowering overhead).
+#[uniffi::export]
+pub fn take_string_array(strings: Vec<String>) {
+    let _ = strings;
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/benchmark/tests/bindings/test_benchmark.ts
+++ b/fixtures/benchmark/tests/bindings/test_benchmark.ts
@@ -1,0 +1,142 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// To run:
+//   cargo test -p uniffi-fixture-benchmark -- jsi
+//   cargo test -p uniffi-fixture-benchmark -- wasm
+
+import {
+  getBytes,
+  getString,
+  getStringArray,
+  takeBytes,
+  takeString,
+  takeStringArray,
+} from "@/generated/uniffi_benchmark";
+import { test } from "@/asserts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Run `fn` `iterations` times and return wall-clock ms. */
+function timeMs(fn: () => void, iterations: number): number {
+  const start = Date.now();
+  for (let i = 0; i < iterations; i++) fn();
+  return Date.now() - start;
+}
+
+/** Return the minimum over `runs` calls of timeMs(fn, iterations). */
+function bench(fn: () => void, iterations: number, runs: number): number {
+  let best = Infinity;
+  for (let r = 0; r < runs; r++) {
+    best = Math.min(best, timeMs(fn, iterations));
+  }
+  return best;
+}
+
+const RUNS = 3;
+
+// Payload sizes for individual string / byte benchmarks.
+const SIZES: Array<{ label: string; bytes: number }> = [
+  { label: "1 KB", bytes: 1_024 },
+  { label: "16 KB", bytes: 16 * 1_024 },
+  { label: "256 KB", bytes: 256 * 1_024 },
+  { label: "512 KB", bytes: 512 * 1_024 },
+  { label: "1 MB", bytes: 1_024 * 1_024 },
+];
+
+// Configurations for array benchmarks: [count, element_bytes].
+const ARRAY_CONFIGS: Array<{ count: number; elemBytes: number }> = [
+  { count: 100, elemBytes: 64 },
+  { count: 1000, elemBytes: 64 },
+  { count: 100, elemBytes: 1024 },
+  { count: 1024, elemBytes: 100 },
+];
+
+// ---------------------------------------------------------------------------
+// String benchmarks
+// ---------------------------------------------------------------------------
+
+test("bench: getString (lifting a string from Rust)", (_t) => {
+  console.log("\n--- getString: lifting a string from Rust ---");
+  const ITERS = 100;
+  for (const { label, bytes } of SIZES) {
+    const ms = bench(() => getString(bytes), ITERS, RUNS);
+    console.log(
+      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+    );
+  }
+});
+
+test("bench: takeString (lowering a string into Rust)", (_t) => {
+  console.log("\n--- takeString: lowering a string into Rust ---");
+  const ITERS = 100;
+  for (const { label, bytes } of SIZES) {
+    const s = "x".repeat(bytes);
+    const ms = bench(() => takeString(s), ITERS, RUNS);
+    console.log(
+      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Bytes benchmarks
+// ---------------------------------------------------------------------------
+
+test("bench: getBytes (lifting bytes from Rust)", (_t) => {
+  console.log("\n--- getBytes: lifting bytes from Rust ---");
+  const ITERS = 100;
+  for (const { label, bytes } of SIZES) {
+    const ms = bench(() => getBytes(bytes), ITERS, RUNS);
+    console.log(
+      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+    );
+  }
+});
+
+test("bench: takeBytes (lowering bytes into Rust)", (_t) => {
+  console.log("\n--- takeBytes: lowering bytes into Rust ---");
+  const ITERS = 100;
+  for (const { label, bytes } of SIZES) {
+    // const b = new Uint8Array(bytes);
+    const b = new ArrayBuffer(bytes);
+    const ms = bench(() => takeBytes(b), ITERS, RUNS);
+    console.log(
+      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// String-array benchmarks
+// ---------------------------------------------------------------------------
+
+test("bench: getStringArray (lifting a Vec<String> from Rust)", (_t) => {
+  console.log("\n--- getStringArray: lifting a Vec<String> from Rust ---");
+  const ITERS = 20;
+  for (const { count, elemBytes } of ARRAY_CONFIGS) {
+    const label = `${count}×${elemBytes}B`;
+    const s = "x".repeat(elemBytes);
+    const ms = bench(() => getStringArray(count, s), ITERS, RUNS);
+    console.log(
+      `  ${label.padEnd(12)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+    );
+  }
+});
+
+test("bench: takeStringArray (lowering a string[] into Rust)", (_t) => {
+  console.log("\n--- takeStringArray: lowering a string[] into Rust ---");
+  const ITERS = 20;
+  for (const { count, elemBytes } of ARRAY_CONFIGS) {
+    const label = `${count}×${elemBytes}B`;
+    const arr = Array.from({ length: count }, () => "x".repeat(elemBytes));
+    const ms = bench(() => takeStringArray(arr), ITERS, RUNS);
+    console.log(
+      `  ${label.padEnd(12)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+    );
+  }
+});

--- a/fixtures/benchmark/tests/test_bindings.rs
+++ b/fixtures/benchmark/tests/test_bindings.rs
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+ubrn_macros::build_foreign_language_testcases! {
+    "tests/bindings/test_benchmark.ts" => [Jsi, Wasm],
+}

--- a/fixtures/benchmark/uniffi.toml
+++ b/fixtures/benchmark/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.typescript]
+strictTypeChecking = true

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -112,6 +112,21 @@ fn identity_colliding_variants(value: CollidingVariants) -> CollidingVariants {
     value
 }
 
+#[derive(uniffi::Enum)]
+pub(crate) enum OptionalFields {
+    Named {
+        required: String,
+        maybe_string: Option<String>,
+        maybe_record: Option<AnimalRecord>,
+    },
+    Empty,
+}
+
+#[uniffi::export]
+fn identity_optional_fields(value: OptionalFields) -> OptionalFields {
+    value
+}
+
 uniffi::include_scaffolding!("enum_types");
 
 #[cfg(test)]

--- a/fixtures/enum-types/tests/bindings/test_enum_types.ts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.ts
@@ -27,6 +27,9 @@ import {
   CollidingVariants_Tags,
   identityCollidingVariants,
   AnimalObjectInterface,
+  OptionalFields,
+  OptionalFields_Tags,
+  identityOptionalFields,
 } from "@/generated/enum_types";
 
 test("Enum discriminant", (t) => {
@@ -176,6 +179,42 @@ test("Variant naming cam collide with existing types", (t) => {
 
     t.assertTrue(CollidingVariants.instanceOf(variant1));
     t.assertTrue(CollidingVariants.CollidingVariants.instanceOf(variant1));
+  }
+});
+
+test("Variant with Option fields accepts omitted keys and undefined", (t) => {
+  // Omitting optional keys is a compile-time check (would fail tsc if `?:` was lost).
+  const v1 = OptionalFields.Named.new({ required: "hello" });
+  t.assertEqual(v1.tag, OptionalFields_Tags.Named);
+  if (OptionalFields.Named.instanceOf(v1)) {
+    t.assertEqual(v1.inner.required, "hello");
+    t.assertEqual(v1.inner.maybeString, undefined);
+    t.assertEqual(v1.inner.maybeRecord, undefined);
+  } else {
+    t.fail("expected Named");
+  }
+
+  // Explicit `undefined` is also accepted.
+  const v2 = new OptionalFields.Named({
+    required: "world",
+    maybeString: undefined,
+    maybeRecord: undefined,
+  });
+  t.assertEqual(identityOptionalFields(v2).tag, OptionalFields_Tags.Named);
+
+  // Supplying values roundtrips.
+  const v3 = OptionalFields.Named.new({
+    required: "r",
+    maybeString: "s",
+    maybeRecord: AnimalRecord.create({ value: 7 }),
+  });
+  const roundTripped = identityOptionalFields(v3);
+  if (OptionalFields.Named.instanceOf(roundTripped)) {
+    t.assertEqual(roundTripped.inner.required, "r");
+    t.assertEqual(roundTripped.inner.maybeString, "s");
+    t.assertEqual(roundTripped.inner.maybeRecord?.value, 7);
+  } else {
+    t.fail("expected Named");
   }
 });
 

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -368,9 +368,20 @@ export const FfiConverterUint8Array = (() => {
 })();
 
 type StringConverter = {
+  // Single-string encoding. Each template picks an environment-appropriate
+  // implementation: the JSI template uses a C++ helper (avoids the
+  // TextEncoder allocation on the hot `lower()` path for large strings);
+  // the WASM template uses `TextEncoder.encode`.
   stringToBytes: (s: string) => UniffiByteArray;
   bytesToString: (ab: UniffiByteArray) => string;
   stringByteLength: (s: string) => number;
+  // Optional direct-buffer operations. When provided, `write` and `read` use
+  // them to skip the intermediate Uint8Array produced by
+  // `stringToBytes`/`bytesToString`. The `buf` argument is a RustBuffer; the
+  // implementation encodes into / decodes from `buf.arrayBuffer` at the given
+  // offset.
+  writeStringIntoBuffer?: (s: string, buf: any, offset: number) => number;
+  readStringFromBuffer?: (buf: any, offset: number, length: number) => string;
 };
 export function uniffiCreateFfiConverterString(
   converter: StringConverter,
@@ -386,20 +397,38 @@ export function uniffiCreateFfiConverterString(
     }
     read(from: RustBuffer): string {
       const length = lengthConverter.read(from);
-      // TODO Currently, RustBufferHelper.cpp is pretty dumb,
-      // and copies all the bytes in the underlying ArrayBuffer.
-      // Making a better shim for Uint8Array would allow us to use
-      // readByteArray here, and eliminate a copy.
-      const bytes = from.readArrayBuffer(length);
-      return converter.bytesToString(new Uint8Array(bytes));
+      if (converter.readStringFromBuffer) {
+        // Read directly from the RustBuffer's backing ArrayBuffer — zero copy.
+        const offset = from.advanceReadOffset(length);
+        return converter.readStringFromBuffer(from, offset, length);
+      }
+      const bytes = from.readByteArray(length);
+      return converter.bytesToString(bytes);
     }
     write(value: string, into: RustBuffer): void {
-      // TODO: work on RustBufferHelper.cpp is needed to avoid
-      // the extra copy and use writeByteArray.
-      const buffer = converter.stringToBytes(value).buffer;
-      const numBytes = buffer.byteLength;
+      if (converter.writeStringIntoBuffer) {
+        // Encode the string first, then backfill the i32 length prefix with
+        // the actual byte count. Skips one `stringByteLength` measurement
+        // call per string compared to the writeByteArray path below.
+        const lengthOffset = into.advanceWriteOffset(4);
+        const dataOffset = lengthOffset + 4;
+        const bytesWritten = converter.writeStringIntoBuffer(
+          value,
+          into,
+          dataOffset,
+        );
+        new DataView(into.arrayBuffer, lengthOffset, 4).setInt32(
+          0,
+          bytesWritten,
+          false,
+        );
+        into.setWriteOffset(dataOffset + bytesWritten);
+        return;
+      }
+      const bytes = converter.stringToBytes(value);
+      const numBytes = bytes.byteLength;
       lengthConverter.write(numBytes, into);
-      into.writeArrayBuffer(buffer);
+      into.writeByteArray(bytes);
     }
     allocationSize(value: string): number {
       return (

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -349,9 +349,20 @@ export const FfiConverterArrayBuffer = (() => {
 })();
 
 type StringConverter = {
+  // Single-string encoding. Each template picks an environment-appropriate
+  // implementation: the JSI template uses a C++ helper (avoids the
+  // TextEncoder allocation on the hot `lower()` path for large strings);
+  // the WASM template uses `TextEncoder.encode`.
   stringToBytes: (s: string) => UniffiByteArray;
   bytesToString: (ab: UniffiByteArray) => string;
   stringByteLength: (s: string) => number;
+  // Optional direct-buffer operations. When provided, `write` and `read` use
+  // them to skip the intermediate Uint8Array produced by
+  // `stringToBytes`/`bytesToString`. The `buf` argument is a RustBuffer; the
+  // implementation encodes into / decodes from `buf.arrayBuffer` at the given
+  // offset.
+  writeStringIntoBuffer?: (s: string, buf: any, offset: number) => number;
+  readStringFromBuffer?: (buf: any, offset: number, length: number) => string;
 };
 export function uniffiCreateFfiConverterString(
   converter: StringConverter,
@@ -367,20 +378,38 @@ export function uniffiCreateFfiConverterString(
     }
     read(from: RustBuffer): string {
       const length = lengthConverter.read(from);
-      // TODO Currently, RustBufferHelper.cpp is pretty dumb,
-      // and copies all the bytes in the underlying ArrayBuffer.
-      // Making a better shim for Uint8Array would allow us to use
-      // readByteArray here, and eliminate a copy.
-      const bytes = from.readArrayBuffer(length);
-      return converter.bytesToString(new Uint8Array(bytes));
+      if (converter.readStringFromBuffer) {
+        // Read directly from the RustBuffer's backing ArrayBuffer — zero copy.
+        const offset = from.advanceReadOffset(length);
+        return converter.readStringFromBuffer(from, offset, length);
+      }
+      const bytes = from.readByteArray(length);
+      return converter.bytesToString(bytes);
     }
     write(value: string, into: RustBuffer): void {
-      // TODO: work on RustBufferHelper.cpp is needed to avoid
-      // the extra copy and use writeByteArray.
-      const buffer = converter.stringToBytes(value).buffer;
-      const numBytes = buffer.byteLength;
+      if (converter.writeStringIntoBuffer) {
+        // Encode the string first, then backfill the i32 length prefix with
+        // the actual byte count. Skips one `stringByteLength` measurement
+        // call per string compared to the writeByteArray path below.
+        const lengthOffset = into.advanceWriteOffset(4);
+        const dataOffset = lengthOffset + 4;
+        const bytesWritten = converter.writeStringIntoBuffer(
+          value,
+          into,
+          dataOffset,
+        );
+        new DataView(into.arrayBuffer, lengthOffset, 4).setInt32(
+          0,
+          bytesWritten,
+          false,
+        );
+        into.setWriteOffset(dataOffset + bytesWritten);
+        return;
+      }
+      const bytes = converter.stringToBytes(value);
+      const numBytes = bytes.byteLength;
       lengthConverter.write(numBytes, into);
-      into.writeArrayBuffer(buffer);
+      into.writeByteArray(bytes);
     }
     allocationSize(value: string): number {
       return (

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -96,6 +96,37 @@ export class RustBuffer {
     this.writeOffset = end;
   }
 
+  /**
+   * Advance the read cursor by `numBytes` and return the starting offset.
+   * Used to construct a typed-array view directly over the backing store.
+   */
+  advanceReadOffset(numBytes: number): number {
+    const start = this.readOffset;
+    this.readOffset = this.checkOverflow(start, numBytes);
+    return start;
+  }
+
+  /**
+   * Advance the write cursor by `numBytes` and return the starting offset.
+   * Used to construct a typed-array view directly over the backing store.
+   */
+  advanceWriteOffset(numBytes: number): number {
+    const start = this.writeOffset;
+    this.writeOffset = this.checkOverflow(start, numBytes);
+    return start;
+  }
+
+  /**
+   * Set the write cursor to an absolute position. Used to backfill after an
+   * in-place encode reports the actual number of bytes written.
+   */
+  setWriteOffset(offset: number): void {
+    if (offset > this.capacity) {
+      throw new UniffiInternalError.BufferOverflow();
+    }
+    this.writeOffset = offset;
+  }
+
   protected checkOverflow(start: number, numBytes: number): number {
     const end = start + numBytes;
     if (this.capacity < end) {


### PR DESCRIPTION
The benchmarks I used were recording getting strings, arrays of strings and byte arrays to and from Rust.

I used string arrays as a proxy for strings that are part of larger types (from Option<String> to Records or Enums containing strings).

The headline numbers are quite surprising. On the same machine, sending strings across the FFI is much slower for JSI, but sending bytes is quicker for JSI.

As with all benchmarks, these numbers may not reflect real world usage.

The biggest speed ups were for JSI strings and string arrays; by reducing the number of JS/C++ calls per string per crossing:
- replacing decoding and encoding in directly into the a buffer from a string
- replacing the string encoding path with the native `TextEncoder`. **This requires react-native 0.74**.

### More detail

Functions are all shaped, e.g.:

```rust
// gets a string from Rust.
fn get_string(length: u32) -> String
// Rust takes a string and consumes it.
fn take_string(string: String) -> ()
```

## JSI

| Operation       | Before   | After    | Change |
|-----------------|----------|----------|--------|
| getString       | 487ms    | 406ms    | -17%   |
| takeString      | 666ms    | 623ms    | -6%    |
| getStringArray  | 3,287ms  | 2,192ms  | -33%   |
| takeStringArray | 6,900ms  | 3,092ms  | -55%   |
| getBytes        | 1,962ms  | ~1,913ms | noise  |
| takeBytes       | 4,292ms  | ~4,182ms | noise  |                                                                              
                                                          
  ## WASM                                                                                                                                     
                                                          
  | Operation       | Before  | After   | Change |
  |-----------------|---------|---------|--------|
  | getString       | 44ms    | 39ms    | -11%   |                                                                                            
  | takeString      | 384ms   | 397ms   | noise  |
  | getStringArray  | 35ms    | 25ms    | -29%   |                                                                                            
  | takeStringArray | 48ms    | 47ms    | noise  |                                                                                            
  | getBytes        | 5,698ms | 6,027ms | noise  |
  | takeBytes       | 6,162ms | 6,411ms | noise  |  