### PR TITLE
Enable all fixtures for Napi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ docs/superpowers/
 
 # napi-rs build artifacts
 *.node
+core

--- a/.licence-config.yaml
+++ b/.licence-config.yaml
@@ -88,6 +88,7 @@ ignore:
   - test
   - ./**/generated
   - ./**/templates
+  - ./**/node_modules
   - runtimes/napi/index.d.ts
   - runtimes/napi/index.js
 

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Struct.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Struct.cpp
@@ -22,18 +22,17 @@ template <> struct Bridging<{{ struct_name }}> {
     // Create the vtable from the js callbacks.
     {%- for field in ffi_struct.fields() %}
     {%-   let rs_field_name = field.name() %}
-    {%-   let ts_field_name = field.name()|var_name %}
     {%-   if field.type_().is_callable() %}
     rsObject.{{ rs_field_name }} = {# space #}
     {%-     call cpp::callback_fn_namespace(ffi_struct, field) -%}
         ::makeCallbackFunction(
-          rt, callInvoker, jsObject.getProperty(rt, "{{ ts_field_name }}")
+          rt, callInvoker, jsObject.getProperty(rt, "{{ rs_field_name }}")
         );
     {%-   else %}
     rsObject.{{ rs_field_name }} = {# space -#}
       {{ field.type_().borrow()|bridging_class(ci) }}::fromJs(
         rt, callInvoker,
-        jsObject.getProperty(rt, "{{ ts_field_name }}")
+        jsObject.getProperty(rt, "{{ rs_field_name }}")
       );
     {%-   endif %}
     {%- endfor %}

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -16,7 +16,7 @@ use uniffi_bindgen::{
     interface::{FfiArgument, FfiCallbackFunction, FfiFunction, FfiType},
     ComponentInterface,
 };
-use util::{camel_case_ident, ident, if_or_default, if_then_map, map_or_default, snake_case_ident};
+use util::{ident, if_or_default, if_then_map, map_or_default, snake_case_ident};
 
 use crate::{
     bindings::{extensions::FfiCallbackFunctionExt as _, metadata::ModuleMetadata},
@@ -511,19 +511,18 @@ impl<'a> ComponentTemplate<'a> {
             .map(|field| {
                 let field_name = field.name();
                 let field_ident = ident(field_name);
-                let js_field_ident = camel_case_ident(field_name);
                 if st.is_callback_method(field_name) {
                     let callback_fn_ident = callback_fn_ident();
                     let alias_ident = st.method_alias_ident(field_name);
                     quote! {
-                        #[wasm_bindgen(method, getter, js_name = #js_field_ident)]
+                        #[wasm_bindgen(method, getter)]
                         fn #field_ident(this: &VTableJs) -> #alias_ident::#callback_fn_ident;
                     }
                 } else {
                     let field_type = field.type_();
                     let type_ = self.ffi_type_foreign_future(&field_type);
                     quote! {
-                        #[wasm_bindgen(method, getter, js_name = #js_field_ident)]
+                        #[wasm_bindgen(method, getter)]
                         fn #field_ident(this: &VTableJs) -> #type_;
                     }
                 }

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/util.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/util.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use heck::{ToLowerCamelCase, ToSnakeCase};
+use heck::ToSnakeCase;
 use proc_macro2::Span;
 use syn::Ident;
 
@@ -44,8 +44,4 @@ pub(super) fn ident(id: &str) -> Ident {
 
 pub(super) fn snake_case_ident(s: &str) -> Ident {
     ident(&s.to_snake_case())
-}
-
-pub(super) fn camel_case_ident(field_name: &str) -> Ident {
-    ident(&field_name.to_lower_camel_case())
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -631,7 +631,7 @@ fn build_vtable_field(
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
 ) -> TsVtableField {
-    let name = fn_name(&vm.callable.name);
+    let name = vm.callable.name.clone();
     let method = Some(build_callable(config, &vm.callable, &None, None, flavor));
 
     let general::FfiType::Function(ref ffi_fn_name) = vm.ffi_type.ty else {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module/builder.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module/builder.rs
@@ -291,7 +291,7 @@ impl TsFfiModule {
             .fields
             .iter()
             .map(|f| FfiFieldDecl {
-                name: f.name.to_lower_camel_case(),
+                name: f.name.clone(),
                 type_name: ffi_type_to_ts(&f.ty.ty),
             })
             .collect();

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -78,10 +78,10 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                     /* {{ ffr.struct_name }} */{
                         {%- match meth.return_type %}
                         {%- when Some(return_type) %}
-                        returnValue: {{ return_type.ffi_converter }}.lower(returnValue),
+                        return_value: {{ return_type.ffi_converter }}.lower(returnValue),
                         {%- when None %}
                         {%- endmatch %}
-                        callStatus: uniffiCaller.createCallStatus()
+                        call_status: uniffiCaller.createCallStatus()
                     }
                     {%- when None %}
                     {}
@@ -96,10 +96,10 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                     {%- when Some with (ffr) %}
                     /* {{ ffr.struct_name }} */{
                         {%- if !ffr.return_ffi_default_value.is_empty() %}
-                        returnValue: {{ ffr.return_ffi_default_value }},
+                        return_value: {{ ffr.return_ffi_default_value }},
                         {%- endif %}
                         // TODO create callstatus with error.
-                        callStatus: uniffiCaller.createErrorStatus(code, errorBuf),
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
                     }
                     {%- when None %}
                     {}
@@ -131,11 +131,11 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
         {%- when None %}
         {%- endmatch %}
         {%- endfor %}
-        uniffiFree: (uniffiHandle: UniffiHandle): void => {
+        uniffi_free: (uniffiHandle: UniffiHandle): void => {
             // this will throw a stale handle error if the handle isn't found.
             {{ ffi_converter_name }}.drop(uniffiHandle);
         },
-        uniffiClone: (uniffiHandle: UniffiHandle): UniffiHandle => {
+        uniffi_clone: (uniffiHandle: UniffiHandle): UniffiHandle => {
             return {{ ffi_converter_name }}.clone(uniffiHandle);
         }
     },

--- a/fixtures/arc-futures/tests/test_bindings.rs
+++ b/fixtures/arc-futures/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_arc_futures.ts" => [Jsi, Wasm],
+    "tests/bindings/test_arc_futures.ts" => [Jsi, Napi, Wasm],
 }

--- a/fixtures/async-callbacks/tests/test_bindings.rs
+++ b/fixtures/async-callbacks/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_async_callbacks.ts" => [Jsi, Wasm],
+    "tests/bindings/test_async_callbacks.ts" => [Jsi, Wasm, Napi],
 }

--- a/fixtures/callbacks-regression/tests/test_bindings.rs
+++ b/fixtures/callbacks-regression/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_callbacks_regression.ts" => [Jsi, Wasm],
+    "tests/bindings/test_callbacks_regression.ts" => [Jsi, Wasm, Napi],
 }

--- a/fixtures/callbacks/tests/test_bindings.rs
+++ b/fixtures/callbacks/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_callbacks.ts" => [Jsi, Wasm],
+    "tests/bindings/test_callbacks.ts" => [Jsi, Wasm, Napi],
 }

--- a/fixtures/coverall/tests/test_bindings.rs
+++ b/fixtures/coverall/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_coverall.ts" => [Jsi, Wasm],
+    "tests/bindings/test_coverall.ts" => [Jsi, Wasm, Napi],
 }

--- a/fixtures/ext-types/tests/test_bindings.rs
+++ b/fixtures/ext-types/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_ext_types.ts" => [Jsi, Wasm],
+    "tests/bindings/test_ext_types.ts" => [Jsi, Wasm, Napi],
 }

--- a/fixtures/futures/tests/test_bindings.rs
+++ b/fixtures/futures/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_futures.ts" => [Jsi],
+    "tests/bindings/test_futures.ts" => [Jsi, Napi],
 }

--- a/fixtures/gc-callbacks-crasher/tests/test_bindings.rs
+++ b/fixtures/gc-callbacks-crasher/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_gc_callbacks_crasher.ts" => [Jsi, Wasm],
+    "tests/bindings/test_gc_callbacks_crasher.ts" => [Jsi, Wasm, Napi],
 }

--- a/runtimes/napi/index.d.ts
+++ b/runtimes/napi/index.d.ts
@@ -1,8 +1,3 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/
- */
 /* tslint:disable */
 /* eslint-disable */
 

--- a/runtimes/napi/src/callback.rs
+++ b/runtimes/napi/src/callback.rs
@@ -199,6 +199,10 @@ pub unsafe extern "C" fn trampoline_callback(
     args: *const *const c_void,
     userdata: &TrampolineUserdata,
 ) {
+    if crate::is_shutting_down() {
+        return;
+    }
+
     if is_main_thread() {
         // Same-thread path: call JS function directly.
         trampoline_main_thread(_cif, _result, args, userdata);

--- a/runtimes/napi/src/callback.rs
+++ b/runtimes/napi/src/callback.rs
@@ -123,6 +123,9 @@ pub enum RawCallbackArg {
     RustBuffer(Vec<u8>),
     /// A raw C pointer (function pointer or opaque reference) transported as usize.
     Pointer(usize),
+    /// Pre-marshalled struct bytes for cross-thread transport.
+    /// Used when a callback returns a by-value struct (e.g. ForeignFutureDroppedCallbackStruct).
+    StructBytes(Vec<u8>),
 }
 
 /// Per-closure state passed to the libffi trampoline as the `userdata` pointer.
@@ -428,6 +431,15 @@ pub fn raw_arg_to_js(env: &Env, raw_arg: &RawCallbackArg) -> napi::Result<napi::
             Ok(unsafe { napi::JsUnknown::from_raw(raw_env, typedarray)? })
         }
         RawCallbackArg::Pointer(v) => Ok(env.create_bigint_from_u64(*v as u64)?.into_unknown()?),
+        RawCallbackArg::StructBytes(data) => {
+            let raw_env = env.raw();
+            // SAFETY: `raw_env` is valid (main thread). `data` is an owned
+            // `Vec<u8>` that outlives this call.
+            let typedarray =
+                unsafe { napi_utils::create_uint8array(raw_env, data.as_ptr(), data.len())? };
+            // SAFETY: `raw_env` is valid and `typedarray` is a live napi_value.
+            Ok(unsafe { napi::JsUnknown::from_raw(raw_env, typedarray)? })
+        }
     }
 }
 

--- a/runtimes/napi/src/cif.rs
+++ b/runtimes/napi/src/cif.rs
@@ -65,7 +65,16 @@ pub fn ffi_type_for(
         | FfiTypeDesc::MutReference(_)
         | FfiTypeDesc::Callback(_) => Ok(Type::pointer()),
         FfiTypeDesc::Void => Ok(Type::void()),
-        FfiTypeDesc::RustCallStatus => Ok(Type::pointer()), // always passed as &mut
+        // When RustCallStatus appears as a struct field, it is an inline value
+        // with layout {i8, u64, u64, pointer} matching RustCallStatusC.
+        // Function-level CIF builders push Type::pointer() directly for &mut args,
+        // so this only affects struct field layout computation.
+        FfiTypeDesc::RustCallStatus => Ok(Type::structure(vec![
+            Type::i8(),
+            Type::u64(),
+            Type::u64(),
+            Type::pointer(),
+        ])),
         FfiTypeDesc::RustBuffer => Ok(Type::structure(vec![
             Type::u64(),
             Type::u64(),

--- a/runtimes/napi/src/fn_pointer.rs
+++ b/runtimes/napi/src/fn_pointer.rs
@@ -58,7 +58,7 @@ use crate::structs::StructDef;
 /// are only populated when `ffi_prep_cif` walks the type tree. This function creates
 /// a minimal dummy CIF with the struct as a parameter type, which triggers the
 /// in-place initialization of the struct's `ffi_type` and all nested struct types.
-fn prep_struct_type(struct_type: &Type) -> Result<()> {
+pub fn prep_struct_type(struct_type: &Type) -> Result<()> {
     unsafe {
         let raw = struct_type.as_raw_ptr();
         // Build a minimal arg types array: [struct_type_ptr, null]
@@ -85,7 +85,7 @@ fn prep_struct_type(struct_type: &Type) -> Result<()> {
 /// After `Type::structure()` is called, libffi populates the internal `ffi_type`
 /// with size, alignment, and element information. This function walks the elements
 /// array and computes the byte offset of each field, respecting alignment padding.
-fn struct_field_offsets(struct_type: &Type) -> Vec<usize> {
+pub fn struct_field_offsets(struct_type: &Type) -> Vec<usize> {
     let raw = struct_type.as_raw_ptr();
     let mut offsets = Vec::new();
     let mut offset = 0usize;
@@ -105,7 +105,7 @@ fn struct_field_offsets(struct_type: &Type) -> Vec<usize> {
 }
 
 /// Get the total size of a libffi type.
-fn ffi_type_size(t: &Type) -> usize {
+pub fn ffi_type_size(t: &Type) -> usize {
     unsafe { (*t.as_raw_ptr()).size }
 }
 
@@ -229,6 +229,50 @@ pub fn marshal_js_struct_to_bytes(
                     rb_from_bytes_ptr,
                 )?;
                 buffer[offset..offset + nested_bytes.len()].copy_from_slice(&nested_bytes);
+            }
+            FfiTypeDesc::RustCallStatus => {
+                // RustCallStatus is an inline struct: {code: i8, error_buf: RustBuffer}
+                // C layout (RustCallStatusC): {i8, u64, u64, *mut u8}
+                // JS shape: {code: number, errorBuf?: Uint8Array}
+                let status_obj: JsObject = js_val.try_into()?;
+                let code: i32 = status_obj.get_named_property("code")?;
+                buffer[offset] = code as i8 as u8;
+
+                let status_type = ffi_type_for(&FfiTypeDesc::RustCallStatus, struct_defs)?;
+                prep_struct_type(&status_type)?;
+                let status_offsets = struct_field_offsets(&status_type);
+
+                // errorBuf → RustBuffer fields (capacity, len, data), default to zero
+                let has_error_buf: bool = status_obj.has_named_property("errorBuf")?;
+                if has_error_buf && code != 0 {
+                    let err_val: JsUnknown = status_obj.get_named_property("errorBuf")?;
+                    // SAFETY: `env.raw()` is valid (main thread), `err_val` is a
+                    // live JsUnknown from JS, `rb_from_bytes_ptr` is the library's
+                    // `rustbuffer_from_bytes` function pointer.
+                    let rb = unsafe {
+                        napi_utils::js_uint8array_to_rust_buffer(
+                            env.raw(),
+                            err_val,
+                            rb_from_bytes_ptr,
+                        )?
+                    };
+                    // SAFETY: `RustBufferC` is `#[repr(C)]` with a fixed layout of
+                    // {u64, u64, *mut u8} = 24 bytes on 64-bit. Transmuting to a
+                    // byte array of the same size is sound.
+                    let rb_bytes: [u8; std::mem::size_of::<RustBufferC>()] =
+                        unsafe { std::mem::transmute(rb) };
+                    // Write capacity at status_offsets[1], len at [2], data at [3]
+                    buffer[offset + status_offsets[1]
+                        ..offset + status_offsets[1] + std::mem::size_of::<u64>()]
+                        .copy_from_slice(&rb_bytes[..8]);
+                    buffer[offset + status_offsets[2]
+                        ..offset + status_offsets[2] + std::mem::size_of::<u64>()]
+                        .copy_from_slice(&rb_bytes[8..16]);
+                    let ptr_size = std::mem::size_of::<*mut u8>();
+                    buffer[offset + status_offsets[3]..offset + status_offsets[3] + ptr_size]
+                        .copy_from_slice(&rb_bytes[16..16 + ptr_size]);
+                }
+                // else: zero-initialized buffer is already correct for success status
             }
             other => {
                 return Err(napi::Error::from_reason(format!(

--- a/runtimes/napi/src/lib.rs
+++ b/runtimes/napi/src/lib.rs
@@ -42,7 +42,8 @@
 //! initialization time, and [`is_main_thread`] is the single predicate that every
 //! callback path consults to choose between these two strategies.
 
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::thread::ThreadId;
 
 use napi::bindgen_prelude::*;
@@ -68,11 +69,103 @@ use library::LibraryHandle;
 /// values directly or must dispatch through a threadsafe function.
 static MAIN_THREAD_ID: OnceLock<ThreadId> = OnceLock::new();
 
+/// Global module state for coordinating shutdown and tracking VTable TSFNs.
+///
+/// During env cleanup (triggered when Node.js is shutting down), the cleanup hook
+/// sets `shutdown` to `true` and aborts all tracked TSFNs. Aborting drops pending
+/// calls and their `SyncSender`s, which unblocks any Rust worker threads that are
+/// waiting on `rx.recv()`. This prevents SIGSEGV crashes on Linux where the shared
+/// library would otherwise be `dlclose()`'d while Rust threads still hold function
+/// pointers into it.
+struct ModuleState {
+    /// Set to `true` when the env cleanup hook fires.
+    shutdown: AtomicBool,
+    /// Raw handles of VTable TSFNs, so the cleanup hook can abort them all.
+    tsfn_handles: Mutex<Vec<napi::sys::napi_threadsafe_function>>,
+}
+
+// SAFETY: `napi_threadsafe_function` (a raw pointer) is designed to be used
+// across threads — napi's threadsafe function APIs are explicitly thread-safe.
+// The `Mutex` synchronizes access to the `Vec`.
+unsafe impl Send for ModuleState {}
+unsafe impl Sync for ModuleState {}
+
+static MODULE_STATE: OnceLock<ModuleState> = OnceLock::new();
+
+/// Returns `true` if the Node.js environment is shutting down.
+///
+/// Callback trampolines check this before attempting any work, so they can
+/// bail out early rather than touching a half-torn-down JS environment.
+pub fn is_shutting_down() -> bool {
+    MODULE_STATE
+        .get()
+        .is_some_and(|s| s.shutdown.load(Ordering::Acquire))
+}
+
+/// Register a VTable TSFN raw handle so the env cleanup hook can abort it.
+pub fn register_tsfn(raw: napi::sys::napi_threadsafe_function) {
+    if let Some(state) = MODULE_STATE.get() {
+        state
+            .tsfn_handles
+            .lock()
+            .expect("tsfn_handles lock poisoned")
+            .push(raw);
+    }
+}
+
+/// Env cleanup hook called by Node.js during shutdown.
+///
+/// # Safety
+/// Called by the napi runtime with the `data` pointer we registered (null in our case).
+unsafe extern "C" fn env_cleanup_hook(_data: *mut std::ffi::c_void) {
+    if let Some(state) = MODULE_STATE.get() {
+        // Signal all trampoline code to stop processing.
+        state.shutdown.store(true, Ordering::Release);
+
+        // Abort every tracked VTable TSFN. This drops any pending calls
+        // (and their SyncSenders), which unblocks Rust worker threads
+        // waiting on `rx.recv()`.
+        let handles = state
+            .tsfn_handles
+            .lock()
+            .expect("tsfn_handles lock poisoned");
+        for &handle in handles.iter() {
+            unsafe {
+                napi::sys::napi_release_threadsafe_function(
+                    handle,
+                    napi::sys::ThreadsafeFunctionReleaseMode::abort,
+                );
+            }
+        }
+    }
+}
+
+/// Install the env cleanup hook (idempotent — only the first call has effect).
+fn install_env_cleanup_hook(env: &Env) {
+    static INSTALLED: AtomicBool = AtomicBool::new(false);
+    if INSTALLED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        unsafe {
+            napi::sys::napi_add_env_cleanup_hook(
+                env.raw(),
+                Some(env_cleanup_hook),
+                std::ptr::null_mut(),
+            );
+        }
+    }
+}
+
 #[module_init]
 fn init() {
     MAIN_THREAD_ID
         .set(std::thread::current().id())
         .expect("module_init called twice");
+    let _ = MODULE_STATE.set(ModuleState {
+        shutdown: AtomicBool::new(false),
+        tsfn_handles: Mutex::new(Vec::new()),
+    });
 }
 
 /// Returns `true` if the calling thread is the main Node.js event-loop thread.
@@ -111,6 +204,10 @@ impl UniffiNativeModule {
     /// are bound to the foreign functions found in the loaded library.
     #[napi]
     pub fn register(&self, env: Env, definitions: JsObject) -> napi::Result<JsObject> {
+        // Install the env cleanup hook on the first register call. This is the
+        // earliest point where we have a valid `Env` (the `#[module_init]` ctor
+        // runs before the napi env exists).
+        install_env_cleanup_hook(&env);
         register::register(env, &self.handle, definitions)
     }
 }

--- a/runtimes/napi/src/library.rs
+++ b/runtimes/napi/src/library.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use std::ffi::c_void;
+use std::mem::ManuallyDrop;
 
 use dlopen2::raw::Library;
 use napi::Result;
@@ -14,8 +15,24 @@ use napi::Result;
 /// stored inside the napi struct for the lifetime of the Node.js module. All
 /// symbol lookups go through [`lookup_symbol`](Self::lookup_symbol), which
 /// returns raw function pointers that libffi later invokes.
+///
+/// The library is wrapped in [`ManuallyDrop`] so that `dlclose` is **never**
+/// called when the napi struct is garbage-collected. This is necessary because:
+///
+/// 1. Leaked closures and userdata hold raw function pointers into the library.
+/// 2. The library's tokio runtime may still have worker threads executing its
+///    code when Node.js GC runs during shutdown.
+///
+/// On macOS `dlclose` is typically a no-op, but on Linux it actually unmaps
+/// the library's code pages — causing SIGSEGV if any thread is still running
+/// library code or if a callback trampoline dereferences a function pointer
+/// into the unmapped region.
+///
+/// When issue #379 adds a proper resource registry and coordinated shutdown,
+/// this can be replaced with an explicit `close()` that waits for the tokio
+/// runtime to drain before calling `dlclose`.
 pub struct LibraryHandle {
-    pub lib: Library,
+    pub lib: ManuallyDrop<Library>,
 }
 
 // SAFETY: `LibraryHandle` wraps a `dlopen2::raw::Library`, which does not
@@ -34,7 +51,9 @@ impl LibraryHandle {
         let lib = Library::open(path)
             .map_err(|e| napi::Error::from_reason(format!("dlopen failed for '{path}': {e}")))?;
 
-        Ok(Self { lib })
+        Ok(Self {
+            lib: ManuallyDrop::new(lib),
+        })
     }
 
     /// Look up a symbol by name in the loaded library, returning a raw pointer.

--- a/runtimes/napi/src/register.rs
+++ b/runtimes/napi/src/register.rs
@@ -55,6 +55,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use libffi::middle::{arg, Arg, Cif, Closure, CodePtr};
 use napi::bindgen_prelude::*;
@@ -80,8 +81,8 @@ struct ResolvedFfiFunc {
 
 /// Shared definition context: callback and struct definitions parsed at registration time.
 struct DefinitionContext {
-    callbacks: Rc<HashMap<String, CallbackDef>>,
-    structs: Rc<HashMap<String, structs::StructDef>>,
+    callbacks: Arc<HashMap<String, CallbackDef>>,
+    structs: Arc<HashMap<String, structs::StructDef>>,
 }
 
 /// Resolve the three RustBuffer management symbols (`alloc`, `free`, `from_bytes`)
@@ -131,11 +132,11 @@ pub fn register(env: Env, handle: &LibraryHandle, definitions: JsObject) -> Resu
 
     // Parse callback definitions if present
     let callback_defs = parse_callbacks(&definitions)?;
-    let callback_defs = Rc::new(callback_defs);
+    let callback_defs = Arc::new(callback_defs);
 
     // Parse struct definitions if present
     let struct_defs = structs::parse_structs(&definitions)?;
-    let struct_defs = Rc::new(struct_defs);
+    let struct_defs = Arc::new(struct_defs);
 
     let functions: JsObject = definitions.get_named_property("functions")?;
     let mut result = env.create_object()?;
@@ -312,8 +313,8 @@ fn call_ffi_function(
                     env,
                     struct_def,
                     &js_obj,
-                    &defs.callbacks,
-                    &defs.structs,
+                    defs.callbacks.clone(),
+                    defs.structs.clone(),
                     rb_ops,
                 )?;
                 struct_ptrs.push(struct_ptr);

--- a/runtimes/napi/src/structs.rs
+++ b/runtimes/napi/src/structs.rs
@@ -226,6 +226,10 @@ pub unsafe extern "C" fn vtable_trampoline_callback(
     args: *const *const c_void,
     userdata: &VTableTrampolineUserdata,
 ) {
+    if crate::is_shutting_down() {
+        return;
+    }
+
     // Zero-initialize the result buffer so that early returns (from error paths
     // in the main-thread or cross-thread trampolines) produce a deterministic
     // zero value rather than leaving uninitialized memory that the Rust caller
@@ -1389,6 +1393,16 @@ pub fn create_callback_closure(
         )?
     };
     let mut tsfn = tsfn;
+
+    // Register the raw TSFN handle so the env cleanup hook can abort it at shutdown.
+    // This ensures that any Rust worker threads blocked on `rx.recv()` are unblocked
+    // when Node.js exits, preventing SIGSEGV on Linux from `dlclose()` racing with
+    // threads that still hold function pointers into the unloaded library.
+    crate::register_tsfn(tsfn.raw());
+
+    // Unref the TSFN so it does not prevent the Node.js event loop from exiting.
+    // The env cleanup hook will abort it if the process shuts down while Rust
+    // worker threads are still waiting.
     tsfn.unref(env)?;
 
     // SAFETY: `userdata_ptr` is a valid, uniquely-owned heap allocation.

--- a/runtimes/napi/src/structs.rs
+++ b/runtimes/napi/src/structs.rs
@@ -60,14 +60,13 @@ use std::collections::HashMap;
 use std::ffi::c_void;
 
 use libffi::low;
-use libffi::middle::{Cif, Closure, Type};
+use libffi::middle::{Cif, Closure};
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, JsObject, JsUnknown, NapiRaw, NapiValue, Result};
 
 use crate::callback::{
     c_arg_to_js, js_return_to_raw, raw_arg_to_js, read_raw_arg, CallbackDef, RawCallbackArg,
 };
-use crate::cif::ffi_type_for;
 use crate::ffi_c_types::{RustBufferC, RustBufferOps};
 use crate::ffi_type::FfiTypeDesc;
 use crate::fn_pointer;
@@ -386,29 +385,45 @@ unsafe fn vtable_trampoline_main_thread(
     let call_result = js_fn.call(None, &js_args);
 
     if userdata.out_return {
-        // UniffiResult protocol: extract code, pointee, and errorBuf from the
-        // returned JS object and write them to the C out-pointers.
         if let Ok(js_ret) = call_result {
-            if let Ok(result_obj) = JsObject::from_raw(userdata.raw_env, js_ret.raw()) {
-                write_uniffi_result_status(
-                    &result_obj,
-                    status_ptr,
-                    userdata.raw_env,
-                    userdata.rb_ops.from_bytes_ptr,
-                );
-                if !out_return_ptr.is_null() {
-                    if let Ok(pointee) = result_obj.get_named_property::<napi::JsUnknown>("pointee")
-                    {
-                        write_return_value(
-                            out_return_ptr,
-                            &userdata.ret_type,
-                            userdata.raw_env,
-                            pointee,
-                            userdata.rb_ops.from_bytes_ptr,
-                            false,
-                        );
+            if userdata.has_rust_call_status {
+                // UniffiResult protocol: extract code, pointee, and errorBuf from the
+                // returned JS object and write them to the C out-pointers.
+                if let Ok(result_obj) = JsObject::from_raw(userdata.raw_env, js_ret.raw()) {
+                    write_uniffi_result_status(
+                        &result_obj,
+                        status_ptr,
+                        userdata.raw_env,
+                        userdata.rb_ops.from_bytes_ptr,
+                    );
+                    if !out_return_ptr.is_null() {
+                        if let Ok(pointee) =
+                            result_obj.get_named_property::<napi::JsUnknown>("pointee")
+                        {
+                            write_return_value(
+                                out_return_ptr,
+                                &userdata.ret_type,
+                                userdata.raw_env,
+                                pointee,
+                                userdata.rb_ops.from_bytes_ptr,
+                                false,
+                            );
+                        }
                     }
                 }
+            } else if !out_return_ptr.is_null() {
+                // Direct struct return (no UniffiResult wrapping).
+                // The JS function returned the struct value directly.
+                let env = Env::from_raw(userdata.raw_env);
+                write_struct_to_out_pointer(
+                    out_return_ptr,
+                    &userdata.ret_type,
+                    &env,
+                    js_ret,
+                    &userdata.callback_defs,
+                    &userdata.struct_defs,
+                    &userdata.rb_ops,
+                );
             }
         }
     } else {
@@ -747,6 +762,125 @@ unsafe fn write_return_value(
     }
 }
 
+/// Marshal a JS struct object into a byte buffer matching the C struct layout.
+///
+/// Handles `UInt64`/`Handle` fields (BigInt) and `Callback` fields (minting closures).
+/// Returns `None` if the type is not a struct, the struct is unknown, or any field
+/// fails to marshal.
+fn marshal_js_struct_to_c_bytes(
+    env: &Env,
+    ret_type: &FfiTypeDesc,
+    js_ret: napi::JsUnknown,
+    callback_defs: &HashMap<String, CallbackDef>,
+    struct_defs: &HashMap<String, StructDef>,
+    rb_ops: &RustBufferOps,
+) -> Option<Vec<u8>> {
+    let FfiTypeDesc::Struct(struct_name) = ret_type else {
+        return None;
+    };
+    let struct_def = struct_defs.get(struct_name)?;
+    // SAFETY: `env.raw()` is valid (main thread) and `js_ret.raw()` is a
+    // live napi_value from the just-completed JS function call.
+    let js_obj = unsafe { napi::JsObject::from_raw(env.raw(), js_ret.raw()).ok()? };
+
+    let field_ffi_types: Vec<libffi::middle::Type> = struct_def
+        .fields
+        .iter()
+        .map(|f| crate::cif::ffi_type_for(&f.field_type, struct_defs))
+        .collect::<napi::Result<Vec<_>>>()
+        .ok()?;
+    let struct_type = libffi::middle::Type::structure(field_ffi_types);
+    fn_pointer::prep_struct_type(&struct_type).ok()?;
+
+    let total_size = fn_pointer::ffi_type_size(&struct_type);
+    let offsets = fn_pointer::struct_field_offsets(&struct_type);
+    let mut buffer = vec![0u8; total_size];
+
+    for (i, field) in struct_def.fields.iter().enumerate() {
+        let offset = offsets[i];
+        let js_val: napi::JsUnknown = js_obj.get_named_property(&field.name).ok()?;
+
+        match &field.field_type {
+            FfiTypeDesc::UInt64 | FfiTypeDesc::Handle => {
+                // SAFETY: `env.raw()` and `js_val.raw()` are valid napi handles
+                // on the main thread. The JS value is a BigInt.
+                unsafe {
+                    let bigint = napi::JsBigInt::from_raw(env.raw(), js_val.raw()).ok()?;
+                    let (v, _) = bigint.get_u64().ok()?;
+                    buffer[offset..offset + 8].copy_from_slice(&v.to_ne_bytes());
+                }
+            }
+            FfiTypeDesc::Callback(cb_name) => {
+                let cb_def = callback_defs.get(cb_name)?;
+                // SAFETY: extracting the raw napi_value from a live JsUnknown.
+                let fn_ptr = create_callback_closure(
+                    env,
+                    unsafe { js_val.raw() },
+                    cb_def,
+                    callback_defs,
+                    struct_defs,
+                    rb_ops,
+                )
+                .ok()?;
+                let ptr_bytes = (fn_ptr as usize).to_ne_bytes();
+                let ptr_size = std::mem::size_of::<usize>();
+                buffer[offset..offset + ptr_size].copy_from_slice(&ptr_bytes);
+            }
+            _ => {
+                #[cfg(debug_assertions)]
+                eprintln!(
+                    "marshal_js_struct_to_c_bytes: unhandled field type {:?} for '{}'",
+                    field.field_type, field.name
+                );
+                return None;
+            }
+        }
+    }
+
+    Some(buffer)
+}
+
+/// Marshal a JS struct and write it directly to a destination pointer (same-thread path).
+///
+/// # Safety
+///
+/// `dest` must point to a writable buffer with sufficient size for the struct.
+unsafe fn write_struct_to_out_pointer(
+    dest: *mut c_void,
+    ret_type: &FfiTypeDesc,
+    env: &Env,
+    js_ret: napi::JsUnknown,
+    callback_defs: &HashMap<String, CallbackDef>,
+    struct_defs: &HashMap<String, StructDef>,
+    rb_ops: &RustBufferOps,
+) -> bool {
+    let Some(bytes) =
+        marshal_js_struct_to_c_bytes(env, ret_type, js_ret, callback_defs, struct_defs, rb_ops)
+    else {
+        return false;
+    };
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest as *mut u8, bytes.len());
+    true
+}
+
+/// Marshal a JS struct into `RawCallbackArg::StructBytes` for cross-thread transport.
+fn marshal_struct_return_to_bytes(
+    env: &Env,
+    ret_type: &FfiTypeDesc,
+    js_ret: napi::JsUnknown,
+    userdata: &VTableTrampolineUserdata,
+) -> Option<RawCallbackArg> {
+    marshal_js_struct_to_c_bytes(
+        env,
+        ret_type,
+        js_ret,
+        &userdata.callback_defs,
+        &userdata.struct_defs,
+        &userdata.rb_ops,
+    )
+    .map(RawCallbackArg::StructBytes)
+}
+
 /// Write a [`RawCallbackArg`] return value into a destination buffer (cross-thread path).
 ///
 /// This is the cross-thread counterpart to [`write_return_value`]. The JS thread has
@@ -843,6 +977,9 @@ unsafe fn write_raw_return_value(
             {
                 *(dest as *mut RustBufferC) = rb;
             }
+        }
+        (FfiTypeDesc::Struct(_), RawCallbackArg::StructBytes(bytes)) => {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest as *mut u8, bytes.len());
         }
         _ => {
             #[cfg(debug_assertions)]
@@ -974,37 +1111,55 @@ fn vtable_tsfn_handler(env: &Env, userdata: &VTableTrampolineUserdata, request: 
     }
 
     if userdata.out_return {
-        // UniffiResult protocol: extract code and pointee from the returned object.
-        let (rcs_code, return_value) = match call_result {
-            Ok(js_ret) => {
-                if let Ok(result_obj) =
-                    unsafe { JsObject::from_raw(userdata.raw_env, js_ret.raw()) }
-                {
-                    let code = result_obj
-                        .get_named_property::<i32>("code")
-                        .map(|c| c as i8)
-                        .unwrap_or(request.rust_call_status_code);
-                    let pointee = if matches!(userdata.ret_type, FfiTypeDesc::Void) {
-                        None
+        if userdata.has_rust_call_status {
+            // UniffiResult protocol: extract code and pointee from the returned object.
+            let (rcs_code, return_value) = match call_result {
+                Ok(js_ret) => {
+                    if let Ok(result_obj) =
+                        unsafe { JsObject::from_raw(userdata.raw_env, js_ret.raw()) }
+                    {
+                        let code = result_obj
+                            .get_named_property::<i32>("code")
+                            .map(|c| c as i8)
+                            .unwrap_or(request.rust_call_status_code);
+                        let pointee = if matches!(userdata.ret_type, FfiTypeDesc::Void) {
+                            None
+                        } else {
+                            result_obj
+                                .get_named_property::<napi::JsUnknown>("pointee")
+                                .ok()
+                                .and_then(|v| js_return_to_raw(env, &userdata.ret_type, v))
+                        };
+                        (code, pointee)
                     } else {
-                        result_obj
-                            .get_named_property::<napi::JsUnknown>("pointee")
-                            .ok()
-                            .and_then(|v| js_return_to_raw(env, &userdata.ret_type, v))
-                    };
-                    (code, pointee)
-                } else {
-                    (request.rust_call_status_code, None)
+                        (request.rust_call_status_code, None)
+                    }
                 }
-            }
-            Err(_) => (request.rust_call_status_code, None),
-        };
+                Err(_) => (request.rust_call_status_code, None),
+            };
 
-        if let Some(tx) = request.response_tx {
-            let _ = tx.send(VTableCallResponse {
-                return_value,
-                rust_call_status_code: rcs_code,
-            });
+            if let Some(tx) = request.response_tx {
+                let _ = tx.send(VTableCallResponse {
+                    return_value,
+                    rust_call_status_code: rcs_code,
+                });
+            }
+        } else {
+            // Direct struct return (no UniffiResult wrapping).
+            // Marshal the struct to bytes on the JS thread.
+            let return_value = match call_result {
+                Ok(js_ret) => {
+                    marshal_struct_return_to_bytes(env, &userdata.ret_type, js_ret, userdata)
+                }
+                Err(_) => None,
+            };
+
+            if let Some(tx) = request.response_tx {
+                let _ = tx.send(VTableCallResponse {
+                    return_value,
+                    rust_call_status_code: 0,
+                });
+            }
         }
     } else {
         // Pass-by-reference status protocol.
@@ -1122,131 +1277,16 @@ pub fn build_vtable_struct(
                     ))
                 })?;
 
-                // Get the JS function from the object.
                 let js_fn_val: JsUnknown = js_obj.get_named_property(&field.name)?;
-                // SAFETY: Extracting the raw napi_value from a live JsUnknown on the
-                // current env thread.
-                let raw_fn_val = unsafe { js_fn_val.raw() };
-
-                // Create a persistent reference (refcount = 1) to prevent GC.
-                // This reference is intentionally never deleted — see "Lifetime
-                // management" in the module docs.
-                let mut fn_ref: napi::sys::napi_ref = std::ptr::null_mut();
-                // SAFETY: `env.raw()` is the current valid env, `raw_fn_val` is a
-                // live napi_value. The initial refcount of 1 keeps the JS function
-                // alive for the process lifetime.
-                let ref_status = unsafe {
-                    napi::sys::napi_create_reference(env.raw(), raw_fn_val, 1, &mut fn_ref)
-                };
-                if ref_status != napi::sys::Status::napi_ok {
-                    return Err(napi::Error::from_reason(format!(
-                        "Failed to create reference for VTable field '{}'",
-                        field.name
-                    )));
-                }
-
-                // Build CIF for this callback:
-                // declared args + optional out-return pointer + optional RustCallStatus pointer
-                let mut cif_arg_types: Vec<Type> = cb_def
-                    .args
-                    .iter()
-                    .map(|a| ffi_type_for(a, struct_defs))
-                    .collect::<napi::Result<Vec<_>>>()?;
-                if cb_def.out_return {
-                    // Out-return pointer: an extra pointer arg before RustCallStatus
-                    cif_arg_types.push(Type::pointer());
-                }
-                if cb_def.has_rust_call_status {
-                    cif_arg_types.push(Type::pointer());
-                }
-                // When out_return is true, the C function returns void; the return
-                // value is written through the out-pointer instead.
-                let cif_ret_type = if cb_def.out_return {
-                    Type::void()
-                } else {
-                    ffi_type_for(&cb_def.ret, struct_defs)?
-                };
-                let cif = Cif::new(cif_arg_types, cif_ret_type);
-
-                // Create userdata
-                let userdata = Box::new(VTableTrampolineUserdata {
-                    raw_env: env.raw(),
-                    fn_ref,
-                    arg_types: cb_def.args.clone(),
-                    ret_type: cb_def.ret.clone(),
-                    has_rust_call_status: cb_def.has_rust_call_status,
-                    out_return: cb_def.out_return,
-                    tsfn: None, // Will be set below.
-                    rb_ops: *rb_ops,
-                    callback_defs: callback_defs.clone(),
-                    struct_defs: struct_defs.clone(),
-                });
-
-                // Leak userdata to a raw pointer for a stable address.
-                // Do NOT create &'static ref yet — we still need to mutate tsfn.
-                // This is step 1 of the sequencing described in the function docs.
-                let userdata_ptr = Box::into_raw(userdata);
-
-                // Create a no-op JS function for the ThreadsafeFunction base. The ThreadsafeFunction auto-calls its base
-                // function with the callback's returned Vec<JsUnknown>. By using a no-op,
-                // the auto-call is harmless — the real JS function is called manually in
-                // vtable_tsfn_handler via fn_ref.
-                let noop_fn =
-                    env.create_function_from_closure("vtable_tsfn_noop", |_ctx| Ok(()))?;
-
-                // Step 2: create the ThreadsafeFunction. The closure captures the userdata address
-                // as a `usize` rather than a raw pointer, because raw pointers are
-                // not `Send` and the closure must be `Send` for `ThreadsafeFunction`.
-                let tsfn: ThreadsafeFunction<VTableCallRequest, ErrorStrategy::Fatal> = {
-                    let ud_addr = userdata_ptr as usize;
-                    noop_fn.create_threadsafe_function(
-                        0,
-                        move |ctx: napi::threadsafe_function::ThreadSafeCallContext<
-                            VTableCallRequest,
-                        >| {
-                            // SAFETY: `ud_addr` was obtained from `Box::into_raw` above,
-                            // so the allocation is valid and leaked (lives forever).
-                            // `ud_addr` was set before any concurrent access is possible
-                            // (the ThreadsafeFunction hasn't been called yet — it is created here and
-                            // only becomes callable after `tsfn.call()` is invoked by a
-                            // trampoline, which cannot happen until `build_vtable_struct`
-                            // returns the VTable pointer to the Rust library).
-                            let ud = unsafe { &*(ud_addr as *const VTableTrampolineUserdata) };
-                            vtable_tsfn_handler(&ctx.env, ud, ctx.value);
-                            Ok(Vec::<napi::JsUnknown>::new())
-                        },
-                    )?
-                };
-
-                // Unref so it doesn't keep the event loop alive.
-                let mut tsfn = tsfn;
-                tsfn.unref(env)?;
-
-                // Step 3: store the ThreadsafeFunction into the userdata via raw pointer mutation.
-                // SAFETY: `userdata_ptr` is a valid, uniquely-owned heap allocation
-                // (no other references exist yet). We are still on the main thread
-                // and no concurrent access is possible.
-                unsafe {
-                    (*userdata_ptr).tsfn = Some(tsfn);
-                }
-
-                // Step 4: all mutation is complete. NOW it is safe to create the
-                // `&'static` reference that `Closure::new` requires.
-                // SAFETY: The allocation is leaked (lives forever) and fully
-                // initialized. No further mutation occurs after this point.
-                let userdata_ref: &'static VTableTrampolineUserdata = unsafe { &*userdata_ptr };
-
-                // Create closure
-                let closure = Closure::new(cif, vtable_trampoline_callback, userdata_ref);
-
-                // Extract the C function pointer from the closure.
-                let fn_ptr: *const c_void = *closure.code_ptr() as *const std::ffi::c_void;
-
-                // Intentionally leak the closure. The function pointer we extracted
-                // above points into the closure's executable trampoline memory. If
-                // the closure were dropped, the function pointer would dangle.
-                std::mem::forget(closure);
-
+                // SAFETY: extracting the raw napi_value from a live JsUnknown.
+                let fn_ptr = create_callback_closure(
+                    env,
+                    unsafe { js_fn_val.raw() },
+                    cb_def,
+                    callback_defs,
+                    struct_defs,
+                    rb_ops,
+                )?;
                 vtable_data.push(fn_ptr);
             }
             _ => {
@@ -1266,4 +1306,103 @@ pub fn build_vtable_struct(
     std::mem::forget(vtable_data);
 
     Ok(ptr)
+}
+
+/// Create a libffi closure from a JS function, returning a C function pointer.
+///
+/// This is the dynamic counterpart to VTable closure registration: given a JS function
+/// and a callback definition, it mints a new libffi closure whose code pointer can be
+/// stored in a C struct field or passed as a function pointer to Rust.
+///
+/// The closure and its userdata are intentionally leaked (process-lifetime), matching
+/// the VTable closure model.
+///
+/// # Safety
+///
+/// Must be called on the JS main thread (accesses napi env).
+pub fn create_callback_closure(
+    env: &Env,
+    js_fn_val: napi::sys::napi_value,
+    cb_def: &CallbackDef,
+    callback_defs: &HashMap<String, CallbackDef>,
+    struct_defs: &HashMap<String, StructDef>,
+    rb_ops: &RustBufferOps,
+) -> napi::Result<*const c_void> {
+    // Create a persistent reference (refcount=1) to prevent GC.
+    let mut fn_ref: napi::sys::napi_ref = std::ptr::null_mut();
+    // SAFETY: `env.raw()` is valid (main thread), `js_fn_val` is a live
+    // napi_value. The refcount of 1 keeps the JS function alive permanently.
+    let ref_status =
+        unsafe { napi::sys::napi_create_reference(env.raw(), js_fn_val, 1, &mut fn_ref) };
+    if ref_status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_reason(
+            "Failed to create reference for callback closure JS function",
+        ));
+    }
+
+    // Build CIF: declared args + optional out-return pointer + optional RustCallStatus pointer
+    let mut cif_arg_types: Vec<libffi::middle::Type> = cb_def
+        .args
+        .iter()
+        .map(|a| crate::cif::ffi_type_for(a, struct_defs))
+        .collect::<napi::Result<Vec<_>>>()?;
+    if cb_def.out_return {
+        cif_arg_types.push(libffi::middle::Type::pointer());
+    }
+    if cb_def.has_rust_call_status {
+        cif_arg_types.push(libffi::middle::Type::pointer());
+    }
+    let cif_ret_type = if cb_def.out_return {
+        libffi::middle::Type::void()
+    } else {
+        crate::cif::ffi_type_for(&cb_def.ret, struct_defs)?
+    };
+    let cif = Cif::new(cif_arg_types, cif_ret_type);
+
+    let userdata = Box::new(VTableTrampolineUserdata {
+        raw_env: env.raw(),
+        fn_ref,
+        arg_types: cb_def.args.clone(),
+        ret_type: cb_def.ret.clone(),
+        has_rust_call_status: cb_def.has_rust_call_status,
+        out_return: cb_def.out_return,
+        tsfn: None,
+        rb_ops: *rb_ops,
+        callback_defs: callback_defs.clone(),
+        struct_defs: struct_defs.clone(),
+    });
+    let userdata_ptr = Box::into_raw(userdata);
+
+    // Create ThreadsafeFunction for cross-thread support.
+    let noop_fn = env.create_function_from_closure("cb_closure_tsfn_noop", |_ctx| Ok(()))?;
+    let tsfn: ThreadsafeFunction<VTableCallRequest, ErrorStrategy::Fatal> = {
+        let ud_addr = userdata_ptr as usize;
+        noop_fn.create_threadsafe_function(
+            0,
+            move |ctx: napi::threadsafe_function::ThreadSafeCallContext<VTableCallRequest>| {
+                // SAFETY: `ud_addr` was obtained from `Box::into_raw` and
+                // is leaked (lives forever). No concurrent mutation.
+                let ud = unsafe { &*(ud_addr as *const VTableTrampolineUserdata) };
+                vtable_tsfn_handler(&ctx.env, ud, ctx.value);
+                Ok(Vec::<napi::JsUnknown>::new())
+            },
+        )?
+    };
+    let mut tsfn = tsfn;
+    tsfn.unref(env)?;
+
+    // SAFETY: `userdata_ptr` is a valid, uniquely-owned heap allocation.
+    // We are still on the main thread; no concurrent access is possible yet.
+    unsafe {
+        (*userdata_ptr).tsfn = Some(tsfn);
+    }
+
+    // SAFETY: The allocation is leaked (lives forever) and fully initialized.
+    // No further mutation occurs after this point.
+    let userdata_ref: &'static VTableTrampolineUserdata = unsafe { &*userdata_ptr };
+    let closure = Closure::new(cif, vtable_trampoline_callback, userdata_ref);
+    let fn_ptr: *const c_void = *closure.code_ptr() as *const c_void;
+    std::mem::forget(closure);
+
+    Ok(fn_ptr)
 }

--- a/runtimes/napi/src/structs.rs
+++ b/runtimes/napi/src/structs.rs
@@ -360,7 +360,11 @@ unsafe fn vtable_trampoline_main_thread(
         // `*mut RustCallStatusForVTable` is layout-compatible because `code: i8`
         // is the first field of both structs.
         status_ptr = *(rcs_arg_ptr as *const *mut RustCallStatusForVTable);
+    }
 
+    // When out_return is true, the JS callback uses the UniffiResult protocol:
+    // it returns { code, pointee?, errorBuf? } instead of accepting a status arg.
+    if userdata.has_rust_call_status && !userdata.out_return {
         let code = if !status_ptr.is_null() {
             (*status_ptr).code as i32
         } else {
@@ -381,33 +385,47 @@ unsafe fn vtable_trampoline_main_thread(
 
     let call_result = js_fn.call(None, &js_args);
 
-    // Write back the (possibly updated) RustCallStatus code from JS.
-    if userdata.has_rust_call_status && !status_ptr.is_null() {
-        if let Some(js_status_unknown) = js_args.last() {
-            if let Ok(js_status_obj) = JsObject::from_raw(userdata.raw_env, js_status_unknown.raw())
-            {
-                if let Ok(code_val) = js_status_obj.get_named_property::<i32>("code") {
-                    // SAFETY: `status_ptr` is non-null (checked above) and points
-                    // to the caller's stack-allocated RustCallStatus.
-                    (*status_ptr).code = code_val as i8;
+    if userdata.out_return {
+        // UniffiResult protocol: extract code, pointee, and errorBuf from the
+        // returned JS object and write them to the C out-pointers.
+        if let Ok(js_ret) = call_result {
+            if let Ok(result_obj) = JsObject::from_raw(userdata.raw_env, js_ret.raw()) {
+                write_uniffi_result_status(
+                    &result_obj,
+                    status_ptr,
+                    userdata.raw_env,
+                    userdata.rb_ops.from_bytes_ptr,
+                );
+                if !out_return_ptr.is_null() {
+                    if let Ok(pointee) = result_obj.get_named_property::<napi::JsUnknown>("pointee")
+                    {
+                        write_return_value(
+                            out_return_ptr,
+                            &userdata.ret_type,
+                            userdata.raw_env,
+                            pointee,
+                            userdata.rb_ops.from_bytes_ptr,
+                            false,
+                        );
+                    }
                 }
             }
         }
-    }
+    } else {
+        // Pass-by-reference status protocol: read back the mutated status object.
+        if userdata.has_rust_call_status && !status_ptr.is_null() {
+            if let Some(js_status_unknown) = js_args.last() {
+                if let Ok(js_status_obj) =
+                    JsObject::from_raw(userdata.raw_env, js_status_unknown.raw())
+                {
+                    if let Ok(code_val) = js_status_obj.get_named_property::<i32>("code") {
+                        (*status_ptr).code = code_val as i8;
+                    }
+                }
+            }
+        }
 
-    if let Ok(js_ret) = call_result {
-        if userdata.out_return && !out_return_ptr.is_null() {
-            // Write the return value to the out-pointer at natural type width
-            // (no ffi_arg widening — the out-pointer is a concrete typed variable).
-            write_return_value(
-                out_return_ptr,
-                &userdata.ret_type,
-                userdata.raw_env,
-                js_ret,
-                userdata.rb_ops.from_bytes_ptr,
-                false,
-            );
-        } else {
+        if let Ok(js_ret) = call_result {
             write_return_value(
                 result as *mut c_void,
                 &userdata.ret_type,
@@ -546,6 +564,37 @@ unsafe fn vtable_trampoline_cross_thread(
         };
 
         tsfn.call(request, ThreadsafeFunctionCallMode::NonBlocking);
+    }
+}
+
+/// Extract the `code` and `errorBuf` fields from a JS UniffiResult object and
+/// write them into the C `RustCallStatus` via `status_ptr`.
+///
+/// # Safety
+///
+/// `status_ptr` must be null or point to a valid `RustCallStatus` on the caller's stack.
+unsafe fn write_uniffi_result_status(
+    result_obj: &JsObject,
+    status_ptr: *mut RustCallStatusForVTable,
+    raw_env: napi::sys::napi_env,
+    rb_from_bytes_ptr: *const c_void,
+) {
+    if status_ptr.is_null() {
+        return;
+    }
+    let Ok(code_val) = result_obj.get_named_property::<i32>("code") else {
+        return;
+    };
+    (*status_ptr).code = code_val as i8;
+    // Only propagate error details when the status indicates failure.
+    if code_val != 0 {
+        if let Ok(err_buf) = result_obj.get_named_property::<napi::JsUnknown>("errorBuf") {
+            if let Ok(rb) =
+                napi_utils::js_uint8array_to_rust_buffer(raw_env, err_buf, rb_from_bytes_ptr)
+            {
+                (*status_ptr).error_buf = rb;
+            }
+        }
     }
 }
 
@@ -895,7 +944,8 @@ fn vtable_tsfn_handler(env: &Env, userdata: &VTableTrampolineUserdata, request: 
         js_args.push(js_val);
     }
 
-    if userdata.has_rust_call_status {
+    // When out_return is true, the JS callback uses the UniffiResult protocol.
+    if userdata.has_rust_call_status && !userdata.out_return {
         let mut js_status = match env.create_object() {
             Ok(o) => o,
             Err(_) => {
@@ -923,45 +973,81 @@ fn vtable_tsfn_handler(env: &Env, userdata: &VTableTrampolineUserdata, request: 
         return;
     }
 
-    let rcs_code = if userdata.has_rust_call_status {
-        if let Some(js_status_unknown) = js_args.last() {
-            if let Ok(js_status_obj) =
-                unsafe { JsObject::from_raw(userdata.raw_env, js_status_unknown.raw()) }
-            {
-                js_status_obj
-                    .get_named_property::<i32>("code")
-                    .map(|c| c as i8)
-                    .unwrap_or(request.rust_call_status_code)
+    if userdata.out_return {
+        // UniffiResult protocol: extract code and pointee from the returned object.
+        let (rcs_code, return_value) = match call_result {
+            Ok(js_ret) => {
+                if let Ok(result_obj) =
+                    unsafe { JsObject::from_raw(userdata.raw_env, js_ret.raw()) }
+                {
+                    let code = result_obj
+                        .get_named_property::<i32>("code")
+                        .map(|c| c as i8)
+                        .unwrap_or(request.rust_call_status_code);
+                    let pointee = if matches!(userdata.ret_type, FfiTypeDesc::Void) {
+                        None
+                    } else {
+                        result_obj
+                            .get_named_property::<napi::JsUnknown>("pointee")
+                            .ok()
+                            .and_then(|v| js_return_to_raw(env, &userdata.ret_type, v))
+                    };
+                    (code, pointee)
+                } else {
+                    (request.rust_call_status_code, None)
+                }
+            }
+            Err(_) => (request.rust_call_status_code, None),
+        };
+
+        if let Some(tx) = request.response_tx {
+            let _ = tx.send(VTableCallResponse {
+                return_value,
+                rust_call_status_code: rcs_code,
+            });
+        }
+    } else {
+        // Pass-by-reference status protocol.
+        let rcs_code = if userdata.has_rust_call_status {
+            if let Some(js_status_unknown) = js_args.last() {
+                if let Ok(js_status_obj) =
+                    unsafe { JsObject::from_raw(userdata.raw_env, js_status_unknown.raw()) }
+                {
+                    js_status_obj
+                        .get_named_property::<i32>("code")
+                        .map(|c| c as i8)
+                        .unwrap_or(request.rust_call_status_code)
+                } else {
+                    request.rust_call_status_code
+                }
             } else {
                 request.rust_call_status_code
             }
         } else {
-            request.rust_call_status_code
-        }
-    } else {
-        0
-    };
+            0
+        };
 
-    let return_value = match call_result {
-        Ok(js_ret) => {
-            if matches!(userdata.ret_type, FfiTypeDesc::Void) {
-                None
-            } else {
-                js_return_to_raw(env, &userdata.ret_type, js_ret)
+        let return_value = match call_result {
+            Ok(js_ret) => {
+                if matches!(userdata.ret_type, FfiTypeDesc::Void) {
+                    None
+                } else {
+                    js_return_to_raw(env, &userdata.ret_type, js_ret)
+                }
             }
-        }
-        Err(_) => None,
-    };
+            Err(_) => None,
+        };
 
-    if let Some(tx) = request.response_tx {
-        let _ = tx.send(VTableCallResponse {
-            return_value,
-            rust_call_status_code: rcs_code,
-        });
+        if let Some(tx) = request.response_tx {
+            let _ = tx.send(VTableCallResponse {
+                return_value,
+                rust_call_status_code: rcs_code,
+            });
+        }
     }
 }
 
-/// Minimal `#[repr(C)]` projection of `RustCallStatus`, containing only the `code` field.
+/// `#[repr(C)]` projection of `RustCallStatus`, layout-compatible with the real struct.
 ///
 /// The full `RustCallStatus` struct (defined in the UniFFI runtime) looks like:
 ///
@@ -973,15 +1059,12 @@ fn vtable_tsfn_handler(env: &Env, userdata: &VTableTrampolineUserdata, request: 
 /// }
 /// ```
 ///
-/// The trampoline only needs to read and write the `code` field. Because `code` is the
-/// *first* field and both structs are `#[repr(C)]`, this partial view is layout-compatible:
-/// a `*mut RustCallStatus` can be safely cast to `*mut RustCallStatusForVTable` and the
-/// `code` field will be at the correct offset (zero).
+/// Because both structs are `#[repr(C)]` and the fields match, a `*mut RustCallStatus`
+/// can be safely cast to `*mut RustCallStatusForVTable`.
 #[repr(C)]
 struct RustCallStatusForVTable {
     code: i8,
-    // The `error_buf: RustBuffer` field follows in the full struct, but we never
-    // touch it in the trampoline — the Rust caller manages it.
+    error_buf: RustBufferC,
 }
 
 /// Build a C-compatible VTable struct from a JS object implementing a UniFFI trait.

--- a/runtimes/napi/src/structs.rs
+++ b/runtimes/napi/src/structs.rs
@@ -58,6 +58,7 @@
 
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::sync::Arc;
 
 use libffi::low;
 use libffi::middle::{Cif, Closure};
@@ -187,10 +188,10 @@ pub struct VTableTrampolineUserdata {
     pub rb_ops: RustBufferOps,
     /// All callback definitions, needed for wrapping `Callback`-typed arguments
     /// (C function pointers) as callable JS functions.
-    pub callback_defs: HashMap<String, CallbackDef>,
+    pub callback_defs: Arc<HashMap<String, CallbackDef>>,
     /// All struct definitions, needed for struct-by-value marshalling when
     /// wrapping C function pointers.
-    pub struct_defs: HashMap<String, StructDef>,
+    pub struct_defs: Arc<HashMap<String, StructDef>>,
 }
 
 // SAFETY: `raw_env` and `fn_ref` are only dereferenced on the main (JS) thread.
@@ -424,8 +425,8 @@ unsafe fn vtable_trampoline_main_thread(
                     &userdata.ret_type,
                     &env,
                     js_ret,
-                    &userdata.callback_defs,
-                    &userdata.struct_defs,
+                    userdata.callback_defs.clone(),
+                    userdata.struct_defs.clone(),
                     &userdata.rb_ops,
                 );
             }
@@ -775,8 +776,8 @@ fn marshal_js_struct_to_c_bytes(
     env: &Env,
     ret_type: &FfiTypeDesc,
     js_ret: napi::JsUnknown,
-    callback_defs: &HashMap<String, CallbackDef>,
-    struct_defs: &HashMap<String, StructDef>,
+    callback_defs: Arc<HashMap<String, CallbackDef>>,
+    struct_defs: Arc<HashMap<String, StructDef>>,
     rb_ops: &RustBufferOps,
 ) -> Option<Vec<u8>> {
     let FfiTypeDesc::Struct(struct_name) = ret_type else {
@@ -790,7 +791,7 @@ fn marshal_js_struct_to_c_bytes(
     let field_ffi_types: Vec<libffi::middle::Type> = struct_def
         .fields
         .iter()
-        .map(|f| crate::cif::ffi_type_for(&f.field_type, struct_defs))
+        .map(|f| crate::cif::ffi_type_for(&f.field_type, &struct_defs))
         .collect::<napi::Result<Vec<_>>>()
         .ok()?;
     let struct_type = libffi::middle::Type::structure(field_ffi_types);
@@ -821,8 +822,8 @@ fn marshal_js_struct_to_c_bytes(
                     env,
                     unsafe { js_val.raw() },
                     cb_def,
-                    callback_defs,
-                    struct_defs,
+                    callback_defs.clone(),
+                    struct_defs.clone(),
                     rb_ops,
                 )
                 .ok()?;
@@ -854,8 +855,8 @@ unsafe fn write_struct_to_out_pointer(
     ret_type: &FfiTypeDesc,
     env: &Env,
     js_ret: napi::JsUnknown,
-    callback_defs: &HashMap<String, CallbackDef>,
-    struct_defs: &HashMap<String, StructDef>,
+    callback_defs: Arc<HashMap<String, CallbackDef>>,
+    struct_defs: Arc<HashMap<String, StructDef>>,
     rb_ops: &RustBufferOps,
 ) -> bool {
     let Some(bytes) =
@@ -878,8 +879,8 @@ fn marshal_struct_return_to_bytes(
         env,
         ret_type,
         js_ret,
-        &userdata.callback_defs,
-        &userdata.struct_defs,
+        userdata.callback_defs.clone(),
+        userdata.struct_defs.clone(),
         &userdata.rb_ops,
     )
     .map(RawCallbackArg::StructBytes)
@@ -1264,8 +1265,8 @@ pub fn build_vtable_struct(
     env: &Env,
     struct_def: &StructDef,
     js_obj: &JsObject,
-    callback_defs: &HashMap<String, CallbackDef>,
-    struct_defs: &HashMap<String, StructDef>,
+    callback_defs: Arc<HashMap<String, CallbackDef>>,
+    struct_defs: Arc<HashMap<String, StructDef>>,
     rb_ops: &RustBufferOps,
 ) -> Result<*const c_void> {
     let field_count = struct_def.fields.len();
@@ -1287,8 +1288,8 @@ pub fn build_vtable_struct(
                     env,
                     unsafe { js_fn_val.raw() },
                     cb_def,
-                    callback_defs,
-                    struct_defs,
+                    callback_defs.clone(),
+                    struct_defs.clone(),
                     rb_ops,
                 )?;
                 vtable_data.push(fn_ptr);
@@ -1328,8 +1329,8 @@ pub fn create_callback_closure(
     env: &Env,
     js_fn_val: napi::sys::napi_value,
     cb_def: &CallbackDef,
-    callback_defs: &HashMap<String, CallbackDef>,
-    struct_defs: &HashMap<String, StructDef>,
+    callback_defs: Arc<HashMap<String, CallbackDef>>,
+    struct_defs: Arc<HashMap<String, StructDef>>,
     rb_ops: &RustBufferOps,
 ) -> napi::Result<*const c_void> {
     // Create a persistent reference (refcount=1) to prevent GC.
@@ -1348,7 +1349,7 @@ pub fn create_callback_closure(
     let mut cif_arg_types: Vec<libffi::middle::Type> = cb_def
         .args
         .iter()
-        .map(|a| crate::cif::ffi_type_for(a, struct_defs))
+        .map(|a| crate::cif::ffi_type_for(a, &struct_defs))
         .collect::<napi::Result<Vec<_>>>()?;
     if cb_def.out_return {
         cif_arg_types.push(libffi::middle::Type::pointer());
@@ -1359,7 +1360,7 @@ pub fn create_callback_closure(
     let cif_ret_type = if cb_def.out_return {
         libffi::middle::Type::void()
     } else {
-        crate::cif::ffi_type_for(&cb_def.ret, struct_defs)?
+        crate::cif::ffi_type_for(&cb_def.ret, &struct_defs)?
     };
     let cif = Cif::new(cif_arg_types, cif_ret_type);
 

--- a/runtimes/napi/tests/fixture.test.mjs
+++ b/runtimes/napi/tests/fixture.test.mjs
@@ -205,13 +205,11 @@ const CALCULATOR_STRUCT = {
 const CALCULATOR_VTABLE_JS = {
   uniffi_free: (handle) => {},
   uniffi_clone: (handle) => handle,
-  add: (handle, a, b, callStatus) => {
-    callStatus.code = 0;
-    return a + b;
+  add: (handle, a, b) => {
+    return { code: 0, pointee: a + b };
   },
-  concatenate: (handle, aBuf, bBuf, callStatus) => {
-    callStatus.code = 0;
-    return lowerString(liftString(aBuf) + liftString(bBuf));
+  concatenate: (handle, aBuf, bBuf) => {
+    return { code: 0, pointee: lowerString(liftString(aBuf) + liftString(bBuf)) };
   },
 };
 

--- a/typescript/src/async-rust-call.ts
+++ b/typescript/src/async-rust-call.ts
@@ -80,6 +80,19 @@ export async function uniffiRustCallAsync<F, S extends UniffiRustCallStatus, T>(
   const abortFunc = createAbortFunction(rustFuture, cancelFunc);
   asyncOpts?.signal.addEventListener("abort", abortFunc);
 
+  // Keep the Node.js event loop alive while polling the Rust future.
+  // The napi runtime's callback TSFNs are deliberately unref'd (so leaked TSFNs
+  // don't prevent process exit). Without a ref'd handle here, the event loop may
+  // exit before the callback fires — especially on Linux where event loop
+  // draining is more aggressive than on macOS.
+  // Only needed when setInterval is natively available (i.e. Node.js / napi
+  // runtime); Hermes/JSI provides timers via a polyfill that may not be loaded
+  // yet at import time, and WASM has its own event loop.
+  const keepAlive =
+    typeof setTimeout === "function"
+      ? setTimeout(() => {}, 2_147_483_647)
+      : undefined;
+
   // We now poll the Rust future until it's ready.
   // The poll, complete and free methods are specialized by the FFIType of the return value.
   try {
@@ -101,6 +114,7 @@ export async function uniffiRustCallAsync<F, S extends UniffiRustCallStatus, T>(
       ),
     );
   } finally {
+    if (keepAlive !== undefined) clearTimeout(keepAlive);
     // We remove the abortFunc now so we don't trigger a use-after-free
     // panic.
     asyncOpts?.signal.removeEventListener("abort", abortFunc);

--- a/typescript/src/async-rust-call.ts
+++ b/typescript/src/async-rust-call.ts
@@ -85,7 +85,7 @@ export async function uniffiRustCallAsync<F, S extends UniffiRustCallStatus, T>(
   // don't prevent process exit). Without a ref'd handle here, the event loop may
   // exit before the callback fires — especially on Linux where event loop
   // draining is more aggressive than on macOS.
-  // Only needed when setInterval is natively available (i.e. Node.js / napi
+  // Only needed when setTimeout is natively available (i.e. Node.js / napi
   // runtime); Hermes/JSI provides timers via a polyfill that may not be loaded
   // yet at import time, and WASM has its own event loop.
   const keepAlive =


### PR DESCRIPTION
This PR fixes the `runtimes/napi` player to run the remaining fixtures.

The struct helper functions (e.g. `uniffi_free` and `uniffi_clone` being called from C++ and Rust were in camelCase, they've now switched to snake case. This meant changing C++ and Rust in two places, and typescript.

The second major fix was lining up the callbacks and async callbacks.

Finally, there was some work to get it working on Linux. This initiated the beginnings of [the lifecylce/layer refactor](#379). 

---

#### callbacks

The vtable trampoline (`structs.rs`) had a single code path for handling the JS callback's return value. The problem was that uniffi uses two different calling conventions depending on the function:

- **Pass-by-reference status**: the RustCallStatus is passed as a mutable arg, JS mutates it in place, Rust reads it back.
- **UniffiResult / out-pointer protocol**: the callback returns `{ code, pointee?, errorBuf? }` as a JS object; Rust reads the return value and status from that object.

These two paths were tangled together. The fix split them into explicit branches: if `out_return` is true, extract code/pointee/errorBuf from the returned JS object; otherwise, read back the mutated status arg. This got the callbacks fixture passing.

#### async-callbacks, futures, arc-futures

Two more gaps exposed by the `async-callbacks` fixtures:

1. **`RustCallStatus` as an inline struct field** — async callback trampolines return a struct that *contains* a `RustCallStatus`. The previous code assumed status was always a separate pointer arg. Added handling for this case in the `out_return` branch: when the return type has `has_rust_call_status` but it's embedded in the struct, unpack it from the JS result object alongside the pointee.

1. **Callback-typed struct fields in return values** — some structs returned from callbacks contain vtable function pointers (i.e., callbacks themselves). The new `marshal_js_struct_to_c_bytes` function handles this: it walks the struct definition field by field, marshalling `UInt64`/`Handle` fields as BigInt and `Callback` fields by minting new libffi closures on the spot.