### PR TITLE
Fix/reserved C++ words template checking

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/filters.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/filters.rs
@@ -3,10 +3,110 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use uniffi_bindgen::{interface::FfiType, ComponentInterface};
 
 use super::extensions::{CppComponentInterfaceExt as _, CppFfiTypeExt as _};
+
+static CPP_KEYWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    HashSet::from([
+        "alignas",
+        "alignof",
+        "and",
+        "and_eq",
+        "asm",
+        "auto",
+        "bitand",
+        "bitor",
+        "bool",
+        "break",
+        "case",
+        "catch",
+        "char",
+        "char8_t",
+        "char16_t",
+        "char32_t",
+        "class",
+        "compl",
+        "concept",
+        "const",
+        "consteval",
+        "constexpr",
+        "constinit",
+        "const_cast",
+        "continue",
+        "co_await",
+        "co_return",
+        "co_yield",
+        "decltype",
+        "default",
+        "delete",
+        "do",
+        "double",
+        "dynamic_cast",
+        "else",
+        "enum",
+        "explicit",
+        "export",
+        "extern",
+        "false",
+        "float",
+        "for",
+        "friend",
+        "goto",
+        "if",
+        "inline",
+        "int",
+        "long",
+        "mutable",
+        "namespace",
+        "new",
+        "noexcept",
+        "not",
+        "not_eq",
+        "nullptr",
+        "operator",
+        "or",
+        "or_eq",
+        "private",
+        "protected",
+        "public",
+        "register",
+        "reinterpret_cast",
+        "requires",
+        "return",
+        "short",
+        "signed",
+        "sizeof",
+        "static",
+        "static_assert",
+        "static_cast",
+        "struct",
+        "switch",
+        "template",
+        "this",
+        "thread_local",
+        "throw",
+        "true",
+        "try",
+        "typedef",
+        "typeid",
+        "typename",
+        "union",
+        "unsigned",
+        "using",
+        "virtual",
+        "void",
+        "volatile",
+        "wchar_t",
+        "while",
+        "xor",
+        "xor_eq",
+    ])
+});
 
 pub fn ffi_type_name_from_js(ffi_type: &FfiType) -> Result<String, askama::Error> {
     Ok(match ffi_type {
@@ -74,8 +174,28 @@ pub fn ffi_type_name(ffi_type: &FfiType) -> Result<String, askama::Error> {
     })
 }
 
+fn rewrite_cpp_keywords(nm: String) -> String {
+    if CPP_KEYWORDS.contains(nm.as_str()) {
+        format!("{nm}_")
+    } else {
+        nm
+    }
+}
+
+pub fn cpp_ident(nm: &str) -> Result<String, askama::Error> {
+    Ok(rewrite_cpp_keywords(nm.to_string()))
+}
+
+pub fn cpp_arg_name(nm: &str) -> Result<String, askama::Error> {
+    cpp_ident(nm)
+}
+
+pub fn cpp_field_name(nm: &str) -> Result<String, askama::Error> {
+    cpp_ident(nm)
+}
+
 pub fn var_name(nm: &str) -> Result<String, askama::Error> {
-    Ok(nm.to_lower_camel_case())
+    Ok(rewrite_cpp_keywords(nm.to_lower_camel_case()))
 }
 
 pub fn ffi_callback_name(nm: &str) -> Result<String, askama::Error> {

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Struct.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/Struct.cpp
@@ -22,14 +22,15 @@ template <> struct Bridging<{{ struct_name }}> {
     // Create the vtable from the js callbacks.
     {%- for field in ffi_struct.fields() %}
     {%-   let rs_field_name = field.name() %}
+    {%-   let cpp_field_name = field.name()|cpp_field_name %}
     {%-   if field.type_().is_callable() %}
-    rsObject.{{ rs_field_name }} = {# space #}
+    rsObject.{{ cpp_field_name }} = {# space #}
     {%-     call cpp::callback_fn_namespace(ffi_struct, field) -%}
         ::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "{{ rs_field_name }}")
         );
     {%-   else %}
-    rsObject.{{ rs_field_name }} = {# space -#}
+    rsObject.{{ cpp_field_name }} = {# space -#}
       {{ field.type_().borrow()|bridging_class(ci) }}::fromJs(
         rt, callInvoker,
         jsObject.getProperty(rt, "{{ rs_field_name }}")

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/macros.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/macros.cpp
@@ -6,7 +6,7 @@
     {%- endmatch %} {# space #}
     {{- func.name() }}(
         {%- for arg in func.arguments() %}
-        {{    arg.type_().borrow()|ffi_type_name_to_rust }} {{ arg.name() }}
+        {{    arg.type_().borrow()|ffi_type_name_to_rust }} {{ arg.name()|cpp_arg_name }}
         {%-   if !loop.last %}, {# space #}
         {%-   endif %}
         {%- endfor %}
@@ -104,7 +104,7 @@ jsi::Value {{ module_name }}::{% call cpp_func_name(func) %}(jsi::Runtime& rt, c
     {%-   endmatch %}
     (*{{  callback.name()|ffi_callback_name }})(
     {%-   for arg in callback.arguments() %}
-    {{ arg.type_().borrow()|ffi_type_name }} {{ arg.name() }}{% if !loop.last %}, {% endif %}
+    {{ arg.type_().borrow()|ffi_type_name }} {{ arg.name()|cpp_arg_name }}{% if !loop.last %}, {% endif %}
     {%-   endfor %}
     {%-   if callback.has_rust_call_status_arg() -%}
     {%      if callback.arguments().len() > 0 %}, {% endif %}RustCallStatus* rust_call_status
@@ -178,7 +178,7 @@ jsi::Value {{ module_name }}::{% call cpp_func_name(func) %}(jsi::Runtime& rt, c
     {%- let struct_name = ffi_struct.name()|ffi_struct_name -%}
     typedef struct {{ struct_name }} {
     {%- for field in ffi_struct.fields() %}
-        {{ field.type_().borrow()|ffi_type_name }} {{ field.name() }};
+        {{ field.type_().borrow()|ffi_type_name }} {{ field.name()|cpp_field_name }};
     {%- endfor %}
     } {{ struct_name }};
 {%- endmacro %}

--- a/fixtures/callbacks-regression/src/lib.rs
+++ b/fixtures/callbacks-regression/src/lib.rs
@@ -14,6 +14,11 @@ pub trait EventListener: Send + Sync {
     fn on_event(&self, message: String, number: i32);
 }
 
+#[uniffi::export(with_foreign)]
+pub trait KeywordListener: Send + Sync {
+    fn delete(&self, value: String) -> String;
+}
+
 #[derive(uniffi::Object)]
 struct EventSource {
     listener: Arc<dyn EventListener>,
@@ -33,4 +38,9 @@ impl EventSource {
             }
         });
     }
+}
+
+#[uniffi::export]
+fn call_delete(listener: Arc<dyn KeywordListener>, value: String) -> String {
+    listener.delete(value)
 }

--- a/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
+++ b/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
@@ -8,10 +8,12 @@
 //   cargo test -p uniffi-example-callbacks-deadlock-regression -- wasm
 
 import generated, {
+  callDelete,
   EventSource,
   EventListener,
+  KeywordListener,
 } from "@/generated/uniffi_callbacks";
-import { asyncTest, AsyncAsserts } from "@/asserts";
+import { asyncTest, AsyncAsserts, test } from "@/asserts";
 import "@/polyfills";
 
 // This is only needed in tests.
@@ -31,11 +33,22 @@ class EventListenerImpl implements EventListener {
   }
 }
 
+class KeywordListenerImpl implements KeywordListener {
+  delete(value: string): string {
+    return `deleted:${value}`;
+  }
+}
+
 async function testToMax(max: number, t: AsyncAsserts) {
   const listener = new EventListenerImpl(t, max);
   const source = new EventSource(listener);
   source.start(`Going to ${max}, now at:`, max);
 }
+
+test("Reserved C++ keyword callback methods work end-to-end", (t) => {
+  const listener = new KeywordListenerImpl();
+  t.assertEqual(callDelete(listener, "abc"), "deleted:abc");
+});
 
 (async () => {
   for (let i = 1; i <= 4096; i *= 2) {

--- a/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
+++ b/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
@@ -34,7 +34,7 @@ class EventListenerImpl implements EventListener {
 }
 
 class KeywordListenerImpl implements KeywordListener {
-  delete(value: string): string {
+  delete_(value: string): string {
     return `deleted:${value}`;
   }
 }

--- a/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
+++ b/fixtures/callbacks-regression/tests/bindings/test_callbacks_regression.ts
@@ -35,6 +35,7 @@ class EventListenerImpl implements EventListener {
 
 class KeywordListenerImpl implements KeywordListener {
   delete_(value: string): string {
+    console.log("delete_", value);
     return `deleted:${value}`;
   }
 }


### PR DESCRIPTION
This PR should fix #387. We found the issue wasn't related to the typescript side since it does check the reserved words. But actually the C++ side where it wasn't doing the same check. I have added some similar functions to the C++ template generation the should emulate the same behavior the typescript generator does. 

I'm not that great at the C++ side of things, so if there is something wrong with my implementation let me know. 

I have added a test to the test_callbacks_regressions.ts. I don't know if this is the best place but I thought since the original example was from the callback area, and it's one test it would be a bit pointless to separate it.