### PR TITLE
Audit default positions and types, add fixture, fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,6 +2034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-defaults"
+version = "0.22.0"
+dependencies = [
+ "ubrn_fixture_testing",
+ "ubrn_macros",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-enum-types"
 version = "0.22.0"
 dependencies = [

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -221,12 +221,14 @@ pub(super) fn build_variant(config: &Config, variant: &general::Variant) -> TsVa
         .map(|field| build_field(config, field))
         .collect();
     let has_nameless_fields = matches!(variant.fields_kind, general::FieldsKind::Unnamed);
+    let has_field_defaults = fields.iter().any(|f| f.default_value.is_some());
     TsVariant {
         name,
         docstring,
         discriminant,
         fields,
         has_nameless_fields,
+        has_field_defaults,
     }
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -150,7 +150,58 @@ fn render_literal(config: &Config, lit: &general::Literal) -> String {
 fn render_default_value(config: &Config, dv: &general::DefaultValue) -> String {
     match dv {
         general::DefaultValue::Literal(lit_node) => render_literal(config, &lit_node.lit),
-        general::DefaultValue::Default(_) => "undefined".into(),
+        general::DefaultValue::Default(tn) => render_type_default(config, &tn.ty),
+    }
+}
+
+fn render_type_default(_config: &Config, ty: &general::Type) -> String {
+    // Per the uniffi-rs default-values docs, the bare `default` keyword maps
+    // each type to its natural zero-value: 0 for numerics, false, empty
+    // string/bytes/sequence/map, None for Option, all-defaults for Record,
+    // primary-constructor-with-0-args for Object. uniffi-rs validates these
+    // are well-formed at the Rust side (e.g. Record only accepts the bare
+    // default if every field itself has a default).
+    match ty {
+        general::Type::UInt8
+        | general::Type::UInt16
+        | general::Type::UInt32
+        | general::Type::Int8
+        | general::Type::Int16
+        | general::Type::Int32
+        | general::Type::Float32
+        | general::Type::Float64 => "0".into(),
+        general::Type::UInt64 | general::Type::Int64 => "BigInt(0)".into(),
+        general::Type::Boolean => "false".into(),
+        general::Type::String => "\"\"".into(),
+        general::Type::Bytes => "new Uint8Array()".into(),
+        general::Type::Optional { .. } => "undefined".into(),
+        general::Type::Sequence { .. } => "[]".into(),
+        general::Type::Map { .. } => "new Map()".into(),
+        general::Type::Custom { builtin, .. } => render_type_default(_config, builtin),
+        general::Type::Record { name, .. } => {
+            let name = rewrite_js_builtins(&name.to_upper_camel_case());
+            format!("{name}.create({{}})")
+        }
+        general::Type::Interface { name, imp, .. } if imp.has_struct() => {
+            // Struct-impl objects: parameter type is `{name}Like` and the
+            // concrete impl class is `{name}`, so `new {name}()` produces a
+            // value assignable to the parameter type.
+            let name = rewrite_js_builtins(&name.to_upper_camel_case());
+            format!("new {name}()")
+        }
+        // No clear default semantic in the uniffi-rs docs:
+        // - Enum: no canonical "first variant" for tagged or flat enums.
+        // - Trait / CallbackTrait Interface: the impl class wraps a Rust-side
+        //   handle and can't be constructed from JS without one.
+        // - CallbackInterface: not constructible from JS as a runtime default.
+        // - Timestamp / Duration: not enumerated; uniffi-rs Python bindings
+        //   reject these, and we don't expect bare default to be used here.
+        // Fall back to `undefined` so strict-mode TS surfaces the gap.
+        general::Type::Enum { .. }
+        | general::Type::Interface { .. }
+        | general::Type::CallbackInterface { .. }
+        | general::Type::Timestamp
+        | general::Type::Duration => "undefined".into(),
     }
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -212,6 +212,12 @@ impl ImportAccumulator {
         if e.has_callables() {
             self.add_infra_value("uniffiTypeNameSymbol");
         }
+        if e.variants
+            .iter()
+            .any(|v| v.has_field_defaults && !v.has_nameless_fields)
+        {
+            self.add_infra_value("uniffiCreateRecord");
+        }
         self.collect_uniffi_traits(&e.uniffi_traits);
         self.collect_callables(&e.constructors);
         self.collect_callables(&e.methods);

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
@@ -72,6 +72,7 @@ pub(crate) struct TsVariant {
     pub discriminant: String,
     pub fields: Vec<TsField>,
     pub has_nameless_fields: bool,
+    pub has_field_defaults: bool,
 }
 
 pub(crate) struct TsEnum {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -333,8 +333,13 @@ Readonly<{%- if !variant.has_nameless_fields %}{
 {%- if !variant.has_nameless_fields %}
 inner: { {%- for field in variant.fields %}{% call field_decl(field) %}{%- if !loop.last %}; {% endif %}{%- endfor %} }
 {%- else %}
-{%- for field in variant.fields %}v{{ loop.index0 }}: {{ field.ts_type }}{%- if !loop.last %}, {% endif %}{%- endfor %}
+{%- for field in variant.fields %}v{{ loop.index0 }}: {{ field.ts_type }}{%- if let Some(dv) = field.default_value %} = {{ dv }}{%- endif %}{%- if !loop.last %}, {% endif %}{%- endfor %}
 {%- endif %}
+{%- endmacro %}
+
+{#- Bare object type for a named variant's inner shape: { name: Type; ... } (no Readonly wrap). -#}
+{%- macro variant_inner_named_type(variant) -%}
+{ {%- for field in variant.fields %}{% call field_decl(field) %}{%- if !loop.last %}; {% endif %}{%- endfor %} }
 {%- endmacro %}
 
 {#- Variant constructor body: freeze inner. -#}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -47,9 +47,25 @@ export const {{ type_name }} = (() => {
 {% call cb::variant_ctor_body(variant) %}
         }
 
+        {%- if !is_tuple && variant.has_field_defaults %}
+        static new = (() => {
+            type Inner = {% call cb::variant_inner_named_type(variant) %};
+            const defaults = () => ({
+                {%- for field in variant.fields %}
+                {%- if let Some(dv) = field.default_value %}
+                {{ field.name }}: {{ dv }}{%- if !loop.last %},{% endif %}
+                {%- endif %}
+                {%- endfor %}
+            });
+            const create = uniffiCreateRecord<Inner, ReturnType<typeof defaults>>(defaults);
+            return (partial: Parameters<typeof create>[0]): {{ variant_class }} =>
+                new {{ variant_class }}(create(partial));
+        })();
+        {%- else %}
         static new({% call cb::variant_fields_decl(variant) %}): {{ variant_class }} {
             return new {{ variant_class }}({% call cb::variant_new_args(variant) %});
         }
+        {%- endif %}
         {%- else %}
         constructor() {
             super("{{ type_name }}", "{{ external_name }}");

--- a/fixtures/defaults/Cargo.toml
+++ b/fixtures/defaults/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uniffi-fixture-defaults"
+edition = "2021"
+version = "0.22.0"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_defaults"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+ubrn_macros = { workspace = true }
+ubrn_fixture_testing = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/defaults/src/lib.rs
+++ b/fixtures/defaults/src/lib.rs
@@ -1,0 +1,178 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+#[derive(uniffi::Enum, Debug, PartialEq, Eq, Clone)]
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+// Function-arg defaults across the literal value forms.
+#[uniffi::export(default(value = 42))]
+pub fn echo_i32(value: i32) -> i32 {
+    value
+}
+
+#[uniffi::export(default(value = "hello"))]
+pub fn echo_string(value: String) -> String {
+    value
+}
+
+#[uniffi::export(default(value = true))]
+pub fn echo_bool(value: bool) -> bool {
+    value
+}
+
+#[uniffi::export(default(value = None))]
+pub fn echo_option_none(value: Option<i32>) -> Option<i32> {
+    value
+}
+
+#[uniffi::export(default(value = Some(7)))]
+pub fn echo_option_some(value: Option<i32>) -> Option<i32> {
+    value
+}
+
+// Enum-variant literals as a default value (e.g. `default = Color::Green`)
+// are not accepted by uniffi-rs' DefaultValue parser, so this function is
+// exported without a default; the test confirms round-trip codegen instead.
+#[uniffi::export]
+pub fn echo_color(value: Color) -> Color {
+    value
+}
+
+// Constructor and method arg defaults.
+#[derive(uniffi::Object)]
+pub struct Greeter {
+    prefix: String,
+}
+
+#[uniffi::export]
+impl Greeter {
+    #[uniffi::constructor(default(prefix = "hi", _version = 1))]
+    pub fn new(prefix: String, _version: i32) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self { prefix })
+    }
+
+    #[uniffi::method(default(name = "world"))]
+    pub fn greet(&self, name: String) -> String {
+        format!("{} {}", self.prefix, name)
+    }
+}
+
+// Record field defaults.
+#[derive(uniffi::Record, Debug, PartialEq, Eq, Clone)]
+pub struct Settings {
+    #[uniffi(default = 10)]
+    pub retries: i32,
+    #[uniffi(default = None)]
+    pub label: Option<String>,
+    pub required: String,
+}
+
+#[uniffi::export]
+pub fn echo_settings(value: Settings) -> Settings {
+    value
+}
+
+// Defaults on enum-variant fields, both named-variant and tuple-variant.
+#[derive(uniffi::Enum, Debug, PartialEq, Eq, Clone)]
+pub enum TestCase {
+    One {
+        #[uniffi(default = 100)]
+        num_value: i32,
+    },
+    Two {
+        #[uniffi(default = None)]
+        maybe_label: Option<String>,
+        required: String,
+    },
+    Three(#[uniffi(default = 5)] i32),
+}
+
+#[uniffi::export]
+pub fn echo_test_case(value: TestCase) -> TestCase {
+    value
+}
+
+// Defaulted arg after a non-defaulted arg.
+#[uniffi::export(default(suffix = "!"))]
+pub fn join(prefix: String, suffix: String) -> String {
+    format!("{prefix}{suffix}")
+}
+
+// Trait method with a default arg, called from foreign code.
+#[uniffi::export(with_foreign)]
+pub trait Formatter: Send + Sync {
+    #[uniffi::method(default(width = 2))]
+    fn format(&self, value: i32, width: i32) -> String;
+}
+
+#[uniffi::export]
+pub fn use_formatter(f: std::sync::Arc<dyn Formatter>) -> String {
+    f.format(7, 4)
+}
+
+// Bare-keyword `default` form: uniffi-rs maps `#[uniffi(default)]` on a field
+// and `default(arg)` (no `= value`) on a function arg to the type's default
+// value (i32 → 0, String → "", Option → None, etc).
+#[derive(uniffi::Record, Debug, PartialEq, Eq, Clone)]
+pub struct BareDefaults {
+    #[uniffi(default)]
+    pub n: i32,
+    pub required: String,
+}
+
+#[uniffi::export]
+pub fn echo_bare_defaults(value: BareDefaults) -> BareDefaults {
+    value
+}
+
+#[uniffi::export(default(value))]
+pub fn echo_bare_arg(value: i32) -> i32 {
+    value
+}
+
+// Bare default on a Record-typed arg: uniffi-rs requires every field of the
+// record to carry a default; codegen renders `AllDefaults.create({})`.
+#[derive(uniffi::Record, Debug, PartialEq, Eq, Clone)]
+pub struct AllDefaults {
+    #[uniffi(default = 1)]
+    pub a: i32,
+    #[uniffi(default = "x")]
+    pub b: String,
+}
+
+#[uniffi::export(default(value))]
+pub fn echo_bare_record_arg(value: AllDefaults) -> AllDefaults {
+    value
+}
+
+// Bare default on an Object-typed arg: uniffi-rs requires a 0-arg primary
+// constructor; codegen renders `new ZeroArgObj()`.
+#[derive(uniffi::Object)]
+pub struct ZeroArgObj {}
+
+#[uniffi::export]
+impl ZeroArgObj {
+    #[uniffi::constructor]
+    pub fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {})
+    }
+
+    #[uniffi::method]
+    pub fn label(&self) -> String {
+        "z".into()
+    }
+}
+
+#[uniffi::export(default(value))]
+pub fn echo_bare_obj_arg(value: std::sync::Arc<ZeroArgObj>) -> std::sync::Arc<ZeroArgObj> {
+    value
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/defaults/tests/bindings/test_defaults.ts
+++ b/fixtures/defaults/tests/bindings/test_defaults.ts
@@ -1,0 +1,165 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// To run:
+//   cargo test -p uniffi-fixture-defaults -- napi
+
+import theModule, {
+  BareDefaults,
+  Color,
+  Formatter,
+  Greeter,
+  Settings,
+  TestCase,
+  echoBareArg,
+  echoBareDefaults,
+  echoBareObjArg,
+  echoBareRecordArg,
+  echoBool,
+  echoColor,
+  echoI32,
+  echoOptionNone,
+  echoOptionSome,
+  echoSettings,
+  echoString,
+  echoTestCase,
+  join,
+  useFormatter,
+} from "@/generated/uniffi_defaults";
+import { Asserts, test, xtest } from "@/asserts";
+import "@/polyfills";
+
+// Initialize the module so that callback-interface vtables are registered
+// with Rust before any callback-bearing function is called.
+theModule.initialize();
+
+test("function arg default: i32", (t) => {
+  t.assertEqual(42, echoI32());
+  t.assertEqual(7, echoI32(7));
+});
+
+test("function arg default: String", (t) => {
+  t.assertEqual("hello", echoString());
+  t.assertEqual("world", echoString("world"));
+});
+
+test("function arg default: bool", (t) => {
+  t.assertEqual(true, echoBool());
+  t.assertEqual(false, echoBool(false));
+});
+
+test("function arg default: Option<T> = None", (t) => {
+  t.assertEqual(undefined, echoOptionNone());
+  t.assertEqual(3, echoOptionNone(3));
+});
+
+test("function arg default: Option<T> = Some(7)", (t) => {
+  t.assertEqual(7, echoOptionSome());
+  t.assertEqual(11, echoOptionSome(11));
+});
+
+test("function arg default: enum variant (round-trip)", (t) => {
+  t.assertEqual(Color.Blue, echoColor(Color.Blue));
+});
+
+// uniffi-rs' DefaultValue parser rejects path expressions like Color::Green,
+// so echo_color cannot carry a default value. If uniffi-rs gains support, flip
+// this xtest to test.
+xtest("function arg default: enum variant", (t) => {
+  // t.assertEqual(Color.Green, echoColor());
+});
+
+test("constructor arg defaults", (t) => {
+  const g = new Greeter();
+  t.assertEqual("hi world", g.greet());
+});
+
+test("method arg default", (t) => {
+  const g = new Greeter("hello");
+  t.assertEqual("hello world", g.greet());
+  t.assertEqual("hello there", g.greet("there"));
+});
+
+test("record field defaults: only required field provided", (t) => {
+  const s = Settings.create({ required: "go" });
+  t.assertEqual(10, s.retries);
+  t.assertEqual(undefined, s.label);
+  t.assertEqual("go", s.required);
+});
+
+test("record field defaults: roundtrip", (t) => {
+  const s = Settings.create({ required: "go", retries: 3, label: "hello" });
+  const out = echoSettings(s);
+  t.assertEqual(3, out.retries);
+  t.assertEqual("hello", out.label);
+  t.assertEqual("go", out.required);
+});
+
+test("enum variant named field default: i32", (t: Asserts) => {
+  const v = TestCase.One.new({});
+  t.assertEqual(100, v.inner.numValue);
+  const out = echoTestCase(v);
+  t.assertInstanceOf(out, TestCase.One.instanceOf);
+  t.assertEqual(100, out.inner.numValue);
+});
+
+test("enum variant named field default: Option<T>=None", (t: Asserts) => {
+  const v = TestCase.Two.new({ required: "r" });
+  t.assertEqual(undefined, v.inner.maybeLabel);
+  t.assertEqual("r", v.inner.required);
+  const out = echoTestCase(v);
+  t.assertInstanceOf(out, TestCase.Two.instanceOf);
+  t.assertEqual(undefined, out.inner.maybeLabel);
+  t.assertEqual("r", out.inner.required);
+});
+
+test("enum variant tuple field default: i32", (t: Asserts) => {
+  const v = TestCase.Three.new();
+  t.assertEqual(5, v.inner[0]);
+  const out = echoTestCase(v);
+  t.assertInstanceOf(out, TestCase.Three.instanceOf);
+  t.assertEqual(5, out.inner[0]);
+});
+
+test("ordering: defaulted arg after non-defaulted", (t) => {
+  t.assertEqual("hi!", join("hi"));
+  t.assertEqual("hi?", join("hi", "?"));
+});
+
+test("bare default on record field (i32 → T::default())", (t) => {
+  const v = BareDefaults.create({ required: "r" });
+  t.assertEqual(0, v.n);
+  const out = echoBareDefaults(v);
+  t.assertEqual(0, out.n);
+  t.assertEqual("r", out.required);
+});
+
+test("bare default on function arg (i32 → T::default())", (t) => {
+  t.assertEqual(0, echoBareArg());
+  t.assertEqual(7, echoBareArg(7));
+});
+
+test("bare default on Record-typed arg → RecordName.create({})", (t) => {
+  const out = echoBareRecordArg();
+  t.assertEqual(1, out.a);
+  t.assertEqual("x", out.b);
+});
+
+test("bare default on Object-typed arg → new ClassName()", (t) => {
+  const out = echoBareObjArg();
+  t.assertEqual("z", out.label());
+});
+
+// The width=2 default on Formatter.format is not visible to JS callers:
+// arg_list_protocol strips defaults from protocol declarations, and Rust's
+// use_formatter passes width=4 explicitly. The default is not exercised here.
+test("trait method default (callback from JS)", (t) => {
+  const f: Formatter = {
+    format(value: number, width: number) {
+      return value.toString().padStart(width, "0");
+    },
+  };
+  t.assertEqual("0007", useFormatter(f));
+});

--- a/fixtures/defaults/tests/test_bindings.rs
+++ b/fixtures/defaults/tests/test_bindings.rs
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+ubrn_macros::build_foreign_language_testcases! {
+    "tests/bindings/test_defaults.ts" => [Napi, Jsi],
+}

--- a/fixtures/defaults/uniffi.toml
+++ b/fixtures/defaults/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.typescript]
+strictTypeChecking = true

--- a/typescript/testing/asserts.ts
+++ b/typescript/testing/asserts.ts
@@ -128,6 +128,17 @@ export class Asserts {
         `${resolveMessage(message, "Not in range")}: ${min} <= ${left} <= ${max}`,
     );
   }
+  assertInstanceOf<T>(
+    obj: any,
+    guard: (o: any) => o is T,
+    message?: Message,
+  ): asserts obj is T {
+    this.assertTrue(
+      guard(obj),
+      () =>
+        `${resolveMessage(message, "Expected instanceOf to be true")}: ${stringify(obj)}`,
+    );
+  }
 
   /// We can't use instanceof here: hermes does not seem to generate the right
   /// prototype chain, so we'll check the error message instead.


### PR DESCRIPTION
Fixes #372

This PR adds a defaults fixture to exercise each position and type where defaults can appear with uniffi's procmacros.

We fix three bugs:
- enum variants with structs
- enum variants with tuples
- `T::default()` in arg positions.

Thanks @alastaircoote for filing the issue!