### PR TITLE
Commit auto-applied change to the lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,6 @@ dependencies = [
  "syn",
  "textwrap",
  "toml 0.9.12+spec-1.1.0",
- "topological-sort",
  "ubrn_common",
  "uniffi_bindgen",
  "uniffi_meta",


### PR DESCRIPTION
This change gets applied to Cargo.lock when building, so check it into version control.