### PR TITLE
Remove redundant files from the package bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,7 +19,6 @@ Cargo.lock
 *.pdb
 
 # OSX
-#
 .DS_Store
 
 # XDE
@@ -30,7 +29,6 @@ Cargo.lock
 jsconfig.json
 
 # Xcode
-#
 build/
 *.pbxuser
 !default.pbxuser
@@ -50,7 +48,6 @@ DerivedData
 project.xcworkspace
 
 # Android/IJ
-#
 .classpath
 .cxx
 .gradle
@@ -64,5 +61,11 @@ android.iml
 node_modules/
 *.bundle.js
 
+# GitHub
+.github
+
 # Uniffi
 generated/
+.clang-format-ignore
+.licence-config.yaml
+.prettierignore


### PR DESCRIPTION
# Why

When working on bundle code explorer for React Native Directory I have spotted that there are several files in the bundle, which can be safely skipped.

# How

Update `.npmignore` to skip bundling the redundant files: `.github` directory content and development tools configs.