### PR TITLE
NAPI: Resolve the location of the cdylib file, controlled at bindgen time

### DIFF
--- a/.github/workflows/napi-publish.yml
+++ b/.github/workflows/napi-publish.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Move artifacts into npm dirs
         run: npm run artifacts
 
+      - name: Build TypeScript helpers
+        run: npm run build:ts
+
       - name: Assemble root package
         run: npm run assemble-root
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "dlopen2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +590,16 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -1706,6 +1722,7 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "clap",
+ "expect-test",
  "extend",
  "heck",
  "paste",

--- a/crates/ubrn_bindgen/Cargo.toml
+++ b/crates/ubrn_bindgen/Cargo.toml
@@ -39,3 +39,7 @@ optional = true
 [dependencies.proc-macro2]
 version = "1.0"
 optional = true
+
+[dev-dependencies]
+camino = { workspace = true }
+expect-test = "1"

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/builder.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/builder.rs
@@ -19,7 +19,8 @@ impl PlayerFfiModule {
     pub(crate) fn from_general(
         namespace: &general::Namespace,
         config: &TsConfig,
-        lib_path: Option<String>,
+        crate_name: String,
+        lib_resolution: LibResolution,
     ) -> Self {
         let has_async = namespace_has_async(namespace);
 
@@ -34,7 +35,8 @@ impl PlayerFfiModule {
 
         Self {
             strict_type_checking: config.strict_type_checking,
-            lib_path,
+            crate_name,
+            lib_resolution,
             symbols,
             functions,
             callbacks,

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/mod.rs
@@ -8,4 +8,27 @@ mod builder;
 mod nodes;
 mod type_mapping;
 
+pub use nodes::LibResolution;
 pub(crate) use nodes::PlayerFfiModule;
+
+/// Render a minimal player template for snapshot testing. Hidden from API docs.
+#[doc(hidden)]
+pub fn render_minimal_for_test(lib_resolution: LibResolution, crate_name: &str) -> String {
+    use nodes::{PlayerFfiModule, PlayerSymbols};
+    let module = PlayerFfiModule {
+        strict_type_checking: false,
+        crate_name: crate_name.to_string(),
+        lib_resolution,
+        symbols: PlayerSymbols {
+            rustbuffer_alloc: "ubrn_test_alloc".into(),
+            rustbuffer_free: "ubrn_test_free".into(),
+            rustbuffer_from_bytes: "ubrn_test_from_bytes".into(),
+        },
+        functions: Vec::new(),
+        callbacks: Vec::new(),
+        structs: Vec::new(),
+        typed_functions: Vec::new(),
+        typed_definitions: Vec::new(),
+    };
+    super::generate_player_lowlevel_code(module).expect("render")
+}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
@@ -4,6 +4,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+use camino::Utf8PathBuf;
+
+/// How the generated player should locate the cdylib at load time.
+///
+/// Maps 1:1 to the three resolveLibPath modes in `@uniffi-runtime/napi`.
+#[derive(Clone, Debug)]
+pub enum LibResolution {
+    /// Look for the conventional filename next to the binding.
+    Colocated,
+    /// Bake an absolute path into the generated code.
+    Absolute(Utf8PathBuf),
+    /// Resolve via `<base>-<triple>` platform packages.
+    Require(String),
+}
+
 /// IR for the player-style `{namespace}-ffi.ts`.
 ///
 /// Generates a `DEFINITIONS` object for the napi player's `register()` call,
@@ -11,9 +26,10 @@
 pub(crate) struct PlayerFfiModule {
     /// Whether to suppress `@ts-nocheck` for strict type checking.
     pub strict_type_checking: bool,
-    /// Optional library path baked into the generated code.
-    /// If None, the getter accepts a path argument at runtime.
-    pub lib_path: Option<String>,
+    /// The crate name, passed to `resolveLibPath` so error messages name it.
+    pub crate_name: String,
+    /// How the player should locate the library at runtime.
+    pub lib_resolution: LibResolution,
     /// Rustbuffer management symbol names.
     pub symbols: PlayerSymbols,
     /// FFI function registrations for `register({ functions: { ... } })`.

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
@@ -15,6 +15,7 @@ use askama::Template;
 
 use self::api_module::{TsTypeDefinition, TsUniffiTrait};
 use self::ffi_module::FfiDefinitionDecl;
+use self::ffi_module_player::LibResolution;
 pub(crate) use self::{config::TsConfig as Config, util::format_directory};
 
 pub(crate) fn generate_lowlevel_code(ffi_module: ffi_module::TsFfiModule) -> Result<String> {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
@@ -7,8 +7,8 @@
 // @ts-nocheck
 {%- endif %}
 
-import lib from "@uniffi-runtime/napi/lib.js";
-const { UniffiNativeModule, FfiType } = lib;
+import lib from "@uniffi-runtime/napi";
+const { UniffiNativeModule, FfiType, resolveLibPath } = lib;
 
 import {
   type StructuralEquality as UniffiStructuralEquality,
@@ -71,18 +71,17 @@ interface NativeModuleInterface {
 let _nativeModule: NativeModuleInterface | undefined;
 const getter: () => NativeModuleInterface = () => {
   if (!_nativeModule) {
-    {%- match module.lib_path %}
-    {%- when Some with (path) %}
-    const libPath = "{{ path }}";
-    {%- when None %}
-    const libPath = process.env.UNIFFI_LIB_PATH;
-    if (!libPath) {
-      throw new Error(
-        "No library path available. " +
-        "Set the UNIFFI_LIB_PATH environment variable to the path of the shared library."
-      );
-    }
-    {%- endmatch %}
+    const libPath = resolveLibPath({
+      crateName: "{{ module.crate_name }}",
+      callerUrl: import.meta.url,
+      {%- match module.lib_resolution %}
+      {%- when LibResolution::Colocated %}
+      {%- when LibResolution::Absolute with (path) %}
+      override: "{{ path }}",
+      {%- when LibResolution::Require with (base) %}
+      npmPackageBase: "{{ base }}",
+      {%- endmatch %}
+    });
     const mod_ = UniffiNativeModule.open(libPath);
     _nativeModule = mod_.register(DEFINITIONS) as unknown as NativeModuleInterface;
   }

--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -31,6 +31,10 @@ pub struct BindingsArgs {
     #[cfg(feature = "wasm")]
     #[command(flatten)]
     switches: SwitchArgs,
+
+    /// Set by the napi CLI; required for the `Napi` flavor (other flavors ignore it).
+    #[clap(skip)]
+    pub(crate) lib_resolution: Option<gen_typescript::ffi_module_player::LibResolution>,
 }
 
 impl BindingsArgs {
@@ -40,7 +44,16 @@ impl BindingsArgs {
             switches: _switches,
             source,
             output,
+            lib_resolution: None,
         }
+    }
+
+    pub fn with_lib_resolution(
+        mut self,
+        resolution: gen_typescript::ffi_module_player::LibResolution,
+    ) -> Self {
+        self.lib_resolution = Some(resolution);
+        self
     }
 
     pub fn ts_dir(&self) -> &Utf8Path {
@@ -119,6 +132,11 @@ impl SourceArgs {
         }
     }
 
+    /// Returns the source path (a UDL file or library file).
+    pub fn source(&self) -> &Utf8PathBuf {
+        &self.source
+    }
+
     pub fn with_config(self, config: Option<Utf8PathBuf>) -> Self {
         Self {
             config,
@@ -176,7 +194,12 @@ impl BindingsArgs {
         let initial_root = pipeline_loader.load_pipeline_initial_root(&source_path, metadata)?;
         let general_root = general::pipeline("react-native").execute(initial_root)?;
 
-        generate_ffi_from_pipeline(&general_root, &switches, &ts_dir)?;
+        generate_ffi_from_pipeline(
+            &general_root,
+            &switches,
+            &ts_dir,
+            self.lib_resolution.clone(),
+        )?;
         let modules = generate_api_from_pipeline(&general_root, &switches, &ts_dir)?;
         if !out.no_format {
             gen_typescript::format_directory(&ts_dir)?;
@@ -265,6 +288,7 @@ fn generate_ffi_from_pipeline(
     root: &general::Root,
     switches: &SwitchArgs,
     ts_dir: &Utf8Path,
+    lib_resolution: Option<gen_typescript::ffi_module_player::LibResolution>,
 ) -> Result<()> {
     for (name, namespace) in &root.namespaces {
         let module = ModuleMetadata::new(name);
@@ -273,9 +297,18 @@ fn generate_ffi_from_pipeline(
         let config = extract_ts_config(namespace)?;
         let code = match &switches.flavor {
             AbiFlavor::Napi => {
+                let lib_resolution = lib_resolution.clone().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "napi codegen requires a LibResolution; pass --lib-colocated or --lib-absolute"
+                    )
+                })?;
+                let crate_name = namespace.crate_name.clone();
                 let player_module =
                     gen_typescript::ffi_module_player::PlayerFfiModule::from_general(
-                        namespace, &config, None,
+                        namespace,
+                        &config,
+                        crate_name,
+                        lib_resolution,
                     );
                 gen_typescript::generate_player_lowlevel_code(player_module)?
             }

--- a/crates/ubrn_bindgen/src/lib.rs
+++ b/crates/ubrn_bindgen/src/lib.rs
@@ -15,3 +15,14 @@ pub use self::{
     cli::{BindingsArgs, OutputArgs, SourceArgs},
     switches::{AbiFlavor, SwitchArgs},
 };
+
+pub mod ffi_module_player_lib_resolution {
+    pub use crate::bindings::gen_typescript::ffi_module_player::LibResolution;
+}
+
+#[doc(hidden)]
+pub mod __player_template_test {
+    pub use crate::bindings::gen_typescript::ffi_module_player::{
+        render_minimal_for_test, LibResolution,
+    };
+}

--- a/crates/ubrn_bindgen/tests/player_template_snapshots.rs
+++ b/crates/ubrn_bindgen/tests/player_template_snapshots.rs
@@ -1,0 +1,101 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use expect_test::expect;
+use ubrn_bindgen::__player_template_test::{render_minimal_for_test, LibResolution};
+
+fn extract_getter_block(rendered: &str) -> String {
+    let start = rendered
+        .find("let _nativeModule")
+        .expect("could not find getter start in rendered template");
+    let end = rendered
+        .find("export default getter;")
+        .expect("could not find getter end in rendered template");
+    rendered[start..end].trim().to_string() + "\nexport default getter;"
+}
+
+#[test]
+fn template_colocated() {
+    let rendered = render_minimal_for_test(LibResolution::Colocated, "my_crate");
+    expect![[r#"
+        let _nativeModule: NativeModuleInterface | undefined;
+        const getter: () => NativeModuleInterface = () => {
+          if (!_nativeModule) {
+            const libPath = resolveLibPath({
+              crateName: "my_crate",
+              callerUrl: import.meta.url,
+            });
+            const mod_ = UniffiNativeModule.open(libPath);
+            _nativeModule = mod_.register(DEFINITIONS) as unknown as NativeModuleInterface;
+          }
+          return _nativeModule;
+        };
+        export default getter;"#]]
+    .assert_eq(&extract_getter_block(&rendered));
+}
+
+#[test]
+fn template_absolute() {
+    let rendered = render_minimal_for_test(
+        LibResolution::Absolute(camino::Utf8PathBuf::from("/abs/lib.so")),
+        "my_crate",
+    );
+    expect![[r#"
+        let _nativeModule: NativeModuleInterface | undefined;
+        const getter: () => NativeModuleInterface = () => {
+          if (!_nativeModule) {
+            const libPath = resolveLibPath({
+              crateName: "my_crate",
+              callerUrl: import.meta.url,
+              override: "/abs/lib.so",
+            });
+            const mod_ = UniffiNativeModule.open(libPath);
+            _nativeModule = mod_.register(DEFINITIONS) as unknown as NativeModuleInterface;
+          }
+          return _nativeModule;
+        };
+        export default getter;"#]]
+    .assert_eq(&extract_getter_block(&rendered));
+}
+
+#[test]
+fn template_require() {
+    let rendered =
+        render_minimal_for_test(LibResolution::Require("@scope/foo".to_string()), "my_crate");
+    expect![[r#"
+        let _nativeModule: NativeModuleInterface | undefined;
+        const getter: () => NativeModuleInterface = () => {
+          if (!_nativeModule) {
+            const libPath = resolveLibPath({
+              crateName: "my_crate",
+              callerUrl: import.meta.url,
+              npmPackageBase: "@scope/foo",
+            });
+            const mod_ = UniffiNativeModule.open(libPath);
+            _nativeModule = mod_.register(DEFINITIONS) as unknown as NativeModuleInterface;
+          }
+          return _nativeModule;
+        };
+        export default getter;"#]]
+    .assert_eq(&extract_getter_block(&rendered));
+}
+
+#[test]
+fn template_absolute_with_windows_path_uses_forward_slashes() {
+    // Even on darwin, the snapshot test exercises that the template renders
+    // a path with forward slashes verbatim — which is what we'll feed it from
+    // resolve_lib_resolution after backslash normalization.
+    let rendered = render_minimal_for_test(
+        LibResolution::Absolute(camino::Utf8PathBuf::from("C:/Users/foo/lib.dll")),
+        "my_crate",
+    );
+    let block = extract_getter_block(&rendered);
+    assert!(
+        block.contains(r#"override: "C:/Users/foo/lib.dll""#),
+        "expected forward-slash path in rendered template, got:\n{block}"
+    );
+    // No backslash should appear in the rendered string literal.
+    assert!(!block.contains('\\'), "backslash leaked: {block}");
+}

--- a/crates/ubrn_cli/src/napi/generate.rs
+++ b/crates/ubrn_cli/src/napi/generate.rs
@@ -6,8 +6,10 @@
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
-use clap::{Args, Subcommand};
-use ubrn_bindgen::{AbiFlavor, OutputArgs, SourceArgs, SwitchArgs};
+use clap::{ArgGroup, Args, Subcommand};
+use ubrn_bindgen::{
+    ffi_module_player_lib_resolution::LibResolution, AbiFlavor, OutputArgs, SourceArgs, SwitchArgs,
+};
 
 #[derive(Args, Debug)]
 pub(crate) struct CmdArg {
@@ -31,8 +33,10 @@ impl Cmd {
     fn run(&self) -> Result<()> {
         match self {
             Self::Bindings(b) => {
-                let b = ubrn_bindgen::BindingsArgs::from(b);
-                b.run(None)?;
+                // Validate before any I/O.
+                let resolution = b.resolve_lib_resolution()?;
+                let bb = ubrn_bindgen::BindingsArgs::from(b).with_lib_resolution(resolution);
+                bb.run(None)?;
                 Ok(())
             }
         }
@@ -40,6 +44,12 @@ impl Cmd {
 }
 
 #[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("lib_resolution")
+        .args(["lib_colocated", "lib_absolute"])
+        .multiple(false)
+        .required(true)
+))]
 pub(crate) struct BindingsArgs {
     #[command(flatten)]
     pub(crate) source: SourceArgs,
@@ -51,6 +61,43 @@ pub(crate) struct BindingsArgs {
     /// The directory in which to put the generated Typescript.
     #[clap(long)]
     pub(crate) ts_dir: Utf8PathBuf,
+
+    /// Generated bindings call resolveLibPath in colocated mode.
+    /// The binary must sit next to the generated `.js` file at runtime.
+    #[clap(long = "lib-colocated")]
+    pub(crate) lib_colocated: bool,
+
+    /// Generated bindings bake the value of --library as an absolute override path.
+    /// Requires --library; the path must be absolute.
+    #[clap(long = "lib-absolute", requires = "library_mode")]
+    pub(crate) lib_absolute: bool,
+}
+
+impl BindingsArgs {
+    fn resolve_lib_resolution(&self) -> Result<LibResolution> {
+        if self.lib_colocated {
+            return Ok(LibResolution::Colocated);
+        }
+        if self.lib_absolute {
+            // SourceArgs.source carries --library's path when --library is set.
+            let path = self.source.source();
+            if !path.is_absolute() {
+                anyhow::bail!(
+                    "--lib-absolute requires --library to be an absolute path; got: {}",
+                    path,
+                );
+            }
+            // Normalize backslashes to forward slashes so the rendered TS string
+            // is valid on Windows (Node accepts forward slashes on all platforms).
+            // Explicit replace, not path-slash, since path-slash's behavior is
+            // host-OS-dependent and we need cross-platform string normalization
+            // here (the codegen output is consumed by Node on any OS).
+            let normalized = Utf8PathBuf::from(path.as_str().replace('\\', "/"));
+            return Ok(LibResolution::Absolute(normalized));
+        }
+        // clap's ArgGroup(required = true) on lib_resolution rejects this case at parse.
+        unreachable!("clap should have rejected: no --lib-* flag passed")
+    }
 }
 
 impl From<&BindingsArgs> for ubrn_bindgen::BindingsArgs {
@@ -63,5 +110,98 @@ impl From<&BindingsArgs> for ubrn_bindgen::BindingsArgs {
             value.source.clone(),
             OutputArgs::new(&value.ts_dir, &value.ts_dir, value.no_format),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        cmd: Cmd,
+    }
+
+    fn parse(args: &[&str]) -> Result<TestCli, clap::Error> {
+        let mut full = vec!["test", "bindings"];
+        full.extend_from_slice(args);
+        TestCli::try_parse_from(&full)
+    }
+
+    #[test]
+    fn lib_colocated_alone_parses() {
+        let r = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-colocated",
+            "--library",
+            "/tmp/foo.dylib",
+        ]);
+        assert!(r.is_ok(), "got: {:?}", r.err().map(|e| e.to_string()));
+    }
+
+    #[test]
+    fn lib_absolute_with_library_parses() {
+        let r = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-absolute",
+            "--library",
+            "/tmp/foo.dylib",
+        ]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn lib_absolute_with_relative_library_errors() {
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-absolute",
+            "--library",
+            "rel/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        assert!(b.resolve_lib_resolution().is_err());
+    }
+
+    #[test]
+    fn lib_absolute_without_library_errors() {
+        // --lib-absolute requires --library (via clap requires = "library_mode")
+        let r = parse(&["--ts-dir", "/tmp/ts", "--lib-absolute", "/tmp/foo.dylib"]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn neither_flag_errors() {
+        // ArgGroup is required; missing both --lib-colocated and --lib-absolute
+        // must fail at parse time.
+        let r = parse(&["--ts-dir", "/tmp/ts", "--library", "/tmp/foo.dylib"]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn both_lib_flags_errors() {
+        let r = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-colocated",
+            "--lib-absolute",
+            "--library",
+            "/tmp/foo.dylib",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn lib_absolute_normalizes_backslashes_in_path() {
+        // Cross-platform string-level normalization (we can't exercise
+        // resolve_lib_resolution end-to-end on non-Windows hosts because
+        // Utf8Path::is_absolute() rejects "C:\..." on Unix).
+        let backslash_path = "C:\\Users\\foo\\lib.dll";
+        assert_eq!(backslash_path.replace('\\', "/"), "C:/Users/foo/lib.dll");
     }
 }

--- a/crates/ubrn_fixture_testing/src/lib.rs
+++ b/crates/ubrn_fixture_testing/src/lib.rs
@@ -160,13 +160,7 @@ pub(crate) fn write_fixture_tsconfig(
     let repo_root = paths::repo_root();
     let rel_root = relative_path(repo_root, fixture_dir);
 
-    let napi_runtime_path = if flavor == Flavor::Napi {
-        format!(
-            ",\n      \"@uniffi-runtime/napi\": [\"{rel_root}/runtimes/napi\"],\n      \"@uniffi-runtime/napi/*\": [\"{rel_root}/runtimes/napi/*\"]"
-        )
-    } else {
-        String::new()
-    };
+    let runtime_paths = tsconfig_runtimes(flavor, &rel_root);
 
     let tsconfig_path = fixture_dir.join("tsconfig.json");
     let contents = format!(
@@ -176,7 +170,7 @@ pub(crate) fn write_fixture_tsconfig(
     "paths": {{
       "@/generated/*": ["./generated/{flavor_str}/ts/*"],
       "@/*": ["{rel_root}/typescript/testing/*"],
-      "uniffi-bindgen-react-native": ["{rel_root}/typescript/src/index"]{napi_runtime_path}
+      {runtime_paths}
     }}
   }}
 }}
@@ -184,6 +178,18 @@ pub(crate) fn write_fixture_tsconfig(
     );
     std::fs::write(&tsconfig_path, contents).expect("failed to write fixture tsconfig.json");
     tsconfig_path
+}
+
+fn tsconfig_runtimes(flavor: Flavor, rel_root: &Utf8PathBuf) -> String {
+    let mut runtime_paths = vec![format!(
+        r#""uniffi-bindgen-react-native": ["{rel_root}/typescript/src/index"]"#
+    )];
+    if flavor == Flavor::Napi {
+        runtime_paths.push(format!(
+            r#""@uniffi-runtime/napi": ["{rel_root}/runtimes/napi/lib"]"#
+        ));
+    }
+    runtime_paths.join(",\n      ")
 }
 
 /// Run a test script with tsx and experimental WASM module support.

--- a/crates/ubrn_fixture_testing/src/napi.rs
+++ b/crates/ubrn_fixture_testing/src/napi.rs
@@ -37,12 +37,12 @@ pub fn run_test(crate_name: &str, test_script: &str, _target_tmpdir: &str) {
     let ts_dir = generated_napi.join("ts");
     generate_bindings(&cdylib_path, &ts_dir);
 
-    // Step 3: Write fixture tsconfig, then run tsx with the library path.
+    // Step 3: Write fixture tsconfig, then run tsx.
     let _tsconfig_guard = crate::CleanupFile::new(crate::write_fixture_tsconfig(
         &fixture_dir,
         crate::Flavor::Napi,
     ));
-    run_test_runner(test_script, &cdylib_path);
+    run_test_runner(test_script);
 }
 
 /// Build the N-API runtime (debug mode) if not already built.
@@ -69,6 +69,7 @@ fn generate_bindings(cdylib_path: &Utf8Path, ts_dir: &Utf8Path) {
             .arg("generate")
             .arg("napi")
             .arg("bindings")
+            .arg("--lib-absolute")
             .arg("--library")
             .arg("--ts-dir")
             .arg(ts_dir.as_str())
@@ -76,12 +77,8 @@ fn generate_bindings(cdylib_path: &Utf8Path, ts_dir: &Utf8Path) {
     );
 }
 
-/// Run tsx with UNIFFI_LIB_PATH set so the generated code can find the library.
-fn run_test_runner(test_script: &Utf8Path, cdylib_path: &Utf8Path) {
+/// Run tsx to execute the test script.
+fn run_test_runner(test_script: &Utf8Path) {
     let tsx = paths::node_modules_bin().join("tsx");
-    run_cmd(
-        crate::command(tsx.as_str())
-            .env("UNIFFI_LIB_PATH", cdylib_path.as_str())
-            .arg(test_script.as_str()),
-    );
+    run_cmd(crate::command(tsx.as_str()).arg(test_script.as_str()));
 }

--- a/runtimes/napi/lib.js
+++ b/runtimes/napi/lib.js
@@ -4,9 +4,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 const native = require("./index.js");
+const {
+  resolveLibPath,
+  ResolveLibPathError,
+} = require("./typescript/dist/resolve-lib.js");
 
 module.exports = {
   ...native,
+  resolveLibPath,
+  ResolveLibPathError,
   FfiType: {
     UInt8: { tag: "UInt8" },
     Int8: { tag: "Int8" },

--- a/runtimes/napi/package-lock.json
+++ b/runtimes/napi/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "@uniffi-runtime/napi",
-  "version": "0.1.0",
+  "version": "0.31.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniffi-runtime/napi",
-      "version": "0.1.0",
+      "version": "0.31.0-2",
+      "license": "MPL-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
-        "prettier": "^3.8.1"
+        "@types/node": "^20.0.0",
+        "prettier": "^3.8.1",
+        "typescript": "^5.4.0"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -29,6 +32,16 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
@@ -44,6 +57,27 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/runtimes/napi/package.json
+++ b/runtimes/napi/package.json
@@ -46,21 +46,26 @@
     "index.js",
     "lib.js",
     "index.d.ts",
+    "typescript/dist/",
     "*.node",
     "README.md"
   ],
   "scripts": {
-    "build": "napi build --platform --release --js-package-name @uniffi-runtime/napi",
-    "build:debug": "napi build --platform --js-package-name @uniffi-runtime/napi",
+    "build:ts": "tsc -p typescript",
+    "build": "npm run build:ts && napi build --platform --release --js-package-name @uniffi-runtime/napi",
+    "build:debug": "npm run build:ts && napi build --platform --js-package-name @uniffi-runtime/napi",
     "artifacts": "napi artifacts --dir artifacts",
     "create-npm-dirs": "napi create-npm-dir -t .",
     "assemble-root": "node ./scripts/assemble-root.mjs",
     "prepare": "npm run build",
     "fmt": "prettier --write . && cargo fmt",
-    "test": "node --import ./tests/setup.mjs --test tests/*.test.mjs"
+    "test": "node --import ./tests/setup.mjs --test tests/*.test.mjs",
+    "test:ts": "node --test tests/resolve-lib.test.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",
-    "prettier": "^3.8.1"
+    "@types/node": "^20.0.0",
+    "prettier": "^3.8.1",
+    "typescript": "^5.4.0"
   }
 }

--- a/runtimes/napi/scripts/assemble-root.mjs
+++ b/runtimes/napi/scripts/assemble-root.mjs
@@ -5,6 +5,8 @@
  */
 import {
   copyFileSync,
+  cpSync,
+  existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -42,6 +44,16 @@ mkdirSync(rootDir, { recursive: true });
 for (const f of COPY_FILES) {
   copyFileSync(join(pkgDir, f), join(rootDir, f));
 }
+
+// lib.js requires typescript/dist/resolve-lib.js at runtime.
+const tsDist = join(pkgDir, "typescript", "dist");
+if (!existsSync(tsDist)) {
+  console.error(
+    `Missing ${tsDist} — run \`npm run build:ts\` before assemble-root.`,
+  );
+  process.exit(1);
+}
+cpSync(tsDist, join(rootDir, "typescript", "dist"), { recursive: true });
 
 const src = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 const workspaceRoot = JSON.parse(

--- a/runtimes/napi/tests/resolve-lib.test.mjs
+++ b/runtimes/napi/tests/resolve-lib.test.mjs
@@ -1,0 +1,332 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { detectTripleForTesting } from "../typescript/dist/resolve-lib.js";
+import {
+  resolveLibPath,
+  ResolveLibPathError,
+  setDetectTripleForTesting,
+} from "../typescript/dist/resolve-lib.js";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "resolve-lib-"));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// Stub helper: build a fake `process`-like object the detector accepts.
+function fakeProcess(platform, arch, { glibc = false } = {}) {
+  return {
+    platform,
+    arch,
+    report: {
+      getReport() {
+        return {
+          header: glibc ? { glibcVersionRuntime: "2.31" } : {},
+        };
+      },
+    },
+  };
+}
+
+test("triple: darwin arm64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("darwin", "arm64")),
+    "darwin-arm64",
+  );
+});
+
+test("triple: darwin x64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("darwin", "x64")),
+    "darwin-x64",
+  );
+});
+
+test("triple: linux x64 gnu", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("linux", "x64", { glibc: true })),
+    "linux-x64-gnu",
+  );
+});
+
+test("triple: linux x64 musl", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("linux", "x64", { glibc: false })),
+    "linux-x64-musl",
+  );
+});
+
+test("triple: linux arm64 gnu", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("linux", "arm64", { glibc: true })),
+    "linux-arm64-gnu",
+  );
+});
+
+test("triple: linux arm64 musl", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("linux", "arm64", { glibc: false })),
+    "linux-arm64-musl",
+  );
+});
+
+test("triple: win32 x64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("win32", "x64")),
+    "win32-x64-msvc",
+  );
+});
+
+test("triple: win32 arm64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("win32", "arm64")),
+    "win32-arm64-msvc",
+  );
+});
+
+test("triple: unsupported platform throws", () => {
+  assert.throws(
+    () => detectTripleForTesting(fakeProcess("freebsd", "x64")),
+    /Unsupported platform.*freebsd.*x64/,
+  );
+});
+
+test("triple: unsupported arch throws", () => {
+  assert.throws(
+    () => detectTripleForTesting(fakeProcess("darwin", "ia32")),
+    /Unsupported platform.*darwin.*ia32/,
+  );
+});
+
+test("override: absolute existing path returns it verbatim", () => {
+  const { dir, cleanup } = makeTempDir();
+  try {
+    const lib = join(dir, "libfoo.dylib");
+    writeFileSync(lib, "");
+    const got = resolveLibPath({
+      crateName: "foo",
+      callerUrl: pathToFileURL(join(dir, "caller.js")).toString(),
+      override: lib,
+    });
+    assert.equal(got, lib);
+  } finally {
+    cleanup();
+  }
+});
+
+test("override: relative path throws", () => {
+  try {
+    resolveLibPath({
+      crateName: "foo",
+      callerUrl: pathToFileURL("/tmp/caller.js").toString(),
+      override: "./relative/lib.so",
+    });
+    assert.fail("expected throw");
+  } catch (e) {
+    assert.ok(e instanceof ResolveLibPathError);
+    assert.equal(e.mode, "override");
+    assert.match(e.message, /must be absolute/);
+    assert.deepEqual(e.attempted, ["./relative/lib.so"]);
+  }
+});
+
+test("override: missing absolute path throws", () => {
+  try {
+    resolveLibPath({
+      crateName: "foo",
+      callerUrl: pathToFileURL("/tmp/caller.js").toString(),
+      override: "/nonexistent/abs/lib.so",
+    });
+    assert.fail("expected throw");
+  } catch (e) {
+    assert.ok(e instanceof ResolveLibPathError);
+    assert.equal(e.mode, "override");
+    assert.match(e.message, /does not exist/);
+    assert.deepEqual(e.attempted, ["/nonexistent/abs/lib.so"]);
+  }
+});
+
+test("colocated: file URL caller resolves to sibling lib", () => {
+  const { dir, cleanup } = makeTempDir();
+  try {
+    const ext =
+      process.platform === "darwin"
+        ? "dylib"
+        : process.platform === "win32"
+          ? "dll"
+          : "so";
+    const fileName =
+      process.platform === "win32" ? `foo.${ext}` : `libfoo.${ext}`;
+    const lib = join(dir, fileName);
+    writeFileSync(lib, "");
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    const got = resolveLibPath({ crateName: "foo", callerUrl });
+    assert.equal(got, lib);
+  } finally {
+    cleanup();
+  }
+});
+
+test("colocated: __filename-style raw path works the same", () => {
+  const { dir, cleanup } = makeTempDir();
+  try {
+    const ext =
+      process.platform === "darwin"
+        ? "dylib"
+        : process.platform === "win32"
+          ? "dll"
+          : "so";
+    const fileName =
+      process.platform === "win32" ? `foo.${ext}` : `libfoo.${ext}`;
+    const lib = join(dir, fileName);
+    writeFileSync(lib, "");
+    const got = resolveLibPath({
+      crateName: "foo",
+      callerUrl: join(dir, "caller.js"),
+    });
+    assert.equal(got, lib);
+  } finally {
+    cleanup();
+  }
+});
+
+test("colocated: missing file throws", () => {
+  const { dir, cleanup } = makeTempDir();
+  try {
+    try {
+      resolveLibPath({
+        crateName: "foo",
+        callerUrl: pathToFileURL(join(dir, "caller.js")).toString(),
+      });
+      assert.fail("expected throw");
+    } catch (e) {
+      assert.ok(e instanceof ResolveLibPathError);
+      assert.equal(e.mode, "colocated");
+      assert.match(e.message, /Could not find lib for crate "foo" colocated/);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+function buildSyntheticPackage(rootDir, base, triple, libFile) {
+  const pkgDir = join(rootDir, "node_modules", `${base}-${triple}`);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify({ name: `${base}-${triple}`, version: "0.0.0" }),
+  );
+  if (libFile !== null) writeFileSync(join(pkgDir, libFile), "");
+  return pkgDir;
+}
+
+test("npmPackageBase: package + binary present returns binary path", () => {
+  const { dir, cleanup } = makeTempDir();
+  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  try {
+    const ext =
+      process.platform === "darwin"
+        ? "dylib"
+        : process.platform === "win32"
+          ? "dll"
+          : "so";
+    const libFile =
+      process.platform === "win32" ? `foo.${ext}` : `libfoo.${ext}`;
+    const pkgDir = buildSyntheticPackage(
+      dir,
+      "@scope/foo",
+      "darwin-arm64",
+      libFile,
+    );
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    const got = resolveLibPath({
+      crateName: "foo",
+      callerUrl,
+      npmPackageBase: "@scope/foo",
+    });
+    assert.equal(got, join(realpathSync(pkgDir), libFile));
+  } finally {
+    setDetectTripleForTesting(restore);
+    cleanup();
+  }
+});
+
+test("npmPackageBase: package missing throws and names triple + base", () => {
+  const { dir, cleanup } = makeTempDir();
+  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  try {
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    try {
+      resolveLibPath({
+        crateName: "foo",
+        callerUrl,
+        npmPackageBase: "@scope/foo",
+      });
+      assert.fail("expected throw");
+    } catch (e) {
+      assert.ok(e instanceof ResolveLibPathError);
+      assert.equal(e.mode, "npmPackageBase");
+      assert.match(e.message, /@scope\/foo-darwin-arm64/);
+      assert.match(e.message, /darwin-arm64/);
+    }
+  } finally {
+    setDetectTripleForTesting(restore);
+    cleanup();
+  }
+});
+
+test("npmPackageBase: package present but binary missing throws malformed", () => {
+  const { dir, cleanup } = makeTempDir();
+  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  try {
+    buildSyntheticPackage(dir, "@scope/foo", "darwin-arm64", null);
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    try {
+      resolveLibPath({
+        crateName: "foo",
+        callerUrl,
+        npmPackageBase: "@scope/foo",
+      });
+      assert.fail("expected throw");
+    } catch (e) {
+      assert.ok(e instanceof ResolveLibPathError);
+      assert.equal(e.mode, "npmPackageBase");
+      assert.match(e.message, /malformed/);
+      assert.equal(e.attempted.length, 1);
+    }
+  } finally {
+    setDetectTripleForTesting(restore);
+    cleanup();
+  }
+});
+
+test("public API: lib.js re-exports resolveLibPath and ResolveLibPathError", async (t) => {
+  let lib;
+  try {
+    lib = (await import("../lib.js")).default;
+  } catch {
+    // lib.js requires the native NAPI binary which may not be built in
+    // TypeScript-only verification environments (e.g. CI without Rust).
+    t.skip("native binary not available; skipping lib.js import check");
+    return;
+  }
+  assert.equal(typeof lib.resolveLibPath, "function");
+  assert.equal(typeof lib.ResolveLibPathError, "function");
+});

--- a/runtimes/napi/typescript/src/resolve-lib.ts
+++ b/runtimes/napi/typescript/src/resolve-lib.ts
@@ -1,0 +1,187 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface ProcessLike {
+  platform: NodeJS.Platform;
+  arch: string;
+  report?: { getReport(): { header?: { glibcVersionRuntime?: string } } };
+}
+
+function detectTriple(proc: ProcessLike): string {
+  const { platform, arch } = proc;
+  if (platform === "darwin" && arch === "arm64") return "darwin-arm64";
+  if (platform === "darwin" && arch === "x64") return "darwin-x64";
+  if (platform === "linux" && (arch === "x64" || arch === "arm64")) {
+    const isGnu =
+      proc.report?.getReport()?.header?.glibcVersionRuntime !== undefined;
+    return `linux-${arch}-${isGnu ? "gnu" : "musl"}`;
+  }
+  if (platform === "win32" && (arch === "x64" || arch === "arm64")) {
+    return `win32-${arch}-msvc`;
+  }
+  throw new Error(
+    `Unsupported platform/arch combination: ${platform}/${arch}. ` +
+      `Supported: darwin-{arm64,x64}, linux-{x64,arm64}-{gnu,musl}, win32-{x64,arm64}-msvc.`,
+  );
+}
+
+/** Test-only export. Do not use from production code. */
+export function detectTripleForTesting(proc: ProcessLike): string {
+  return detectTriple(proc);
+}
+
+export type ResolveMode = "override" | "npmPackageBase" | "colocated";
+
+export class ResolveLibPathError extends Error {
+  readonly mode: ResolveMode;
+  readonly crateName: string;
+  readonly attempted: string[];
+  override readonly cause?: unknown;
+
+  constructor(args: {
+    message: string;
+    mode: ResolveMode;
+    crateName: string;
+    attempted: string[];
+    cause?: unknown;
+  }) {
+    super(args.message);
+    this.name = "ResolveLibPathError";
+    this.mode = args.mode;
+    this.crateName = args.crateName;
+    this.attempted = args.attempted;
+    if (args.cause !== undefined) this.cause = args.cause;
+  }
+}
+
+export type ResolveLibPathOptions = {
+  crateName: string;
+  callerUrl: string;
+} & (
+  | { override: string; npmPackageBase?: never }
+  | { npmPackageBase: string; override?: never }
+  | { override?: never; npmPackageBase?: never }
+);
+
+function callerDir(callerUrl: string): string {
+  const path = callerUrl.startsWith("file://")
+    ? fileURLToPath(callerUrl)
+    : callerUrl;
+  return dirname(path);
+}
+
+function libFileName(crateName: string, platform: NodeJS.Platform): string {
+  if (platform === "win32") return `${crateName}.dll`;
+  const ext = platform === "darwin" ? "dylib" : "so";
+  return `lib${crateName}.${ext}`;
+}
+
+export function resolveLibPath(opts: ResolveLibPathOptions): string {
+  if ("override" in opts && opts.override !== undefined) {
+    return resolveOverride(opts.crateName, opts.override);
+  }
+  if ("npmPackageBase" in opts && opts.npmPackageBase !== undefined) {
+    return resolveNpmPackage(
+      opts.crateName,
+      opts.callerUrl,
+      opts.npmPackageBase,
+    );
+  }
+  return resolveColocated(opts.crateName, opts.callerUrl);
+}
+
+function resolveColocated(crateName: string, callerUrl: string): string {
+  const candidate = join(
+    callerDir(callerUrl),
+    libFileName(crateName, process.platform),
+  );
+  if (!existsSync(candidate)) {
+    throw new ResolveLibPathError({
+      message: `Could not find lib for crate "${crateName}" colocated with caller. Looked for: ${candidate}.`,
+      mode: "colocated",
+      crateName,
+      attempted: [candidate],
+    });
+  }
+  return candidate;
+}
+
+function resolveOverride(crateName: string, path: string): string {
+  if (!isAbsolute(path)) {
+    throw new ResolveLibPathError({
+      message: `Override path must be absolute; got "${path}".`,
+      mode: "override",
+      crateName,
+      attempted: [path],
+    });
+  }
+  if (!existsSync(path)) {
+    throw new ResolveLibPathError({
+      message: `Override path "${path}" for crate "${crateName}" does not exist.`,
+      mode: "override",
+      crateName,
+      attempted: [path],
+    });
+  }
+  return path;
+}
+
+let _detectTripleImpl: () => string = () =>
+  detectTriple(process as ProcessLike);
+
+/** Test-only seam to override triple detection. Returns the previous impl. */
+export function setDetectTripleForTesting(fn: () => string): () => string {
+  const prev = _detectTripleImpl;
+  _detectTripleImpl = fn;
+  return prev;
+}
+
+function resolveNpmPackage(
+  crateName: string,
+  callerUrl: string,
+  npmPackageBase: string,
+): string {
+  const triple = _detectTripleImpl();
+  const pkgName = `${npmPackageBase}-${triple}`;
+  const require_ = createRequire(callerUrl);
+
+  let pkgJsonPath: string;
+  try {
+    pkgJsonPath = require_.resolve(`${pkgName}/package.json`);
+  } catch (cause) {
+    throw new ResolveLibPathError({
+      message:
+        `Could not find platform package for crate "${crateName}": tried "${pkgName}". ` +
+        `Detected platform: ${triple}. Either the package is not installed (run npm install) ` +
+        `or this platform is not in the published matrix.`,
+      mode: "npmPackageBase",
+      crateName,
+      attempted: [pkgName],
+      cause,
+    });
+  }
+
+  const binaryPath = join(
+    dirname(pkgJsonPath),
+    libFileName(crateName, process.platform),
+  );
+  if (!existsSync(binaryPath)) {
+    throw new ResolveLibPathError({
+      message:
+        `Platform package "${pkgName}" is installed but does not contain ` +
+        `"${libFileName(crateName, process.platform)}" — package layout is malformed.`,
+      mode: "npmPackageBase",
+      crateName,
+      attempted: [binaryPath],
+    });
+  }
+  return binaryPath;
+}

--- a/runtimes/napi/typescript/tsconfig.json
+++ b/runtimes/napi/typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This PR introduces a resolve-lib module into the NAPI runtime.

This looks after the finding of the correct filename for the platform (e.g. `.so` for linux, `.dll` for windows, etc) and finding it on disk.

Three strategies:
- absolute: use an absolute path to the cdylib file.
- colocated: located next to the generated file
- use npm: use require to look up the path to a file installed via NPM.
