### PR TITLE
feat: add global configuration which enables emitting `Vec<u8>` as `Uint8Array` in TS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-strict-byte-arrays"
+version = "0.22.0"
+dependencies = [
+ "async-std",
+ "thiserror 1.0.69",
+ "ubrn_fixture_testing",
+ "ubrn_macros",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-time"
 version = "0.22.0"
 dependencies = [

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -11,35 +11,36 @@ use std::collections::HashMap;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use uniffi_bindgen::pipeline::general;
 
+use crate::bindings::gen_typescript::Config;
 use crate::{bindings::gen_typescript::config::CustomTypeConfig, switches::AbiFlavor};
 
 use super::docstring::{format_docstring, format_docstring_indented};
 use super::nodes::*;
 use super::type_helpers::*;
 
-pub(super) fn build_optional(opt: &general::OptionalType) -> TsSimpleWrapper {
+pub(super) fn build_optional(cfg: &Config, opt: &general::OptionalType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterOptional".into(),
         ffi_converter_name: ffi_converter_name_for(&opt.self_type),
-        type_label: type_label_for(&opt.self_type.ty),
+        type_label: type_label_for(cfg, &opt.self_type.ty),
         inner_converters: vec![ffi_converter_name_for(&opt.inner)],
     }
 }
 
-pub(super) fn build_sequence(seq: &general::SequenceType) -> TsSimpleWrapper {
+pub(super) fn build_sequence(cfg: &Config, seq: &general::SequenceType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterArray".into(),
         ffi_converter_name: ffi_converter_name_for(&seq.self_type),
-        type_label: type_label_for(&seq.self_type.ty),
+        type_label: type_label_for(cfg, &seq.self_type.ty),
         inner_converters: vec![ffi_converter_name_for(&seq.inner)],
     }
 }
 
-pub(super) fn build_map(map: &general::MapType) -> TsSimpleWrapper {
+pub(super) fn build_map(cfg: &Config, map: &general::MapType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterMap".into(),
         ffi_converter_name: ffi_converter_name_for(&map.self_type),
-        type_label: type_label_for(&map.self_type.ty),
+        type_label: type_label_for(cfg, &map.self_type.ty),
         inner_converters: vec![
             ffi_converter_name_for(&map.key),
             ffi_converter_name_for(&map.value),
@@ -72,16 +73,17 @@ pub(super) fn build_string_helper(flavor: &AbiFlavor) -> TsStringHelper {
 
 /// `config` = `None` means no custom lift/lower; falls back to the builtin converter.
 pub(super) fn build_custom_type(
+    cfg: &Config,
     custom: &general::CustomType,
-    config: Option<&CustomTypeConfig>,
+    type_config: Option<&CustomTypeConfig>,
 ) -> TsCustomType {
     let type_name = custom.name.clone();
     let ffi_converter_name = ffi_converter_name_for(&custom.self_type);
-    let builtin_type_name = type_label_for(&custom.builtin.ty);
+    let builtin_type_name = type_label_for(cfg, &custom.builtin.ty);
     let builtin_ffi_converter = ffi_converter_name_for(&custom.builtin);
     let ffi_type_name = ffi_type_to_ts_name(&custom.builtin.ffi_type.ty);
 
-    let custom_config = config.map(|cfg| TsCustomConfig {
+    let custom_config = type_config.map(|cfg| TsCustomConfig {
         concrete_type_name: cfg.type_name.clone(),
         imports: cfg.imports.clone(),
         lift_expr: cfg.lift("intermediate"),
@@ -98,9 +100,12 @@ pub(super) fn build_custom_type(
     }
 }
 
-pub(super) fn build_external_type(external: &general::ExternalType) -> TsExternalType {
+pub(super) fn build_external_type(
+    cfg: &Config,
+    external: &general::ExternalType,
+) -> TsExternalType {
     let module_path = external.namespace.clone();
-    let type_name = type_label_for(&external.self_type.ty);
+    let type_name = type_label_for(cfg, &external.self_type.ty);
     let converter_name = ffi_converter_name_for(&external.self_type);
     let is_enum_type = matches!(external.self_type.ty, general::Type::Enum { .. });
 
@@ -112,7 +117,7 @@ pub(super) fn build_external_type(external: &general::ExternalType) -> TsExterna
     }
 }
 
-fn render_literal(lit: &general::Literal) -> String {
+fn render_literal(cfg: &Config, lit: &general::Literal) -> String {
     match lit {
         general::Literal::Boolean(b) => b.to_string(),
         general::Literal::String(s) => format!("\"{}\"", s),
@@ -127,27 +132,27 @@ fn render_literal(lit: &general::Literal) -> String {
         general::Literal::Float(s, _) => s.clone(),
         general::Literal::Enum(variant, type_node) => {
             // No containing enum context here, so just use the UpperCamelCase variant name.
-            let type_name = type_label_for(&type_node.ty);
+            let type_name = type_label_for(cfg, &type_node.ty);
             let variant_name = variant.to_upper_camel_case();
             format!("{type_name}.{variant_name}")
         }
         general::Literal::EmptySequence => "[]".into(),
         general::Literal::EmptyMap => "new Map()".into(),
         general::Literal::None => "undefined".into(),
-        general::Literal::Some { inner } => render_default_value(inner),
+        general::Literal::Some { inner } => render_default_value(cfg, inner),
     }
 }
 
-fn render_default_value(dv: &general::DefaultValue) -> String {
+fn render_default_value(cfg: &Config, dv: &general::DefaultValue) -> String {
     match dv {
-        general::DefaultValue::Literal(lit_node) => render_literal(&lit_node.lit),
+        general::DefaultValue::Literal(lit_node) => render_literal(cfg, &lit_node.lit),
         general::DefaultValue::Default(_) => "undefined".into(),
     }
 }
 
 /// Discriminants stay in JS (not sent across the FFI), so large integers
 /// can be safely narrowed to JS numbers when they fit.
-fn render_variant_discr(discr: &general::LiteralNode) -> String {
+fn render_variant_discr(cfg: &Config, discr: &general::LiteralNode) -> String {
     match &discr.lit {
         general::Literal::String(s) => format!("\"{}\"", s),
         general::Literal::UInt(n, _, type_node) => match &type_node.ty {
@@ -170,24 +175,27 @@ fn render_variant_discr(discr: &general::LiteralNode) -> String {
             }
             _ => n.to_string(),
         },
-        other => format!("\"{}\"", render_literal(other)),
+        other => format!("\"{}\"", render_literal(cfg, other)),
     }
 }
 
-pub(super) fn build_field(field: &general::Field) -> TsField {
+pub(super) fn build_field(cfg: &Config, field: &general::Field) -> TsField {
     let name = field.name.to_lower_camel_case();
     let is_optional = matches!(&field.ty.ty, general::Type::Optional { .. });
     let ts_type = if is_optional {
         // Unwrap Optional<T> to just T; the `?:` in the type declaration handles optionality.
         match &field.ty.ty {
-            general::Type::Optional { inner_type } => type_label_for(inner_type),
+            general::Type::Optional { inner_type } => type_label_for(cfg, inner_type),
             _ => unreachable!(),
         }
     } else {
-        type_label_for(&field.ty.ty)
+        type_label_for(cfg, &field.ty.ty)
     };
     let ffi_converter = ffi_converter_name_for(&field.ty);
-    let default_value = field.default.as_ref().map(render_default_value);
+    let default_value = field
+        .default
+        .as_ref()
+        .map(|default| render_default_value(cfg, default));
     let docstring = field.docstring.as_deref().map(format_docstring_indented);
     TsField {
         name,
@@ -199,11 +207,15 @@ pub(super) fn build_field(field: &general::Field) -> TsField {
     }
 }
 
-pub(super) fn build_variant(variant: &general::Variant) -> TsVariant {
+pub(super) fn build_variant(cfg: &Config, variant: &general::Variant) -> TsVariant {
     let name = variant.name.to_upper_camel_case();
     let docstring = variant.docstring.as_deref().map(format_docstring_indented);
-    let discriminant = render_variant_discr(&variant.discr);
-    let fields: Vec<TsField> = variant.fields.iter().map(build_field).collect();
+    let discriminant = render_variant_discr(cfg, &variant.discr);
+    let fields: Vec<TsField> = variant
+        .fields
+        .iter()
+        .map(|field| build_field(cfg, field))
+        .collect();
     let has_nameless_fields = matches!(variant.fields_kind, general::FieldsKind::Unnamed);
     TsVariant {
         name,
@@ -215,11 +227,13 @@ pub(super) fn build_variant(variant: &general::Variant) -> TsVariant {
 }
 
 /// `Some` only when Rust declares an explicit discriminant type (e.g. `#[repr(u8)]`).
-fn discr_type_for(en: &general::Enum) -> Option<String> {
-    en.meta_discr_type.as_ref().map(|t| type_label_for(&t.ty))
+fn discr_type_for(cfg: &Config, en: &general::Enum) -> Option<String> {
+    en.meta_discr_type
+        .as_ref()
+        .map(|t| type_label_for(cfg, &t.ty))
 }
 
-pub(super) fn build_enum(en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
+pub(super) fn build_enum(cfg: &Config, en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
     let ts_name = rewrite_js_builtins(&en.name.to_upper_camel_case());
     let ffi_converter_name = ffi_converter_name_for(&en.self_type);
     let docstring = en.docstring.as_deref().map(format_docstring);
@@ -227,21 +241,25 @@ pub(super) fn build_enum(en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
     let is_error = matches!(en.shape, general::EnumShape::Error { .. });
     let is_flat = en.is_flat;
 
-    let discr_type = discr_type_for(en);
+    let discr_type = discr_type_for(cfg, en);
 
-    let variants: Vec<TsVariant> = en.variants.iter().map(build_variant).collect();
+    let variants: Vec<TsVariant> = en
+        .variants
+        .iter()
+        .map(|variant| build_variant(cfg, variant))
+        .collect();
 
     let uniffi_traits =
-        build_uniffi_traits_value(&en.uniffi_trait_methods, &ffi_converter_name, flavor);
+        build_uniffi_traits_value(cfg, &en.uniffi_trait_methods, &ffi_converter_name, flavor);
     let constructors = en
         .constructors
         .iter()
-        .map(|c| build_constructor_callable(c, flavor))
+        .map(|c| build_constructor_callable(cfg, c, flavor))
         .collect();
     let methods = en
         .methods
         .iter()
-        .map(|m| build_value_method_callable(m, &ffi_converter_name, flavor))
+        .map(|m| build_value_method_callable(cfg, m, &ffi_converter_name, flavor))
         .collect();
 
     TsEnum {
@@ -258,28 +276,32 @@ pub(super) fn build_enum(en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
     }
 }
 
-pub(super) fn build_record(rec: &general::Record, flavor: &AbiFlavor) -> TsRecord {
+pub(super) fn build_record(cfg: &Config, rec: &general::Record, flavor: &AbiFlavor) -> TsRecord {
     let ts_name = rewrite_js_builtins(&rec.name.to_upper_camel_case());
     let ffi_converter_name = ffi_converter_name_for(&rec.self_type);
     let docstring = rec.docstring.as_deref().map(format_docstring);
 
-    let fields: Vec<TsField> = rec.fields.iter().map(build_field).collect();
+    let fields: Vec<TsField> = rec
+        .fields
+        .iter()
+        .map(|field| build_field(cfg, field))
+        .collect();
 
     // Suppress default TS factory helpers when Rust defines a constructor with the same name.
     let has_create_constructor = rec.constructors.iter().any(|c| c.callable.name == "create");
     let has_new_constructor = rec.constructors.iter().any(|c| c.callable.name == "new");
 
     let uniffi_traits =
-        build_uniffi_traits_value(&rec.uniffi_trait_methods, &ffi_converter_name, flavor);
+        build_uniffi_traits_value(cfg, &rec.uniffi_trait_methods, &ffi_converter_name, flavor);
     let constructors = rec
         .constructors
         .iter()
-        .map(|c| build_constructor_callable(c, flavor))
+        .map(|c| build_constructor_callable(cfg, c, flavor))
         .collect();
     let methods = rec
         .methods
         .iter()
-        .map(|m| build_value_method_callable(m, &ffi_converter_name, flavor))
+        .map(|m| build_value_method_callable(cfg, m, &ffi_converter_name, flavor))
         .collect();
 
     TsRecord {
@@ -304,14 +326,14 @@ fn ffi_error_converter_for(type_node: &general::TypeNode) -> String {
     name
 }
 
-fn build_error_type(type_node: &general::TypeNode) -> TsErrorType {
+fn build_error_type(cfg: &Config, type_node: &general::TypeNode) -> TsErrorType {
     let ffi_error_converter = ffi_error_converter_for(type_node);
     let lift_error_fn = format!("{ffi_error_converter}.lift.bind({ffi_error_converter})");
     let lower_error_fn = format!("{ffi_error_converter}.lower.bind({ffi_error_converter})");
     // Enums use type_label; objects use the class name directly.
     let decl_type_name = match &type_node.ty {
         general::Type::Interface { name, .. } => name.to_upper_camel_case(),
-        _ => type_label_for(&type_node.ty),
+        _ => type_label_for(cfg, &type_node.ty),
     };
     TsErrorType {
         lift_error_fn,
@@ -320,31 +342,43 @@ fn build_error_type(type_node: &general::TypeNode) -> TsErrorType {
     }
 }
 
-pub(super) fn build_arg(arg: &general::Argument) -> TsArg {
+pub(super) fn build_arg(cfg: &Config, arg: &general::Argument) -> TsArg {
     TsArg {
         name: arg_name(&arg.name),
-        ts_type: type_label_for(&arg.ty.ty),
+        ts_type: type_label_for(cfg, &arg.ty.ty),
         ffi_converter: ffi_converter_name_for(&arg.ty),
-        default_value: arg.default.as_ref().map(render_default_value),
+        default_value: arg
+            .default
+            .as_ref()
+            .map(|default| render_default_value(cfg, default)),
     }
 }
 
 /// `receiver`: `None` for top-level functions and constructors,
 /// `Some(Pointer)` for object methods.
 pub(super) fn build_callable(
+    cfg: &Config,
     callable: &general::Callable,
     docstring: &Option<String>,
     receiver: Option<TsReceiver>,
     flavor: &AbiFlavor,
 ) -> TsCallable {
     let name = fn_name(&callable.name);
-    let arguments: Vec<TsArg> = callable.arguments.iter().map(build_arg).collect();
+    let arguments: Vec<TsArg> = callable
+        .arguments
+        .iter()
+        .map(|arg| build_arg(cfg, arg))
+        .collect();
     let return_type = callable.return_type.ty.as_ref().map(|tn| TsReturnType {
-        ts_type: type_label_for(&tn.ty),
+        ts_type: type_label_for(cfg, &tn.ty),
         ffi_converter: ffi_converter_name_for(tn),
         ffi_type: ffi_type_to_ts_name(&tn.ffi_type.ty),
     });
-    let throws = callable.throws_type.ty.as_ref().map(build_error_type);
+    let throws = callable
+        .throws_type
+        .ty
+        .as_ref()
+        .map(|type_node| build_error_type(cfg, type_node));
     let callable_ffi_name = ffi_name(flavor, &callable.ffi_func.0);
     let ffi_async = callable.async_data.as_ref().map(|ad| TsAsyncFfi {
         poll: ffi_name(flavor, &ad.ffi_rust_future_poll.0),
@@ -366,19 +400,21 @@ pub(super) fn build_callable(
 }
 
 pub(super) fn build_method_callable(
+    cfg: &Config,
     method: &general::Method,
     _ffi_clone_name: &str,
     flavor: &AbiFlavor,
 ) -> TsCallable {
     let receiver = Some(TsReceiver::Pointer);
-    build_callable(&method.callable, &method.docstring, receiver, flavor)
+    build_callable(cfg, &method.callable, &method.docstring, receiver, flavor)
 }
 
 pub(super) fn build_constructor_callable(
+    cfg: &Config,
     cons: &general::Constructor,
     flavor: &AbiFlavor,
 ) -> TsCallable {
-    build_callable(&cons.callable, &cons.docstring, None, flavor)
+    build_callable(cfg, &cons.callable, &cons.docstring, None, flavor)
 }
 
 fn collect_uniffi_traits(
@@ -418,14 +454,18 @@ fn collect_uniffi_traits(
 }
 
 pub(super) fn build_uniffi_traits(
+    cfg: &Config,
     tm: &general::UniffiTraitMethods,
     ffi_clone_name: &str,
     flavor: &AbiFlavor,
 ) -> Vec<TsUniffiTrait> {
-    collect_uniffi_traits(tm, |m| build_method_callable(m, ffi_clone_name, flavor))
+    collect_uniffi_traits(tm, |m| {
+        build_method_callable(cfg, m, ffi_clone_name, flavor)
+    })
 }
 
 pub(super) fn build_value_method_callable(
+    cfg: &Config,
     method: &general::Method,
     ffi_converter: &str,
     flavor: &AbiFlavor,
@@ -433,20 +473,22 @@ pub(super) fn build_value_method_callable(
     let receiver = Some(TsReceiver::Value {
         ffi_converter: ffi_converter.to_string(),
     });
-    build_callable(&method.callable, &method.docstring, receiver, flavor)
+    build_callable(cfg, &method.callable, &method.docstring, receiver, flavor)
 }
 
 pub(super) fn build_uniffi_traits_value(
+    cfg: &Config,
     tm: &general::UniffiTraitMethods,
     ffi_converter: &str,
     flavor: &AbiFlavor,
 ) -> Vec<TsUniffiTrait> {
     collect_uniffi_traits(tm, |m| {
-        build_value_method_callable(m, ffi_converter, flavor)
+        build_value_method_callable(cfg, m, ffi_converter, flavor)
     })
 }
 
 pub(super) fn build_object(
+    cfg: &Config,
     interface: &general::Interface,
     flavor: &AbiFlavor,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
@@ -487,7 +529,7 @@ pub(super) fn build_object(
         let mut primary = None;
         let mut alternates = Vec::new();
         for cons in &interface.constructors {
-            let built = build_constructor_callable(cons, flavor);
+            let built = build_constructor_callable(cfg, cons, flavor);
             if matches!(
                 cons.callable.kind,
                 general::CallableKind::Constructor { primary: true, .. }
@@ -503,17 +545,18 @@ pub(super) fn build_object(
     let methods: Vec<TsMethod> = interface
         .methods
         .iter()
-        .map(|m| build_method_callable(m, &ffi_clone, flavor))
+        .map(|m| build_method_callable(cfg, m, &ffi_clone, flavor))
         .collect();
 
-    let uniffi_traits = build_uniffi_traits(&interface.uniffi_trait_methods, &ffi_clone, flavor);
+    let uniffi_traits =
+        build_uniffi_traits(cfg, &interface.uniffi_trait_methods, &ffi_clone, flavor);
 
     let supports_finalization_registry = flavor.supports_finalization_registry();
 
     let vtable = interface
         .vtable
         .as_ref()
-        .map(|vt| build_vtable(vt, ffi_fn_types, flavor));
+        .map(|vt| build_vtable(cfg, vt, ffi_fn_types, flavor));
 
     let trait_impl = format!("uniffiCallbackInterface{}", class_name);
 
@@ -543,6 +586,7 @@ pub(super) fn build_object(
 }
 
 pub(super) fn build_vtable(
+    cfg: &Config,
     vt: &general::VTable,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
@@ -551,7 +595,7 @@ pub(super) fn build_vtable(
     let fields = vt
         .methods
         .iter()
-        .map(|vm| build_vtable_field(vm, ffi_fn_types, flavor))
+        .map(|vm| build_vtable_field(cfg, vm, ffi_fn_types, flavor))
         .collect();
     TsVtable {
         ffi_init_fn,
@@ -560,12 +604,13 @@ pub(super) fn build_vtable(
 }
 
 fn build_vtable_field(
+    cfg: &Config,
     vm: &general::VTableMethod,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
 ) -> TsVtableField {
     let name = fn_name(&vm.callable.name);
-    let method = Some(build_callable(&vm.callable, &None, None, flavor));
+    let method = Some(build_callable(cfg, &vm.callable, &None, None, flavor));
 
     let general::FfiType::Function(ref ffi_fn_name) = vm.ffi_type.ty else {
         return TsVtableField {
@@ -640,6 +685,7 @@ fn build_closure_args(
 }
 
 pub(super) fn build_callback_interface(
+    cfg: &Config,
     cbi: &general::CallbackInterface,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
@@ -654,12 +700,12 @@ pub(super) fn build_callback_interface(
     let methods: Vec<TsCallable> = cbi
         .methods
         .iter()
-        .map(|m| build_callable(&m.callable, &m.docstring, None, flavor))
+        .map(|m| build_callable(cfg, &m.callable, &m.docstring, None, flavor))
         .collect();
 
     let has_async_methods = cbi.methods.iter().any(|m| m.callable.is_async());
 
-    let vtable = build_vtable(&cbi.vtable, ffi_fn_types, flavor);
+    let vtable = build_vtable(cfg, &cbi.vtable, ffi_fn_types, flavor);
 
     let trait_impl = format!("uniffiCallbackInterface{ts_name}");
 
@@ -676,13 +722,14 @@ pub(super) fn build_callback_interface(
 }
 
 pub(super) fn build_functions(
+    cfg: &Config,
     namespace: &general::Namespace,
     flavor: &AbiFlavor,
 ) -> Vec<TsFunction> {
     namespace
         .functions
         .iter()
-        .map(|f| build_callable(&f.callable, &f.docstring, None, flavor))
+        .map(|f| build_callable(cfg, &f.callable, &f.docstring, None, flavor))
         .collect()
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -12,7 +12,7 @@ use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use uniffi_bindgen::pipeline::general;
 
 use crate::bindings::gen_typescript::Config;
-use crate::{bindings::gen_typescript::config::CustomTypeConfig, switches::AbiFlavor};
+use crate::switches::AbiFlavor;
 
 use super::docstring::{format_docstring, format_docstring_indented};
 use super::nodes::*;
@@ -71,24 +71,26 @@ pub(super) fn build_string_helper(flavor: &AbiFlavor) -> TsStringHelper {
     }
 }
 
-/// `config` = `None` means no custom lift/lower; falls back to the builtin converter.
-pub(super) fn build_custom_type(
-    cfg: &Config,
-    custom: &general::CustomType,
-    type_config: Option<&CustomTypeConfig>,
-) -> TsCustomType {
+/// Custom lift/lower instructions are stored within the configuration table within the `custom_types` section,
+/// keyed by the custom type's name.
+///
+/// If no such instructions are present in the configuration, falls back to the builtin converter.
+pub(super) fn build_custom_type(cfg: &Config, custom: &general::CustomType) -> TsCustomType {
     let type_name = custom.name.clone();
     let ffi_converter_name = ffi_converter_name_for(cfg, &custom.self_type);
     let builtin_type_name = type_label_for(cfg, &custom.builtin.ty);
     let builtin_ffi_converter = ffi_converter_name_for(cfg, &custom.builtin);
     let ffi_type_name = ffi_type_to_ts_name(&custom.builtin.ffi_type.ty);
 
-    let custom_config = type_config.map(|cfg| TsCustomConfig {
-        concrete_type_name: cfg.type_name.clone(),
-        imports: cfg.imports.clone(),
-        lift_expr: cfg.lift("intermediate"),
-        lower_expr: cfg.lower("value"),
-    });
+    let custom_config = cfg
+        .custom_types
+        .get(&custom.name)
+        .map(|cfg| TsCustomConfig {
+            concrete_type_name: cfg.type_name.clone(),
+            imports: cfg.imports.clone(),
+            lift_expr: cfg.lift("intermediate"),
+            lower_expr: cfg.lower("value"),
+        });
 
     TsCustomType {
         type_name,

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -18,32 +18,32 @@ use super::docstring::{format_docstring, format_docstring_indented};
 use super::nodes::*;
 use super::type_helpers::*;
 
-pub(super) fn build_optional(cfg: &Config, opt: &general::OptionalType) -> TsSimpleWrapper {
+pub(super) fn build_optional(config: &Config, opt: &general::OptionalType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterOptional".into(),
-        ffi_converter_name: ffi_converter_name_for(cfg, &opt.self_type),
-        type_label: type_label_for(cfg, &opt.self_type.ty),
-        inner_converters: vec![ffi_converter_name_for(cfg, &opt.inner)],
+        ffi_converter_name: ffi_converter_name_for(config, &opt.self_type),
+        type_label: type_label_for(config, &opt.self_type.ty),
+        inner_converters: vec![ffi_converter_name_for(config, &opt.inner)],
     }
 }
 
-pub(super) fn build_sequence(cfg: &Config, seq: &general::SequenceType) -> TsSimpleWrapper {
+pub(super) fn build_sequence(config: &Config, seq: &general::SequenceType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterArray".into(),
-        ffi_converter_name: ffi_converter_name_for(cfg, &seq.self_type),
-        type_label: type_label_for(cfg, &seq.self_type.ty),
-        inner_converters: vec![ffi_converter_name_for(cfg, &seq.inner)],
+        ffi_converter_name: ffi_converter_name_for(config, &seq.self_type),
+        type_label: type_label_for(config, &seq.self_type.ty),
+        inner_converters: vec![ffi_converter_name_for(config, &seq.inner)],
     }
 }
 
-pub(super) fn build_map(cfg: &Config, map: &general::MapType) -> TsSimpleWrapper {
+pub(super) fn build_map(config: &Config, map: &general::MapType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterMap".into(),
-        ffi_converter_name: ffi_converter_name_for(cfg, &map.self_type),
-        type_label: type_label_for(cfg, &map.self_type.ty),
+        ffi_converter_name: ffi_converter_name_for(config, &map.self_type),
+        type_label: type_label_for(config, &map.self_type.ty),
         inner_converters: vec![
-            ffi_converter_name_for(cfg, &map.key),
-            ffi_converter_name_for(cfg, &map.value),
+            ffi_converter_name_for(config, &map.key),
+            ffi_converter_name_for(config, &map.value),
         ],
     }
 }
@@ -75,14 +75,14 @@ pub(super) fn build_string_helper(flavor: &AbiFlavor) -> TsStringHelper {
 /// keyed by the custom type's name.
 ///
 /// If no such instructions are present in the configuration, falls back to the builtin converter.
-pub(super) fn build_custom_type(cfg: &Config, custom: &general::CustomType) -> TsCustomType {
+pub(super) fn build_custom_type(config: &Config, custom: &general::CustomType) -> TsCustomType {
     let type_name = custom.name.clone();
-    let ffi_converter_name = ffi_converter_name_for(cfg, &custom.self_type);
-    let builtin_type_name = type_label_for(cfg, &custom.builtin.ty);
-    let builtin_ffi_converter = ffi_converter_name_for(cfg, &custom.builtin);
+    let ffi_converter_name = ffi_converter_name_for(config, &custom.self_type);
+    let builtin_type_name = type_label_for(config, &custom.builtin.ty);
+    let builtin_ffi_converter = ffi_converter_name_for(config, &custom.builtin);
     let ffi_type_name = ffi_type_to_ts_name(&custom.builtin.ffi_type.ty);
 
-    let custom_config = cfg
+    let custom_config = config
         .custom_types
         .get(&custom.name)
         .map(|cfg| TsCustomConfig {
@@ -103,12 +103,12 @@ pub(super) fn build_custom_type(cfg: &Config, custom: &general::CustomType) -> T
 }
 
 pub(super) fn build_external_type(
-    cfg: &Config,
+    config: &Config,
     external: &general::ExternalType,
 ) -> TsExternalType {
     let module_path = external.namespace.clone();
-    let type_name = type_label_for(cfg, &external.self_type.ty);
-    let converter_name = ffi_converter_name_for(cfg, &external.self_type);
+    let type_name = type_label_for(config, &external.self_type.ty);
+    let converter_name = ffi_converter_name_for(config, &external.self_type);
     let is_enum_type = matches!(external.self_type.ty, general::Type::Enum { .. });
 
     TsExternalType {
@@ -119,7 +119,7 @@ pub(super) fn build_external_type(
     }
 }
 
-fn render_literal(cfg: &Config, lit: &general::Literal) -> String {
+fn render_literal(config: &Config, lit: &general::Literal) -> String {
     match lit {
         general::Literal::Boolean(b) => b.to_string(),
         general::Literal::String(s) => format!("\"{}\"", s),
@@ -134,27 +134,27 @@ fn render_literal(cfg: &Config, lit: &general::Literal) -> String {
         general::Literal::Float(s, _) => s.clone(),
         general::Literal::Enum(variant, type_node) => {
             // No containing enum context here, so just use the UpperCamelCase variant name.
-            let type_name = type_label_for(cfg, &type_node.ty);
+            let type_name = type_label_for(config, &type_node.ty);
             let variant_name = variant.to_upper_camel_case();
             format!("{type_name}.{variant_name}")
         }
         general::Literal::EmptySequence => "[]".into(),
         general::Literal::EmptyMap => "new Map()".into(),
         general::Literal::None => "undefined".into(),
-        general::Literal::Some { inner } => render_default_value(cfg, inner),
+        general::Literal::Some { inner } => render_default_value(config, inner),
     }
 }
 
-fn render_default_value(cfg: &Config, dv: &general::DefaultValue) -> String {
+fn render_default_value(config: &Config, dv: &general::DefaultValue) -> String {
     match dv {
-        general::DefaultValue::Literal(lit_node) => render_literal(cfg, &lit_node.lit),
+        general::DefaultValue::Literal(lit_node) => render_literal(config, &lit_node.lit),
         general::DefaultValue::Default(_) => "undefined".into(),
     }
 }
 
 /// Discriminants stay in JS (not sent across the FFI), so large integers
 /// can be safely narrowed to JS numbers when they fit.
-fn render_variant_discr(cfg: &Config, discr: &general::LiteralNode) -> String {
+fn render_variant_discr(config: &Config, discr: &general::LiteralNode) -> String {
     match &discr.lit {
         general::Literal::String(s) => format!("\"{}\"", s),
         general::Literal::UInt(n, _, type_node) => match &type_node.ty {
@@ -177,27 +177,27 @@ fn render_variant_discr(cfg: &Config, discr: &general::LiteralNode) -> String {
             }
             _ => n.to_string(),
         },
-        other => format!("\"{}\"", render_literal(cfg, other)),
+        other => format!("\"{}\"", render_literal(config, other)),
     }
 }
 
-pub(super) fn build_field(cfg: &Config, field: &general::Field) -> TsField {
+pub(super) fn build_field(config: &Config, field: &general::Field) -> TsField {
     let name = field.name.to_lower_camel_case();
     let is_optional = matches!(&field.ty.ty, general::Type::Optional { .. });
     let ts_type = if is_optional {
         // Unwrap Optional<T> to just T; the `?:` in the type declaration handles optionality.
         match &field.ty.ty {
-            general::Type::Optional { inner_type } => type_label_for(cfg, inner_type),
+            general::Type::Optional { inner_type } => type_label_for(config, inner_type),
             _ => unreachable!(),
         }
     } else {
-        type_label_for(cfg, &field.ty.ty)
+        type_label_for(config, &field.ty.ty)
     };
-    let ffi_converter = ffi_converter_name_for(cfg, &field.ty);
+    let ffi_converter = ffi_converter_name_for(config, &field.ty);
     let default_value = field
         .default
         .as_ref()
-        .map(|default| render_default_value(cfg, default));
+        .map(|default| render_default_value(config, default));
     let docstring = field.docstring.as_deref().map(format_docstring_indented);
     TsField {
         name,
@@ -209,14 +209,14 @@ pub(super) fn build_field(cfg: &Config, field: &general::Field) -> TsField {
     }
 }
 
-pub(super) fn build_variant(cfg: &Config, variant: &general::Variant) -> TsVariant {
+pub(super) fn build_variant(config: &Config, variant: &general::Variant) -> TsVariant {
     let name = variant.name.to_upper_camel_case();
     let docstring = variant.docstring.as_deref().map(format_docstring_indented);
-    let discriminant = render_variant_discr(cfg, &variant.discr);
+    let discriminant = render_variant_discr(config, &variant.discr);
     let fields: Vec<TsField> = variant
         .fields
         .iter()
-        .map(|field| build_field(cfg, field))
+        .map(|field| build_field(config, field))
         .collect();
     let has_nameless_fields = matches!(variant.fields_kind, general::FieldsKind::Unnamed);
     TsVariant {
@@ -229,39 +229,43 @@ pub(super) fn build_variant(cfg: &Config, variant: &general::Variant) -> TsVaria
 }
 
 /// `Some` only when Rust declares an explicit discriminant type (e.g. `#[repr(u8)]`).
-fn discr_type_for(cfg: &Config, en: &general::Enum) -> Option<String> {
+fn discr_type_for(config: &Config, en: &general::Enum) -> Option<String> {
     en.meta_discr_type
         .as_ref()
-        .map(|t| type_label_for(cfg, &t.ty))
+        .map(|t| type_label_for(config, &t.ty))
 }
 
-pub(super) fn build_enum(cfg: &Config, en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
+pub(super) fn build_enum(config: &Config, en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
     let ts_name = rewrite_js_builtins(&en.name.to_upper_camel_case());
-    let ffi_converter_name = ffi_converter_name_for(cfg, &en.self_type);
+    let ffi_converter_name = ffi_converter_name_for(config, &en.self_type);
     let docstring = en.docstring.as_deref().map(format_docstring);
 
     let is_error = matches!(en.shape, general::EnumShape::Error { .. });
     let is_flat = en.is_flat;
 
-    let discr_type = discr_type_for(cfg, en);
+    let discr_type = discr_type_for(config, en);
 
     let variants: Vec<TsVariant> = en
         .variants
         .iter()
-        .map(|variant| build_variant(cfg, variant))
+        .map(|variant| build_variant(config, variant))
         .collect();
 
-    let uniffi_traits =
-        build_uniffi_traits_value(cfg, &en.uniffi_trait_methods, &ffi_converter_name, flavor);
+    let uniffi_traits = build_uniffi_traits_value(
+        config,
+        &en.uniffi_trait_methods,
+        &ffi_converter_name,
+        flavor,
+    );
     let constructors = en
         .constructors
         .iter()
-        .map(|c| build_constructor_callable(cfg, c, flavor))
+        .map(|c| build_constructor_callable(config, c, flavor))
         .collect();
     let methods = en
         .methods
         .iter()
-        .map(|m| build_value_method_callable(cfg, m, &ffi_converter_name, flavor))
+        .map(|m| build_value_method_callable(config, m, &ffi_converter_name, flavor))
         .collect();
 
     TsEnum {
@@ -278,32 +282,36 @@ pub(super) fn build_enum(cfg: &Config, en: &general::Enum, flavor: &AbiFlavor) -
     }
 }
 
-pub(super) fn build_record(cfg: &Config, rec: &general::Record, flavor: &AbiFlavor) -> TsRecord {
+pub(super) fn build_record(config: &Config, rec: &general::Record, flavor: &AbiFlavor) -> TsRecord {
     let ts_name = rewrite_js_builtins(&rec.name.to_upper_camel_case());
-    let ffi_converter_name = ffi_converter_name_for(cfg, &rec.self_type);
+    let ffi_converter_name = ffi_converter_name_for(config, &rec.self_type);
     let docstring = rec.docstring.as_deref().map(format_docstring);
 
     let fields: Vec<TsField> = rec
         .fields
         .iter()
-        .map(|field| build_field(cfg, field))
+        .map(|field| build_field(config, field))
         .collect();
 
     // Suppress default TS factory helpers when Rust defines a constructor with the same name.
     let has_create_constructor = rec.constructors.iter().any(|c| c.callable.name == "create");
     let has_new_constructor = rec.constructors.iter().any(|c| c.callable.name == "new");
 
-    let uniffi_traits =
-        build_uniffi_traits_value(cfg, &rec.uniffi_trait_methods, &ffi_converter_name, flavor);
+    let uniffi_traits = build_uniffi_traits_value(
+        config,
+        &rec.uniffi_trait_methods,
+        &ffi_converter_name,
+        flavor,
+    );
     let constructors = rec
         .constructors
         .iter()
-        .map(|c| build_constructor_callable(cfg, c, flavor))
+        .map(|c| build_constructor_callable(config, c, flavor))
         .collect();
     let methods = rec
         .methods
         .iter()
-        .map(|m| build_value_method_callable(cfg, m, &ffi_converter_name, flavor))
+        .map(|m| build_value_method_callable(config, m, &ffi_converter_name, flavor))
         .collect();
 
     TsRecord {
@@ -320,22 +328,22 @@ pub(super) fn build_record(cfg: &Config, rec: &general::Record, flavor: &AbiFlav
 }
 
 /// Objects get `FfiConverter{name}__as_error`; other types use the regular converter name.
-fn ffi_error_converter_for(cfg: &Config, type_node: &general::TypeNode) -> String {
-    let mut name = ffi_converter_name_for(cfg, type_node);
+fn ffi_error_converter_for(config: &Config, type_node: &general::TypeNode) -> String {
+    let mut name = ffi_converter_name_for(config, type_node);
     if matches!(&type_node.ty, general::Type::Interface { .. }) {
         name.push_str("__as_error");
     }
     name
 }
 
-fn build_error_type(cfg: &Config, type_node: &general::TypeNode) -> TsErrorType {
-    let ffi_error_converter = ffi_error_converter_for(cfg, type_node);
+fn build_error_type(config: &Config, type_node: &general::TypeNode) -> TsErrorType {
+    let ffi_error_converter = ffi_error_converter_for(config, type_node);
     let lift_error_fn = format!("{ffi_error_converter}.lift.bind({ffi_error_converter})");
     let lower_error_fn = format!("{ffi_error_converter}.lower.bind({ffi_error_converter})");
     // Enums use type_label; objects use the class name directly.
     let decl_type_name = match &type_node.ty {
         general::Type::Interface { name, .. } => name.to_upper_camel_case(),
-        _ => type_label_for(cfg, &type_node.ty),
+        _ => type_label_for(config, &type_node.ty),
     };
     TsErrorType {
         lift_error_fn,
@@ -344,22 +352,22 @@ fn build_error_type(cfg: &Config, type_node: &general::TypeNode) -> TsErrorType 
     }
 }
 
-pub(super) fn build_arg(cfg: &Config, arg: &general::Argument) -> TsArg {
+pub(super) fn build_arg(config: &Config, arg: &general::Argument) -> TsArg {
     TsArg {
         name: arg_name(&arg.name),
-        ts_type: type_label_for(cfg, &arg.ty.ty),
-        ffi_converter: ffi_converter_name_for(cfg, &arg.ty),
+        ts_type: type_label_for(config, &arg.ty.ty),
+        ffi_converter: ffi_converter_name_for(config, &arg.ty),
         default_value: arg
             .default
             .as_ref()
-            .map(|default| render_default_value(cfg, default)),
+            .map(|default| render_default_value(config, default)),
     }
 }
 
 /// `receiver`: `None` for top-level functions and constructors,
 /// `Some(Pointer)` for object methods.
 pub(super) fn build_callable(
-    cfg: &Config,
+    config: &Config,
     callable: &general::Callable,
     docstring: &Option<String>,
     receiver: Option<TsReceiver>,
@@ -369,18 +377,18 @@ pub(super) fn build_callable(
     let arguments: Vec<TsArg> = callable
         .arguments
         .iter()
-        .map(|arg| build_arg(cfg, arg))
+        .map(|arg| build_arg(config, arg))
         .collect();
     let return_type = callable.return_type.ty.as_ref().map(|tn| TsReturnType {
-        ts_type: type_label_for(cfg, &tn.ty),
-        ffi_converter: ffi_converter_name_for(cfg, tn),
+        ts_type: type_label_for(config, &tn.ty),
+        ffi_converter: ffi_converter_name_for(config, tn),
         ffi_type: ffi_type_to_ts_name(&tn.ffi_type.ty),
     });
     let throws = callable
         .throws_type
         .ty
         .as_ref()
-        .map(|type_node| build_error_type(cfg, type_node));
+        .map(|type_node| build_error_type(config, type_node));
     let callable_ffi_name = ffi_name(flavor, &callable.ffi_func.0);
     let ffi_async = callable.async_data.as_ref().map(|ad| TsAsyncFfi {
         poll: ffi_name(flavor, &ad.ffi_rust_future_poll.0),
@@ -402,21 +410,27 @@ pub(super) fn build_callable(
 }
 
 pub(super) fn build_method_callable(
-    cfg: &Config,
+    config: &Config,
     method: &general::Method,
     _ffi_clone_name: &str,
     flavor: &AbiFlavor,
 ) -> TsCallable {
     let receiver = Some(TsReceiver::Pointer);
-    build_callable(cfg, &method.callable, &method.docstring, receiver, flavor)
+    build_callable(
+        config,
+        &method.callable,
+        &method.docstring,
+        receiver,
+        flavor,
+    )
 }
 
 pub(super) fn build_constructor_callable(
-    cfg: &Config,
+    config: &Config,
     cons: &general::Constructor,
     flavor: &AbiFlavor,
 ) -> TsCallable {
-    build_callable(cfg, &cons.callable, &cons.docstring, None, flavor)
+    build_callable(config, &cons.callable, &cons.docstring, None, flavor)
 }
 
 fn collect_uniffi_traits(
@@ -456,18 +470,18 @@ fn collect_uniffi_traits(
 }
 
 pub(super) fn build_uniffi_traits(
-    cfg: &Config,
+    config: &Config,
     tm: &general::UniffiTraitMethods,
     ffi_clone_name: &str,
     flavor: &AbiFlavor,
 ) -> Vec<TsUniffiTrait> {
     collect_uniffi_traits(tm, |m| {
-        build_method_callable(cfg, m, ffi_clone_name, flavor)
+        build_method_callable(config, m, ffi_clone_name, flavor)
     })
 }
 
 pub(super) fn build_value_method_callable(
-    cfg: &Config,
+    config: &Config,
     method: &general::Method,
     ffi_converter: &str,
     flavor: &AbiFlavor,
@@ -475,22 +489,28 @@ pub(super) fn build_value_method_callable(
     let receiver = Some(TsReceiver::Value {
         ffi_converter: ffi_converter.to_string(),
     });
-    build_callable(cfg, &method.callable, &method.docstring, receiver, flavor)
+    build_callable(
+        config,
+        &method.callable,
+        &method.docstring,
+        receiver,
+        flavor,
+    )
 }
 
 pub(super) fn build_uniffi_traits_value(
-    cfg: &Config,
+    config: &Config,
     tm: &general::UniffiTraitMethods,
     ffi_converter: &str,
     flavor: &AbiFlavor,
 ) -> Vec<TsUniffiTrait> {
     collect_uniffi_traits(tm, |m| {
-        build_value_method_callable(cfg, m, ffi_converter, flavor)
+        build_value_method_callable(config, m, ffi_converter, flavor)
     })
 }
 
 pub(super) fn build_object(
-    cfg: &Config,
+    config: &Config,
     interface: &general::Interface,
     flavor: &AbiFlavor,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
@@ -512,7 +532,7 @@ pub(super) fn build_object(
     let ts_name = class_name.clone();
     let decl_type_name = impl_class_name.clone();
     let obj_factory = format!("uniffiType{impl_class_name}ObjectFactory");
-    let ffi_converter_name = ffi_converter_name_for(cfg, &interface.self_type);
+    let ffi_converter_name = ffi_converter_name_for(config, &interface.self_type);
     let ffi_error_converter_name = format!("{ffi_converter_name}__as_error");
 
     let docstring = interface.docstring.as_deref().map(format_docstring);
@@ -531,7 +551,7 @@ pub(super) fn build_object(
         let mut primary = None;
         let mut alternates = Vec::new();
         for cons in &interface.constructors {
-            let built = build_constructor_callable(cfg, cons, flavor);
+            let built = build_constructor_callable(config, cons, flavor);
             if matches!(
                 cons.callable.kind,
                 general::CallableKind::Constructor { primary: true, .. }
@@ -547,18 +567,18 @@ pub(super) fn build_object(
     let methods: Vec<TsMethod> = interface
         .methods
         .iter()
-        .map(|m| build_method_callable(cfg, m, &ffi_clone, flavor))
+        .map(|m| build_method_callable(config, m, &ffi_clone, flavor))
         .collect();
 
     let uniffi_traits =
-        build_uniffi_traits(cfg, &interface.uniffi_trait_methods, &ffi_clone, flavor);
+        build_uniffi_traits(config, &interface.uniffi_trait_methods, &ffi_clone, flavor);
 
     let supports_finalization_registry = flavor.supports_finalization_registry();
 
     let vtable = interface
         .vtable
         .as_ref()
-        .map(|vt| build_vtable(cfg, vt, ffi_fn_types, flavor));
+        .map(|vt| build_vtable(config, vt, ffi_fn_types, flavor));
 
     let trait_impl = format!("uniffiCallbackInterface{}", class_name);
 
@@ -588,7 +608,7 @@ pub(super) fn build_object(
 }
 
 pub(super) fn build_vtable(
-    cfg: &Config,
+    config: &Config,
     vt: &general::VTable,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
@@ -597,7 +617,7 @@ pub(super) fn build_vtable(
     let fields = vt
         .methods
         .iter()
-        .map(|vm| build_vtable_field(cfg, vm, ffi_fn_types, flavor))
+        .map(|vm| build_vtable_field(config, vm, ffi_fn_types, flavor))
         .collect();
     TsVtable {
         ffi_init_fn,
@@ -606,13 +626,13 @@ pub(super) fn build_vtable(
 }
 
 fn build_vtable_field(
-    cfg: &Config,
+    config: &Config,
     vm: &general::VTableMethod,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
 ) -> TsVtableField {
     let name = fn_name(&vm.callable.name);
-    let method = Some(build_callable(cfg, &vm.callable, &None, None, flavor));
+    let method = Some(build_callable(config, &vm.callable, &None, None, flavor));
 
     let general::FfiType::Function(ref ffi_fn_name) = vm.ffi_type.ty else {
         return TsVtableField {
@@ -687,7 +707,7 @@ fn build_closure_args(
 }
 
 pub(super) fn build_callback_interface(
-    cfg: &Config,
+    config: &Config,
     cbi: &general::CallbackInterface,
     ffi_fn_types: &HashMap<String, &general::FfiFunctionType>,
     flavor: &AbiFlavor,
@@ -702,12 +722,12 @@ pub(super) fn build_callback_interface(
     let methods: Vec<TsCallable> = cbi
         .methods
         .iter()
-        .map(|m| build_callable(cfg, &m.callable, &m.docstring, None, flavor))
+        .map(|m| build_callable(config, &m.callable, &m.docstring, None, flavor))
         .collect();
 
     let has_async_methods = cbi.methods.iter().any(|m| m.callable.is_async());
 
-    let vtable = build_vtable(cfg, &cbi.vtable, ffi_fn_types, flavor);
+    let vtable = build_vtable(config, &cbi.vtable, ffi_fn_types, flavor);
 
     let trait_impl = format!("uniffiCallbackInterface{ts_name}");
 
@@ -724,14 +744,14 @@ pub(super) fn build_callback_interface(
 }
 
 pub(super) fn build_functions(
-    cfg: &Config,
+    config: &Config,
     namespace: &general::Namespace,
     flavor: &AbiFlavor,
 ) -> Vec<TsFunction> {
     namespace
         .functions
         .iter()
-        .map(|f| build_callable(cfg, &f.callable, &f.docstring, None, flavor))
+        .map(|f| build_callable(config, &f.callable, &f.docstring, None, flavor))
         .collect()
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -21,29 +21,29 @@ use super::type_helpers::*;
 pub(super) fn build_optional(cfg: &Config, opt: &general::OptionalType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterOptional".into(),
-        ffi_converter_name: ffi_converter_name_for(&opt.self_type),
+        ffi_converter_name: ffi_converter_name_for(cfg, &opt.self_type),
         type_label: type_label_for(cfg, &opt.self_type.ty),
-        inner_converters: vec![ffi_converter_name_for(&opt.inner)],
+        inner_converters: vec![ffi_converter_name_for(cfg, &opt.inner)],
     }
 }
 
 pub(super) fn build_sequence(cfg: &Config, seq: &general::SequenceType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterArray".into(),
-        ffi_converter_name: ffi_converter_name_for(&seq.self_type),
+        ffi_converter_name: ffi_converter_name_for(cfg, &seq.self_type),
         type_label: type_label_for(cfg, &seq.self_type.ty),
-        inner_converters: vec![ffi_converter_name_for(&seq.inner)],
+        inner_converters: vec![ffi_converter_name_for(cfg, &seq.inner)],
     }
 }
 
 pub(super) fn build_map(cfg: &Config, map: &general::MapType) -> TsSimpleWrapper {
     TsSimpleWrapper {
         infra_class: "FfiConverterMap".into(),
-        ffi_converter_name: ffi_converter_name_for(&map.self_type),
+        ffi_converter_name: ffi_converter_name_for(cfg, &map.self_type),
         type_label: type_label_for(cfg, &map.self_type.ty),
         inner_converters: vec![
-            ffi_converter_name_for(&map.key),
-            ffi_converter_name_for(&map.value),
+            ffi_converter_name_for(cfg, &map.key),
+            ffi_converter_name_for(cfg, &map.value),
         ],
     }
 }
@@ -78,9 +78,9 @@ pub(super) fn build_custom_type(
     type_config: Option<&CustomTypeConfig>,
 ) -> TsCustomType {
     let type_name = custom.name.clone();
-    let ffi_converter_name = ffi_converter_name_for(&custom.self_type);
+    let ffi_converter_name = ffi_converter_name_for(cfg, &custom.self_type);
     let builtin_type_name = type_label_for(cfg, &custom.builtin.ty);
-    let builtin_ffi_converter = ffi_converter_name_for(&custom.builtin);
+    let builtin_ffi_converter = ffi_converter_name_for(cfg, &custom.builtin);
     let ffi_type_name = ffi_type_to_ts_name(&custom.builtin.ffi_type.ty);
 
     let custom_config = type_config.map(|cfg| TsCustomConfig {
@@ -106,7 +106,7 @@ pub(super) fn build_external_type(
 ) -> TsExternalType {
     let module_path = external.namespace.clone();
     let type_name = type_label_for(cfg, &external.self_type.ty);
-    let converter_name = ffi_converter_name_for(&external.self_type);
+    let converter_name = ffi_converter_name_for(cfg, &external.self_type);
     let is_enum_type = matches!(external.self_type.ty, general::Type::Enum { .. });
 
     TsExternalType {
@@ -191,7 +191,7 @@ pub(super) fn build_field(cfg: &Config, field: &general::Field) -> TsField {
     } else {
         type_label_for(cfg, &field.ty.ty)
     };
-    let ffi_converter = ffi_converter_name_for(&field.ty);
+    let ffi_converter = ffi_converter_name_for(cfg, &field.ty);
     let default_value = field
         .default
         .as_ref()
@@ -235,7 +235,7 @@ fn discr_type_for(cfg: &Config, en: &general::Enum) -> Option<String> {
 
 pub(super) fn build_enum(cfg: &Config, en: &general::Enum, flavor: &AbiFlavor) -> TsEnum {
     let ts_name = rewrite_js_builtins(&en.name.to_upper_camel_case());
-    let ffi_converter_name = ffi_converter_name_for(&en.self_type);
+    let ffi_converter_name = ffi_converter_name_for(cfg, &en.self_type);
     let docstring = en.docstring.as_deref().map(format_docstring);
 
     let is_error = matches!(en.shape, general::EnumShape::Error { .. });
@@ -278,7 +278,7 @@ pub(super) fn build_enum(cfg: &Config, en: &general::Enum, flavor: &AbiFlavor) -
 
 pub(super) fn build_record(cfg: &Config, rec: &general::Record, flavor: &AbiFlavor) -> TsRecord {
     let ts_name = rewrite_js_builtins(&rec.name.to_upper_camel_case());
-    let ffi_converter_name = ffi_converter_name_for(&rec.self_type);
+    let ffi_converter_name = ffi_converter_name_for(cfg, &rec.self_type);
     let docstring = rec.docstring.as_deref().map(format_docstring);
 
     let fields: Vec<TsField> = rec
@@ -318,8 +318,8 @@ pub(super) fn build_record(cfg: &Config, rec: &general::Record, flavor: &AbiFlav
 }
 
 /// Objects get `FfiConverter{name}__as_error`; other types use the regular converter name.
-fn ffi_error_converter_for(type_node: &general::TypeNode) -> String {
-    let mut name = ffi_converter_name_for(type_node);
+fn ffi_error_converter_for(cfg: &Config, type_node: &general::TypeNode) -> String {
+    let mut name = ffi_converter_name_for(cfg, type_node);
     if matches!(&type_node.ty, general::Type::Interface { .. }) {
         name.push_str("__as_error");
     }
@@ -327,7 +327,7 @@ fn ffi_error_converter_for(type_node: &general::TypeNode) -> String {
 }
 
 fn build_error_type(cfg: &Config, type_node: &general::TypeNode) -> TsErrorType {
-    let ffi_error_converter = ffi_error_converter_for(type_node);
+    let ffi_error_converter = ffi_error_converter_for(cfg, type_node);
     let lift_error_fn = format!("{ffi_error_converter}.lift.bind({ffi_error_converter})");
     let lower_error_fn = format!("{ffi_error_converter}.lower.bind({ffi_error_converter})");
     // Enums use type_label; objects use the class name directly.
@@ -346,7 +346,7 @@ pub(super) fn build_arg(cfg: &Config, arg: &general::Argument) -> TsArg {
     TsArg {
         name: arg_name(&arg.name),
         ts_type: type_label_for(cfg, &arg.ty.ty),
-        ffi_converter: ffi_converter_name_for(&arg.ty),
+        ffi_converter: ffi_converter_name_for(cfg, &arg.ty),
         default_value: arg
             .default
             .as_ref()
@@ -371,7 +371,7 @@ pub(super) fn build_callable(
         .collect();
     let return_type = callable.return_type.ty.as_ref().map(|tn| TsReturnType {
         ts_type: type_label_for(cfg, &tn.ty),
-        ffi_converter: ffi_converter_name_for(tn),
+        ffi_converter: ffi_converter_name_for(cfg, tn),
         ffi_type: ffi_type_to_ts_name(&tn.ffi_type.ty),
     });
     let throws = callable
@@ -510,7 +510,7 @@ pub(super) fn build_object(
     let ts_name = class_name.clone();
     let decl_type_name = impl_class_name.clone();
     let obj_factory = format!("uniffiType{impl_class_name}ObjectFactory");
-    let ffi_converter_name = ffi_converter_name_for(&interface.self_type);
+    let ffi_converter_name = ffi_converter_name_for(cfg, &interface.self_type);
     let ffi_error_converter_name = format!("{ffi_converter_name}__as_error");
 
     let docstring = interface.docstring.as_deref().map(format_docstring);

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -382,8 +382,7 @@ impl TsApiModule {
                     deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_map(cfg, map)));
                 }
                 general::TypeDefinition::Custom(custom) => {
-                    let config = cfg.custom_types.get(custom.name.as_str());
-                    let td = TsTypeDefinition::Custom(build_custom_type(cfg, custom, config));
+                    let td = TsTypeDefinition::Custom(build_custom_type(cfg, custom));
                     if matches!(
                         custom.builtin.ty,
                         general::Type::Map { .. }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -134,11 +134,11 @@ impl ImportAccumulator {
         self.add_infra_value("UniffiRustCaller");
     }
 
-    pub fn collect_primitive(&mut self, cfg: &Config, ty: &general::Type) {
+    pub fn collect_primitive(&mut self, config: &Config, ty: &general::Type) {
         if matches!(ty, general::Type::String) {
             return;
         }
-        if let Some(name) = type_helpers::ffi_converter_name_for_type(cfg, ty) {
+        if let Some(name) = type_helpers::ffi_converter_name_for_type(config, ty) {
             self.add_infra_value(&name);
         }
         match ty {
@@ -340,7 +340,7 @@ impl ImportAccumulator {
 
 impl TsApiModule {
     fn build_type_definitions(
-        cfg: &Config,
+        config: &Config,
         namespace: &general::Namespace,
         flavor: &AbiFlavor,
     ) -> Vec<TsTypeDefinition> {
@@ -372,17 +372,17 @@ impl TsApiModule {
                 }
                 general::TypeDefinition::Optional(opt) => {
                     deferred_wrappers
-                        .push(TsTypeDefinition::SimpleWrapper(build_optional(cfg, opt)));
+                        .push(TsTypeDefinition::SimpleWrapper(build_optional(config, opt)));
                 }
                 general::TypeDefinition::Sequence(seq) => {
                     deferred_wrappers
-                        .push(TsTypeDefinition::SimpleWrapper(build_sequence(cfg, seq)));
+                        .push(TsTypeDefinition::SimpleWrapper(build_sequence(config, seq)));
                 }
                 general::TypeDefinition::Map(map) => {
-                    deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_map(cfg, map)));
+                    deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_map(config, map)));
                 }
                 general::TypeDefinition::Custom(custom) => {
-                    let td = TsTypeDefinition::Custom(build_custom_type(cfg, custom));
+                    let td = TsTypeDefinition::Custom(build_custom_type(config, custom));
                     if matches!(
                         custom.builtin.ty,
                         general::Type::Map { .. }
@@ -395,10 +395,10 @@ impl TsApiModule {
                     }
                 }
                 general::TypeDefinition::External(ext) => {
-                    defs.push(TsTypeDefinition::External(build_external_type(cfg, ext)));
+                    defs.push(TsTypeDefinition::External(build_external_type(config, ext)));
                 }
                 general::TypeDefinition::Enum(e) => {
-                    let ts_enum = build_enum(cfg, e, flavor);
+                    let ts_enum = build_enum(config, e, flavor);
                     if ts_enum.is_flat && ts_enum.is_error {
                         defs.push(TsTypeDefinition::FlatError(ts_enum));
                     } else if ts_enum.is_flat {
@@ -408,20 +408,20 @@ impl TsApiModule {
                     }
                 }
                 general::TypeDefinition::Record(r) => {
-                    defs.push(TsTypeDefinition::Record(build_record(cfg, r, flavor)));
+                    defs.push(TsTypeDefinition::Record(build_record(config, r, flavor)));
                 }
                 general::TypeDefinition::Interface(i) => {
                     defs.push(TsTypeDefinition::Object(Box::new(build_object(
-                        cfg,
+                        config,
                         i,
                         flavor,
                         &ffi_fn_types,
-                        cfg.strict_object_types,
+                        config.strict_object_types,
                     ))));
                 }
                 general::TypeDefinition::CallbackInterface(cbi) => {
                     defs.push(TsTypeDefinition::CallbackInterface(
-                        build_callback_interface(cfg, cbi, &ffi_fn_types, flavor),
+                        build_callback_interface(config, cbi, &ffi_fn_types, flavor),
                     ));
                 }
             }
@@ -475,7 +475,7 @@ impl TsApiModule {
     }
 
     pub(crate) fn from_general(
-        cfg: &Config,
+        config: &Config,
         namespace: &general::Namespace,
         flavor: AbiFlavor,
         ffi_exported_definitions: Vec<ffi_module::FfiExportedName>,
@@ -483,26 +483,26 @@ impl TsApiModule {
         let module_name = namespace.name.clone();
         let namespace_docstring = namespace.docstring.as_deref().map(format_docstring);
         let supports_rust_backtrace = flavor.supports_rust_backtrace();
-        let type_definitions = Self::build_type_definitions(cfg, namespace, &flavor);
-        let functions = build_functions(cfg, namespace, &flavor);
+        let type_definitions = Self::build_type_definitions(config, namespace, &flavor);
+        let functions = build_functions(config, namespace, &flavor);
         let initialization = build_initialization(namespace, &flavor);
 
         let mut primitive_imports = ImportAccumulator::new();
         for td in &namespace.type_definitions {
             if let general::TypeDefinition::Simple(node) = td {
-                primitive_imports.collect_primitive(cfg, &node.ty);
+                primitive_imports.collect_primitive(config, &node.ty);
             }
         }
 
         let mut module = Self {
             module_name,
             namespace_docstring,
-            strict_type_checking: cfg.strict_type_checking,
+            strict_type_checking: config.strict_type_checking,
             flavor,
-            is_debug: cfg.is_debug(),
-            is_verbose: cfg.is_verbose(),
+            is_debug: config.is_debug(),
+            is_verbose: config.is_verbose(),
             supports_rust_backtrace,
-            console_import: cfg.console_import.clone(),
+            console_import: config.console_import.clone(),
             file_imports: Vec::new(),
             converter_imports: Vec::new(),
             exported_converters: BTreeSet::new(),

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -21,7 +21,7 @@ use heck::ToUpperCamelCase;
 use uniffi_bindgen::pipeline::general;
 
 use crate::{
-    bindings::gen_typescript::{config::CustomTypeConfig, ffi_module},
+    bindings::gen_typescript::{ffi_module, Config},
     switches::AbiFlavor,
 };
 
@@ -340,10 +340,9 @@ impl ImportAccumulator {
 
 impl TsApiModule {
     fn build_type_definitions(
+        cfg: &Config,
         namespace: &general::Namespace,
         flavor: &AbiFlavor,
-        custom_type_configs: &HashMap<String, CustomTypeConfig>,
-        strict_object_types: bool,
     ) -> Vec<TsTypeDefinition> {
         let mut defs = Vec::new();
 
@@ -372,17 +371,19 @@ impl TsApiModule {
                     }
                 }
                 general::TypeDefinition::Optional(opt) => {
-                    deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_optional(opt)));
+                    deferred_wrappers
+                        .push(TsTypeDefinition::SimpleWrapper(build_optional(cfg, opt)));
                 }
                 general::TypeDefinition::Sequence(seq) => {
-                    deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_sequence(seq)));
+                    deferred_wrappers
+                        .push(TsTypeDefinition::SimpleWrapper(build_sequence(cfg, seq)));
                 }
                 general::TypeDefinition::Map(map) => {
-                    deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_map(map)));
+                    deferred_wrappers.push(TsTypeDefinition::SimpleWrapper(build_map(cfg, map)));
                 }
                 general::TypeDefinition::Custom(custom) => {
-                    let config = custom_type_configs.get(custom.name.as_str());
-                    let td = TsTypeDefinition::Custom(build_custom_type(custom, config));
+                    let config = cfg.custom_types.get(custom.name.as_str());
+                    let td = TsTypeDefinition::Custom(build_custom_type(cfg, custom, config));
                     if matches!(
                         custom.builtin.ty,
                         general::Type::Map { .. }
@@ -395,10 +396,10 @@ impl TsApiModule {
                     }
                 }
                 general::TypeDefinition::External(ext) => {
-                    defs.push(TsTypeDefinition::External(build_external_type(ext)));
+                    defs.push(TsTypeDefinition::External(build_external_type(cfg, ext)));
                 }
                 general::TypeDefinition::Enum(e) => {
-                    let ts_enum = build_enum(e, flavor);
+                    let ts_enum = build_enum(cfg, e, flavor);
                     if ts_enum.is_flat && ts_enum.is_error {
                         defs.push(TsTypeDefinition::FlatError(ts_enum));
                     } else if ts_enum.is_flat {
@@ -408,19 +409,20 @@ impl TsApiModule {
                     }
                 }
                 general::TypeDefinition::Record(r) => {
-                    defs.push(TsTypeDefinition::Record(build_record(r, flavor)));
+                    defs.push(TsTypeDefinition::Record(build_record(cfg, r, flavor)));
                 }
                 general::TypeDefinition::Interface(i) => {
                     defs.push(TsTypeDefinition::Object(Box::new(build_object(
+                        cfg,
                         i,
                         flavor,
                         &ffi_fn_types,
-                        strict_object_types,
+                        cfg.strict_object_types,
                     ))));
                 }
                 general::TypeDefinition::CallbackInterface(cbi) => {
                     defs.push(TsTypeDefinition::CallbackInterface(
-                        build_callback_interface(cbi, &ffi_fn_types, flavor),
+                        build_callback_interface(cfg, cbi, &ffi_fn_types, flavor),
                     ));
                 }
             }
@@ -474,21 +476,16 @@ impl TsApiModule {
     }
 
     pub(crate) fn from_general(
+        cfg: &Config,
         namespace: &general::Namespace,
         flavor: AbiFlavor,
-        config: &super::Config,
         ffi_exported_definitions: Vec<ffi_module::FfiExportedName>,
     ) -> Self {
         let module_name = namespace.name.clone();
         let namespace_docstring = namespace.docstring.as_deref().map(format_docstring);
         let supports_rust_backtrace = flavor.supports_rust_backtrace();
-        let type_definitions = Self::build_type_definitions(
-            namespace,
-            &flavor,
-            &config.custom_types,
-            config.strict_object_types,
-        );
-        let functions = build_functions(namespace, &flavor);
+        let type_definitions = Self::build_type_definitions(cfg, namespace, &flavor);
+        let functions = build_functions(cfg, namespace, &flavor);
         let initialization = build_initialization(namespace, &flavor);
 
         let mut primitive_imports = ImportAccumulator::new();
@@ -501,12 +498,12 @@ impl TsApiModule {
         let mut module = Self {
             module_name,
             namespace_docstring,
-            strict_type_checking: config.strict_type_checking,
+            strict_type_checking: cfg.strict_type_checking,
             flavor,
-            is_debug: config.is_debug(),
-            is_verbose: config.is_verbose(),
+            is_debug: cfg.is_debug(),
+            is_verbose: cfg.is_verbose(),
             supports_rust_backtrace,
-            console_import: config.console_import.clone(),
+            console_import: cfg.console_import.clone(),
             file_imports: Vec::new(),
             converter_imports: Vec::new(),
             exported_converters: BTreeSet::new(),

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -134,11 +134,11 @@ impl ImportAccumulator {
         self.add_infra_value("UniffiRustCaller");
     }
 
-    pub fn collect_primitive(&mut self, ty: &general::Type) {
+    pub fn collect_primitive(&mut self, cfg: &Config, ty: &general::Type) {
         if matches!(ty, general::Type::String) {
             return;
         }
-        if let Some(name) = type_helpers::ffi_converter_name_for_type(ty) {
+        if let Some(name) = type_helpers::ffi_converter_name_for_type(cfg, ty) {
             self.add_infra_value(&name);
         }
         match ty {
@@ -491,7 +491,7 @@ impl TsApiModule {
         let mut primitive_imports = ImportAccumulator::new();
         for td in &namespace.type_definitions {
             if let general::TypeDefinition::Simple(node) = td {
-                primitive_imports.collect_primitive(&node.ty);
+                primitive_imports.collect_primitive(cfg, &node.ty);
             }
         }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
@@ -82,18 +82,18 @@ pub(super) fn type_label_for(cfg: &Config, ty: &general::Type) -> String {
         | general::Type::CallbackInterface { name, .. }
         | general::Type::Custom { name, .. } => rewrite_js_builtins(&name.to_upper_camel_case()),
         general::Type::Optional { inner_type } => {
-            format!("{} | undefined", type_label_for(inner_type))
+            format!("{} | undefined", type_label_for(cfg, inner_type))
         }
         general::Type::Sequence { inner_type } => {
-            format!("Array<{}>", type_label_for(inner_type))
+            format!("Array<{}>", type_label_for(cfg, inner_type))
         }
         general::Type::Map {
             key_type,
             value_type,
         } => format!(
             "Map<{}, {}>",
-            type_label_for(key_type),
-            type_label_for(value_type)
+            type_label_for(cfg, key_type),
+            type_label_for(cfg, value_type)
         ),
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
@@ -18,18 +18,18 @@ pub(super) use crate::bindings::gen_typescript::type_mapping::ffi_type_to_ts as 
 use crate::bindings::gen_typescript::Config;
 
 /// Primitives use short names (`FfiConverterBool`); all others use `FfiConverter{canonical_name}`.
-pub(super) fn ffi_converter_name_for(cfg: &Config, node: &general::TypeNode) -> String {
-    ffi_converter_name_for_type(cfg, &node.ty)
+pub(super) fn ffi_converter_name_for(config: &Config, node: &general::TypeNode) -> String {
+    ffi_converter_name_for_type(config, &node.ty)
         .unwrap_or_else(|| format!("FfiConverter{}", node.canonical_name))
 }
 
 /// Returns `None` for non-primitive types.
-pub(super) fn ffi_converter_name_for_type(cfg: &Config, ty: &general::Type) -> Option<String> {
+pub(super) fn ffi_converter_name_for_type(config: &Config, ty: &general::Type) -> Option<String> {
     let name = match ty {
         general::Type::Boolean => "FfiConverterBool",
         general::Type::String => "FfiConverterString",
         general::Type::Bytes => {
-            if cfg.strict_byte_arrays {
+            if config.strict_byte_arrays {
                 "FfiConverterUint8Array"
             } else {
                 "FfiConverterArrayBuffer"
@@ -52,7 +52,7 @@ pub(super) fn ffi_converter_name_for_type(cfg: &Config, ty: &general::Type) -> O
     Some(name.to_string())
 }
 
-pub(super) fn type_label_for(cfg: &Config, ty: &general::Type) -> String {
+pub(super) fn type_label_for(config: &Config, ty: &general::Type) -> String {
     match ty {
         general::Type::UInt8 => "number".into(),
         general::Type::Int8 => "number".into(),
@@ -67,7 +67,7 @@ pub(super) fn type_label_for(cfg: &Config, ty: &general::Type) -> String {
         general::Type::Boolean => "boolean".into(),
         general::Type::String => "string".into(),
         general::Type::Bytes => {
-            if cfg.strict_byte_arrays {
+            if config.strict_byte_arrays {
                 "Uint8Array".into()
             } else {
                 "ArrayBuffer".into()
@@ -88,18 +88,18 @@ pub(super) fn type_label_for(cfg: &Config, ty: &general::Type) -> String {
         | general::Type::CallbackInterface { name, .. }
         | general::Type::Custom { name, .. } => rewrite_js_builtins(&name.to_upper_camel_case()),
         general::Type::Optional { inner_type } => {
-            format!("{} | undefined", type_label_for(cfg, inner_type))
+            format!("{} | undefined", type_label_for(config, inner_type))
         }
         general::Type::Sequence { inner_type } => {
-            format!("Array<{}>", type_label_for(cfg, inner_type))
+            format!("Array<{}>", type_label_for(config, inner_type))
         }
         general::Type::Map {
             key_type,
             value_type,
         } => format!(
             "Map<{}, {}>",
-            type_label_for(cfg, key_type),
-            type_label_for(cfg, value_type)
+            type_label_for(config, key_type),
+            type_label_for(config, value_type)
         ),
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
@@ -18,8 +18,8 @@ pub(super) use crate::bindings::gen_typescript::type_mapping::ffi_type_to_ts as 
 use crate::bindings::gen_typescript::Config;
 
 /// Primitives use short names (`FfiConverterBool`); all others use `FfiConverter{canonical_name}`.
-pub(super) fn ffi_converter_name_for(node: &general::TypeNode) -> String {
-    ffi_converter_name_for_type(&node.ty)
+pub(super) fn ffi_converter_name_for(cfg: &Config, node: &general::TypeNode) -> String {
+    ffi_converter_name_for_type(cfg, &node.ty)
         .unwrap_or_else(|| format!("FfiConverter{}", node.canonical_name))
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
@@ -15,6 +15,7 @@ use heck::ToLowerCamelCase;
 use uniffi_bindgen::pipeline::general;
 
 pub(super) use crate::bindings::gen_typescript::type_mapping::ffi_type_to_ts as ffi_type_to_ts_name;
+use crate::bindings::gen_typescript::Config;
 
 /// Primitives use short names (`FfiConverterBool`); all others use `FfiConverter{canonical_name}`.
 pub(super) fn ffi_converter_name_for(node: &general::TypeNode) -> String {
@@ -45,7 +46,7 @@ pub(super) fn ffi_converter_name_for_type(ty: &general::Type) -> Option<String> 
     Some(name.to_string())
 }
 
-pub(super) fn type_label_for(ty: &general::Type) -> String {
+pub(super) fn type_label_for(cfg: &Config, ty: &general::Type) -> String {
     match ty {
         general::Type::UInt8 => "number".into(),
         general::Type::Int8 => "number".into(),
@@ -59,7 +60,13 @@ pub(super) fn type_label_for(ty: &general::Type) -> String {
         general::Type::Float64 => "number".into(),
         general::Type::Boolean => "boolean".into(),
         general::Type::String => "string".into(),
-        general::Type::Bytes => "ArrayBuffer".into(),
+        general::Type::Bytes => {
+            if cfg.strict_byte_arrays {
+                "Uint8Array".into()
+            } else {
+                "ArrayBuffer".into()
+            }
+        }
         general::Type::Timestamp => "Date".into(),
         general::Type::Duration => "number".into(),
         general::Type::Interface { name, imp, .. } => {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/type_helpers.rs
@@ -24,11 +24,17 @@ pub(super) fn ffi_converter_name_for(node: &general::TypeNode) -> String {
 }
 
 /// Returns `None` for non-primitive types.
-pub(super) fn ffi_converter_name_for_type(ty: &general::Type) -> Option<String> {
+pub(super) fn ffi_converter_name_for_type(cfg: &Config, ty: &general::Type) -> Option<String> {
     let name = match ty {
         general::Type::Boolean => "FfiConverterBool",
         general::Type::String => "FfiConverterString",
-        general::Type::Bytes => "FfiConverterArrayBuffer",
+        general::Type::Bytes => {
+            if cfg.strict_byte_arrays {
+                "FfiConverterUint8Array"
+            } else {
+                "FfiConverterArrayBuffer"
+            }
+        }
         general::Type::Int8 => "FfiConverterInt8",
         general::Type::Int16 => "FfiConverterInt16",
         general::Type::Int32 => "FfiConverterInt32",

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/config.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/config.rs
@@ -23,6 +23,9 @@ pub(crate) struct TsConfig {
     /// include `@ts-nocheck` to avoid noise in downstream projects).
     #[serde(default)]
     pub(crate) strict_type_checking: bool,
+    /// When `true`, emit byte arrays (`Vec<u8>`) as `Uint8Array` instead of `ArrayBuffer`.
+    #[serde(default)]
+    pub(crate) strict_byte_arrays: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -230,9 +230,9 @@ fn generate_api_from_pipeline(
         );
         let ffi_exports = ffi_module.exported_names();
         let api_module = gen_typescript::api_module::TsApiModule::from_general(
+            &config,
             namespace,
             switches.flavor.clone(),
-            &config,
             ffi_exports,
         );
         let code = gen_typescript::generate_api_code_from_ir(api_module)?;

--- a/docs/src/reference/uniffi-toml.md
+++ b/docs/src/reference/uniffi-toml.md
@@ -15,6 +15,17 @@ this behavior, set `bindings.typescript.strictObjectTypes` to `true`.
 strictObjectTypes = true
 ```
 
+### Typescript strict byte arrays
+
+By default, byte arrays in Rust (i.e. `Vec<u8>`) are translated into Typescript [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) instances. This is advantageous when it is desirable to use a byte array to transport a sequence of more complex types. 
+
+However, not all projects use or want that functionality. To globally translate `Vec<u8>` into [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) instead, set the `strictByteArrays` property of the typescript bindings to `true`.
+
+```toml
+[bindings.typescript]
+strictByteArrays = true
+```
+
 ### Logging the FFI
 
 The generated Typescript code can optionally be created to generate logging.

--- a/fixtures/strict-byte-arrays/Cargo.toml
+++ b/fixtures/strict-byte-arrays/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "uniffi-fixture-strict-byte-arrays"
+edition = "2021"
+version = "0.22.0"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_strict_byte_arrays"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+async-std = "1.12.0"
+thiserror = "1.0"
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+ubrn_macros = { workspace = true }
+ubrn_fixture_testing = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/strict-byte-arrays/src/lib.rs
+++ b/fixtures/strict-byte-arrays/src/lib.rs
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+#[uniffi::export]
+/// This makes the byte array in rust, and the test in JS will compare it there.
+///
+/// This eliminates the possibility of two symmetrical bugs in each of the lift and
+/// lower for the roundtrip tests– this just uses the Rust lower, and the Typescript
+/// lift.
+pub fn well_known_bytes() -> Vec<u8> {
+    vec![1, 2, 3, 255]
+}
+
+#[uniffi::export]
+/// This uses a byte array to pass an argument and return, so it uses lift/lower methods.
+pub fn identity_bytes(bytes: Vec<u8>) -> Vec<u8> {
+    bytes
+}
+
+#[uniffi::export]
+/// This uses an option to force the lift/lower machinery to use read and write
+/// directly from the Option lift and lower, not from the byte array lift and lower.
+pub fn identity_bytes_forced_read(bytes: Option<Vec<u8>>) -> Option<Vec<u8>> {
+    bytes
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/strict-byte-arrays/tests/bindings/test_strict_byte_arrays.ts
+++ b/fixtures/strict-byte-arrays/tests/bindings/test_strict_byte_arrays.ts
@@ -1,0 +1,103 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// To run:
+//   cargo test -p uniffi-fixture-strict-byte-arrays -- jsi
+//   cargo test -p uniffi-fixture-strict-byte-arrays -- wasm
+
+import {
+  identityBytes,
+  identityBytesForcedRead,
+  wellKnownBytes,
+} from "@/generated/uniffi_strict_byte_arrays";
+import { test } from "@/asserts";
+import "@/polyfills";
+
+test("well known array returned", (t) => {
+  const wellKnown = wellKnownBytes();
+  t.assertEqual(4, wellKnown.byteLength);
+  t.assertEqual(new Uint8Array([1, 2, 3, 255]), wellKnown);
+});
+
+test("array equals", (t) => {
+  t.assertEqual(uint8Array(16).byteLength, 16);
+  t.assertEqual(uint8Array(16), uint8Array(16), undefined, byteArrayEquals);
+
+  const mutated = new Uint8Array(uint8Array(32).buffer, 0).reverse();
+  t.assertNotEqual(mutated, uint8Array(32), undefined, byteArrayEquals);
+});
+
+test("array roundtrip using lift/lower", (t) => {
+  function rt(ab: Uint8Array) {
+    t.assertEqual(ab, identityBytes(ab), undefined, byteArrayEquals);
+  }
+  for (let i = 0; i < 64; i++) {
+    rt(uint8Array(i));
+  }
+});
+
+test("array roundtrip using read/write", (t) => {
+  function rt(ab: Uint8Array) {
+    t.assertEqual(ab, identityBytesForcedRead(ab)!, undefined, byteArrayEquals);
+  }
+  for (let i = 0; i < 64; i++) {
+    rt(uint8Array(i));
+  }
+});
+
+test("Uint8Array roundtrip of different sizes", (t) => {
+  function rt(ab: Uint8Array) {
+    t.assertNotNull(identityBytes(ab)!);
+  }
+  // 1 kB = 1<<10
+  // 1 MB = 1<<20
+  // 16 MB = 1<<24
+  for (let i = 0; i < 26; i++) {
+    const byteLength = 1 << i;
+    const buffer = new Uint8Array(byteLength);
+    const start = Date.now();
+    rt(buffer);
+    const end = Date.now();
+    console.log(
+      `Uint8Array roundtrip: ${bytes(byteLength)} in ${end - start} ms`,
+    );
+  }
+});
+
+function bytes(n: number): string {
+  if (n === 0) {
+    return "0 bytes";
+  }
+  if (n < 1 << 10) {
+    return `${n} bytes`;
+  }
+  if (n < 1 << 20) {
+    return `${n / (1 << 10)} kB`;
+  }
+  if (n < 1 << 30) {
+    return `${n / (1 << 20)} MB`;
+  }
+  return `${n / (1 << 30)} GB`;
+}
+
+function byteArrayEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+
+  const len = a.byteLength;
+
+  for (let i = 0; i < len; i++) {
+    if (a.at(i) !== b.at(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function uint8Array(numBytes: number): Uint8Array {
+  return Uint8Array.from({ length: numBytes }, (_v, i) => i % 255);
+}

--- a/fixtures/strict-byte-arrays/tests/test_bindings.rs
+++ b/fixtures/strict-byte-arrays/tests/test_bindings.rs
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+ubrn_macros::build_foreign_language_testcases! {
+    "tests/bindings/test_strict_byte_arrays.ts" => [Jsi, Wasm, Napi],
+}

--- a/fixtures/strict-byte-arrays/uniffi.toml
+++ b/fixtures/strict-byte-arrays/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.typescript]
+strictTypeChecking = true
+strictByteArrays = true

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -348,6 +348,25 @@ export const FfiConverterArrayBuffer = (() => {
   return new FFIConverter();
 })();
 
+export const FfiConverterUint8Array = (() => {
+  const lengthConverter = FfiConverterInt32;
+  class FFIConverter extends AbstractFfiConverterByteArray<Uint8Array> {
+    read(from: RustBuffer): Uint8Array {
+      const length = lengthConverter.read(from);
+      return new Uint8Array(from.readArrayBuffer(length));
+    }
+    write(value: Uint8Array, into: RustBuffer): void {
+      const length = value.byteLength;
+      lengthConverter.write(length, into);
+      into.writeByteArray(value);
+    }
+    allocationSize(value: Uint8Array): number {
+      return lengthConverter.allocationSize(0) + value.byteLength;
+    }
+  }
+  return new FFIConverter();
+})();
+
 type StringConverter = {
   stringToBytes: (s: string) => UniffiByteArray;
   bytesToString: (ab: UniffiByteArray) => string;


### PR DESCRIPTION
For some teams (such as my own) this will be an improvement over rendering them as `ArrayBuffer`.

- Closes #326.

Technique as recommended [here](https://github.com/jhugman/uniffi-bindgen-react-native/issues/326#issuecomment-4127259938).