### PR TITLE
Benchmark and single copy optimizations

### DIFF
--- a/cpp/includes/Bridging.h
+++ b/cpp/includes/Bridging.h
@@ -10,6 +10,13 @@ namespace uniffi_jsi {
 // Declare the Bridging template
 template <typename T> struct Bridging;
 
+// Property name used to stash a Rust-side capacity hint on a Uint8Array
+// view that aliases Rust-owned memory. Set by `Bridging<RustBuffer>::toJs`
+// when `capacity != len`; read by the JSI `rustbufferFree` host function
+// to free with the original allocation's capacity. Defining this once
+// here avoids silent drift between the two sites.
+constexpr const char *kUbrnRustCapacity = "__ubrnRustCapacity";
+
 /* ArrayBuffer constructor expects MutableBuffer*/
 class CMutableBuffer : public jsi::MutableBuffer {
 public:
@@ -21,5 +28,18 @@ private:
   uint8_t *_data;
   size_t len;
 };
+
+// Wrap an `ArrayBuffer` as a `Uint8Array` by invoking the JS-side
+// `Uint8Array` constructor. Used wherever native code hands a buffer of
+// bytes to JS — the wasm/napi runtimes expose `Uint8Array` directly, and
+// JSI follows suit so converters can decode against a single shape. The
+// constructor lookup is a fast Hermes dictionary read; caching is a
+// possible follow-up if profiling shows it's worth the plumbing.
+inline jsi::Object arraybufferToUint8Array(jsi::Runtime &rt,
+                                           jsi::ArrayBuffer arrayBuffer) {
+  auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
+  return u8ctor.callAsConstructor(rt, jsi::Value(rt, std::move(arrayBuffer)))
+      .asObject(rt);
+}
 
 } // namespace uniffi_jsi

--- a/cpp/test-harness/test-runner.cpp
+++ b/cpp/test-harness/test-runner.cpp
@@ -23,6 +23,7 @@ static const char *s_jslib =
 #include "MyCallInvoker.h"
 #include <ReactCommon/CallInvoker.h>
 #include <hermes/hermes.h>
+#include <jsi/instrumentation.h>
 
 /// Read the contents of a file into a string.
 static std::optional<std::string> readFile(const char *path) {
@@ -129,10 +130,58 @@ static double currentTimeMillis() {
       .count();
 }
 
+static void installPerformanceNow(facebook::jsi::Runtime &runtime) {
+  auto fn = facebook::jsi::Function::createFromHostFunction(
+      runtime,
+      facebook::jsi::PropNameID::forAscii(runtime, "__performanceNow"),
+      0,
+      [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
+         const facebook::jsi::Value *, size_t) -> facebook::jsi::Value {
+        auto now = std::chrono::steady_clock::now().time_since_epoch();
+        double ms = std::chrono::duration<double, std::milli>(now).count();
+        return facebook::jsi::Value(ms);
+      });
+  runtime.global().setProperty(runtime, "__performanceNow", fn);
+}
+
+static void installHeapInfo(facebook::jsi::Runtime &runtime) {
+  auto fn = facebook::jsi::Function::createFromHostFunction(
+      runtime,
+      facebook::jsi::PropNameID::forAscii(runtime, "__hermesHeapInfo"),
+      0,
+      [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
+         const facebook::jsi::Value *, size_t) -> facebook::jsi::Value {
+        auto info = rt.instrumentation().getHeapInfo(/*includeExpensive=*/false);
+        facebook::jsi::Object out(rt);
+        for (const auto &kv : info) {
+          out.setProperty(rt, kv.first.c_str(),
+                          facebook::jsi::Value(static_cast<double>(kv.second)));
+        }
+        return facebook::jsi::Value(rt, out);
+      });
+  runtime.global().setProperty(runtime, "__hermesHeapInfo", fn);
+}
+
+static void installGc(facebook::jsi::Runtime &runtime) {
+  auto fn = facebook::jsi::Function::createFromHostFunction(
+      runtime,
+      facebook::jsi::PropNameID::forAscii(runtime, "__hermesGc"),
+      0,
+      [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
+         const facebook::jsi::Value *, size_t) -> facebook::jsi::Value {
+        rt.instrumentation().collectGarbage("test-runner");
+        return facebook::jsi::Value::undefined();
+      });
+  runtime.global().setProperty(runtime, "__hermesGc", fn);
+}
+
 static int runEventLoop(facebook::jsi::Runtime &runtime,
                         std::shared_ptr<uniffi::testing::MyCallInvoker> invoker,
                         const std::string &jsCode, const char *jsPath) {
   try {
+    installPerformanceNow(runtime);
+    installHeapInfo(runtime);
+    installGc(runtime);
     facebook::jsi::Object helpers =
         runtime
             .evaluateJavaScript(

--- a/cpp/test-harness/test-runner.cpp
+++ b/cpp/test-harness/test-runner.cpp
@@ -132,8 +132,7 @@ static double currentTimeMillis() {
 
 static void installPerformanceNow(facebook::jsi::Runtime &runtime) {
   auto fn = facebook::jsi::Function::createFromHostFunction(
-      runtime,
-      facebook::jsi::PropNameID::forAscii(runtime, "__performanceNow"),
+      runtime, facebook::jsi::PropNameID::forAscii(runtime, "__performanceNow"),
       0,
       [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
          const facebook::jsi::Value *, size_t) -> facebook::jsi::Value {
@@ -146,12 +145,12 @@ static void installPerformanceNow(facebook::jsi::Runtime &runtime) {
 
 static void installHeapInfo(facebook::jsi::Runtime &runtime) {
   auto fn = facebook::jsi::Function::createFromHostFunction(
-      runtime,
-      facebook::jsi::PropNameID::forAscii(runtime, "__hermesHeapInfo"),
+      runtime, facebook::jsi::PropNameID::forAscii(runtime, "__hermesHeapInfo"),
       0,
       [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
          const facebook::jsi::Value *, size_t) -> facebook::jsi::Value {
-        auto info = rt.instrumentation().getHeapInfo(/*includeExpensive=*/false);
+        auto info =
+            rt.instrumentation().getHeapInfo(/*includeExpensive=*/false);
         facebook::jsi::Object out(rt);
         for (const auto &kv : info) {
           out.setProperty(rt, kv.first.c_str(),
@@ -164,9 +163,7 @@ static void installHeapInfo(facebook::jsi::Runtime &runtime) {
 
 static void installGc(facebook::jsi::Runtime &runtime) {
   auto fn = facebook::jsi::Function::createFromHostFunction(
-      runtime,
-      facebook::jsi::PropNameID::forAscii(runtime, "__hermesGc"),
-      0,
+      runtime, facebook::jsi::PropNameID::forAscii(runtime, "__hermesGc"), 0,
       [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
          const facebook::jsi::Value *, size_t) -> facebook::jsi::Value {
         rt.instrumentation().collectGarbage("test-runner");

--- a/cpp/test-harness/timers.js.inc
+++ b/cpp/test-harness/timers.js.inc
@@ -55,6 +55,49 @@ R"((function() {
     globalThis.setImmediate = setImmediate;
     globalThis.clearImmediate = clearImmediate;
 
+    if (typeof globalThis.gc === 'undefined' &&
+        typeof globalThis.__hermesGc === 'function') {
+        globalThis.gc = globalThis.__hermesGc;
+    }
+
+    if (typeof globalThis.process === 'undefined' &&
+        typeof globalThis.__hermesHeapInfo === 'function') {
+        var hostHeapInfo = globalThis.__hermesHeapInfo;
+        globalThis.process = {
+            memoryUsage: function() {
+                var info = hostHeapInfo();
+                var heapUsed = info.hermes_allocatedBytes || 0;
+                var heapTotal = info.hermes_heapSize || 0;
+                // Hermes' mallocSizeEstimate covers off-heap memory it knows
+                // about (e.g. ArrayBuffer backing stores registered with the
+                // GC). It's the closest analog to Node's `external`.
+                var external = info.hermes_mallocSizeEstimate || 0;
+                return {
+                    rss: heapTotal,
+                    heapTotal: heapTotal,
+                    heapUsed: heapUsed,
+                    external: external,
+                    arrayBuffers: 0,
+                };
+            },
+        };
+    }
+
+    if (typeof globalThis.performance === 'undefined') {
+        var hostNow = globalThis.__performanceNow;
+        if (typeof hostNow === 'function') {
+            var perfOrigin = hostNow();
+            globalThis.performance = {
+                now: function() { return hostNow() - perfOrigin; }
+            };
+        } else {
+            var perfStart = Date.now();
+            globalThis.performance = {
+                now: function() { return Date.now() - perfStart; }
+            };
+        }
+    }
+
     return {peek: peekMacroTask, run: runMacroTask};
 })();
 )"

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustBufferHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustBufferHelper.cpp
@@ -50,24 +50,33 @@ template <> struct Bridging<RustBuffer> {
 
   static jsi::Value toJs(jsi::Runtime &rt, std::shared_ptr<CallInvoker>,
                          RustBuffer buf) {
-    // We need to make a copy of the bytes from Rust's memory space into
-    // Javascripts memory space. We need to do this because the two languages
-    // manages memory very differently: a garbage collector needs to track all
-    // the memory at runtime, Rust is doing it all closer to compile time.
-    uint8_t *bytes = new uint8_t[buf.len];
-    std::memcpy(bytes, buf.data, buf.len);
-
-    // Construct an ArrayBuffer with copy of the bytes from the RustBuffer.
+    // View-handoff: hand JS a `Uint8Array` view aliasing the Rust-owned bytes
+    // (no boundary copy). The single mandatory copy now happens inside
+    // `converter.lift(view)` (string decode, byte-array `set`, field-by-field
+    // record reads). The codegen-emitted try/finally calls `rustbuffer_free`
+    // on the view after `lift` returns, releasing the Rust allocation.
+    //
+    // Capacity hint: Rust may return a buffer where `capacity > len`. The
+    // view's `byteLength` is `len` (so converters that decode the whole view
+    // see only the message bytes), but `rustbuffer_free` needs `capacity` to
+    // free correctly. We stash `capacity` on the view via a string-keyed
+    // property when it differs from `len`; the JSI `rustbufferFree` host
+    // function reads it back and falls back to `byteLength` for views from
+    // `rustbufferAlloc(n)` where `byteLength == capacity` already.
+    //
+    // CMutableBuffer is non-owning here: its destructor leaves `buf.data`
+    // alone. Only the codegen-emitted `rustbuffer_free` path frees it.
     auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(
-        uniffi_jsi::CMutableBuffer((uint8_t *)bytes, buf.len));
+        buf.data, static_cast<size_t>(buf.len));
     auto arrayBuffer = jsi::ArrayBuffer(rt, payload);
-
-    // Once we have a Javascript version, we no longer need the Rust version, so
-    // we can call into Rust to tell it it's okay to free that memory.
-    rustbuffer_free(buf);
-
-    // Finally, return the ArrayBuffer.
-    return uniffi_jsi::Bridging<jsi::ArrayBuffer>::arraybuffer_to_value(rt, arrayBuffer);;
+    auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
+    auto view = u8ctor.callAsConstructor(rt, jsi::Value(rt, arrayBuffer))
+                    .asObject(rt);
+    if (buf.capacity != static_cast<uint64_t>(buf.len)) {
+      view.setProperty(rt, "__ubrnRustCapacity",
+                       jsi::Value(static_cast<double>(buf.capacity)));
+    }
+    return jsi::Value(rt, view);
   }
 };
 

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustBufferHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustBufferHelper.cpp
@@ -68,12 +68,10 @@ template <> struct Bridging<RustBuffer> {
     // alone. Only the codegen-emitted `rustbuffer_free` path frees it.
     auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(
         buf.data, static_cast<size_t>(buf.len));
-    auto arrayBuffer = jsi::ArrayBuffer(rt, payload);
-    auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
-    auto view = u8ctor.callAsConstructor(rt, jsi::Value(rt, arrayBuffer))
-                    .asObject(rt);
+    auto view = uniffi_jsi::arraybufferToUint8Array(
+        rt, jsi::ArrayBuffer(rt, payload));
     if (buf.capacity != static_cast<uint64_t>(buf.len)) {
-      view.setProperty(rt, "__ubrnRustCapacity",
+      view.setProperty(rt, uniffi_jsi::kUbrnRustCapacity,
                        jsi::Value(static_cast<double>(buf.capacity)));
     }
     return jsi::Value(rt, view);

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustCallStatusHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustCallStatusHelper.cpp
@@ -18,9 +18,23 @@ template <> struct Bridging<RustCallStatus> {
                          const jsi::Value &jsStatus) {
     auto statusObject = jsStatus.asObject(rt);
     if (status.error_buf.data != nullptr) {
-      auto rbuf = Bridging<RustBuffer>::toJs(rt, callInvoker,
-                                                         status.error_buf);
-      statusObject.setProperty(rt, "errorBuf", rbuf);
+      // The error path is NOT wrapped in the codegen-emitted try/finally that
+      // covers normal returns: `errorBuf` is read by the runtime's call-status
+      // dispatcher (rust-call.ts) which throws straight to the user without
+      // ever calling `rustbuffer_free`. Switching this site to view-handoff
+      // would leak the Rust allocation, so we keep the copy semantics here:
+      // copy the bytes into a JS-owned ArrayBuffer and free the Rust buffer
+      // immediately. The errorBuf is small (a serialized error variant) and
+      // only allocated on the cold error path, so the boundary copy is cheap.
+      auto len = static_cast<size_t>(status.error_buf.len);
+      uint8_t *bytes = new uint8_t[len];
+      std::memcpy(bytes, status.error_buf.data, len);
+      auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(bytes, len);
+      auto arrayBuffer = jsi::ArrayBuffer(rt, payload);
+      auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
+      auto view = u8ctor.callAsConstructor(rt, jsi::Value(rt, arrayBuffer));
+      statusObject.setProperty(rt, "errorBuf", view);
+      Bridging<RustBuffer>::rustbuffer_free(status.error_buf);
     }
     if (status.code != UNIFFI_CALL_STATUS_OK) {
       auto code =

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustCallStatusHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustCallStatusHelper.cpp
@@ -30,9 +30,8 @@ template <> struct Bridging<RustCallStatus> {
       uint8_t *bytes = new uint8_t[len];
       std::memcpy(bytes, status.error_buf.data, len);
       auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(bytes, len);
-      auto arrayBuffer = jsi::ArrayBuffer(rt, payload);
-      auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
-      auto view = u8ctor.callAsConstructor(rt, jsi::Value(rt, arrayBuffer));
+      auto view = uniffi_jsi::arraybufferToUint8Array(
+          rt, jsi::ArrayBuffer(rt, payload));
       statusObject.setProperty(rt, "errorBuf", view);
       Bridging<RustBuffer>::rustbuffer_free(status.error_buf);
     }

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
@@ -135,28 +135,33 @@ extern "C" {
                 throw jsi::JSError(rt, "rustbuffer_free expected a Uint8Array argument");
             }
             auto view = args[0].asObject(rt);
-            auto buffer = view.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
-            auto byteOffset =
-                static_cast<size_t>(view.getProperty(rt, "byteOffset").asNumber());
             auto byteLength =
                 static_cast<size_t>(view.getProperty(rt, "byteLength").asNumber());
-            // Empty views were never allocated by `rustbuffer_alloc`; nothing to free.
+            // Empty views were never allocated by `rustbuffer_alloc`; nothing
+            // to free. Bail out before reading buffer/byteOffset/capacity to
+            // skip three JSI property traversals on the empty path.
             if (byteLength == 0) {
                 return jsi::Value::undefined();
             }
-            // For a buffer originally produced by `rustbuffer_alloc(n)`, capacity == n
-            // and len == 0. The view's byteLength is `n`, so we mirror it back into
-            // capacity. `len` is irrelevant to free — the library only inspects capacity
-            // and data pointer for deallocation.
-            // TODO(Tasks 11/12): Today this is correct because `rustbuffer_alloc(n)`
-            // returns a view whose `byteLength` equals the original `capacity`. Once
-            // lift-via-handoff lands, a returned `RustBuffer` may produce a view whose
-            // `byteLength` is `len < capacity`. At that point this reconstruction will
-            // need a different mechanism (separate free path, or a side-channel that
-            // remembers the original capacity).
+            // Capacity resolution:
+            //   * For a view from `rustbuffer_alloc(n)`, `byteLength == n == capacity`,
+            //     and no `__ubrnRustCapacity` hint was set.
+            //   * For a view from a lift-handoff, the codegen-emitted
+            //     `Bridging<RustBuffer>::toJs` set `byteLength = len` and stashed
+            //     the original `capacity` on `__ubrnRustCapacity` whenever
+            //     `capacity != len`.
+            // So: prefer the hint, fall back to byteLength.
+            size_t capacity = byteLength;
+            if (view.hasProperty(rt, "__ubrnRustCapacity")) {
+                capacity = static_cast<size_t>(
+                    view.getProperty(rt, "__ubrnRustCapacity").asNumber());
+            }
+            auto buffer = view.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
+            auto byteOffset =
+                static_cast<size_t>(view.getProperty(rt, "byteOffset").asNumber());
             // Honour byteOffset for safety (defensive; currently always 0).
             RustBuffer rb {
-                .capacity = static_cast<uint64_t>(byteLength),
+                .capacity = static_cast<uint64_t>(capacity),
                 .len = 0,
                 .data = buffer.data(rt) + byteOffset,
             };

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
@@ -119,10 +119,10 @@ extern "C" {
             // explicitly before dropping the reference.
             auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(
                 rb.data, static_cast<size_t>(rb.capacity));
-            auto arrayBuffer = jsi::ArrayBuffer(rt, payload);
             // Wrap as Uint8Array so JS can index/assign bytes directly.
-            auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
-            return u8ctor.callAsConstructor(rt, jsi::Value(rt, arrayBuffer));
+            return jsi::Value(
+                rt, uniffi_jsi::arraybufferToUint8Array(
+                        rt, jsi::ArrayBuffer(rt, payload)));
         }
     );
 
@@ -152,9 +152,9 @@ extern "C" {
             //     `capacity != len`.
             // So: prefer the hint, fall back to byteLength.
             size_t capacity = byteLength;
-            if (view.hasProperty(rt, "__ubrnRustCapacity")) {
+            if (view.hasProperty(rt, uniffi_jsi::kUbrnRustCapacity)) {
                 capacity = static_cast<size_t>(
-                    view.getProperty(rt, "__ubrnRustCapacity").asNumber());
+                    view.getProperty(rt, uniffi_jsi::kUbrnRustCapacity).asNumber());
             }
             auto buffer = view.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
             auto byteOffset =

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
@@ -90,6 +90,80 @@ extern "C" {
         }
     );
     {%- endfor %}
+
+    // `rustbuffer_alloc(n)` -> Uint8Array view over Rust-owned memory of capacity `n`.
+    // `rustbuffer_free(view)` -> hands the underlying (ptr, capacity) back to the
+    // crate's `rustbuffer_free`. Together they let JS allocate buffers that the
+    // codegen-emitted lowering path can fill in place and ship to Rust without copying.
+    props["rustbuffer_alloc"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "rustbuffer_alloc"),
+        1,
+        [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            if (count < 1 || !args[0].isNumber()) {
+                throw jsi::JSError(rt, "rustbuffer_alloc expected a number argument");
+            }
+            double size = args[0].asNumber();
+            if (size < 0) {
+                throw jsi::JSError(rt, "rustbuffer_alloc: size must be non-negative");
+            }
+            if (size > INT32_MAX) {
+                throw jsi::JSError(rt, "rustbuffer_alloc: size exceeds INT32_MAX");
+            }
+            auto rb = {{ ci.cpp_namespace() }}::Bridging<RustBuffer>::rustbuffer_alloc(static_cast<int32_t>(size));
+            if (rb.data == nullptr) {
+                throw jsi::JSError(rt, "rustbuffer_alloc failed: alloc returned null");
+            }
+            // Non-owning view over Rust-allocated memory; CMutableBuffer's destructor
+            // is the default and does not free `rb.data`. JS must call rustbuffer_free
+            // explicitly before dropping the reference.
+            auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(
+                rb.data, static_cast<size_t>(rb.capacity));
+            auto arrayBuffer = jsi::ArrayBuffer(rt, payload);
+            // Wrap as Uint8Array so JS can index/assign bytes directly.
+            auto u8ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
+            return u8ctor.callAsConstructor(rt, jsi::Value(rt, arrayBuffer));
+        }
+    );
+
+    props["rustbuffer_free"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "rustbuffer_free"),
+        1,
+        [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            if (count < 1 || !args[0].isObject()) {
+                throw jsi::JSError(rt, "rustbuffer_free expected a Uint8Array argument");
+            }
+            auto view = args[0].asObject(rt);
+            auto buffer = view.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
+            auto byteOffset =
+                static_cast<size_t>(view.getProperty(rt, "byteOffset").asNumber());
+            auto byteLength =
+                static_cast<size_t>(view.getProperty(rt, "byteLength").asNumber());
+            // Empty views were never allocated by `rustbuffer_alloc`; nothing to free.
+            if (byteLength == 0) {
+                return jsi::Value::undefined();
+            }
+            // For a buffer originally produced by `rustbuffer_alloc(n)`, capacity == n
+            // and len == 0. The view's byteLength is `n`, so we mirror it back into
+            // capacity. `len` is irrelevant to free — the library only inspects capacity
+            // and data pointer for deallocation.
+            // TODO(Tasks 11/12): Today this is correct because `rustbuffer_alloc(n)`
+            // returns a view whose `byteLength` equals the original `capacity`. Once
+            // lift-via-handoff lands, a returned `RustBuffer` may produce a view whose
+            // `byteLength` is `len < capacity`. At that point this reconstruction will
+            // need a different mechanism (separate free path, or a side-channel that
+            // remembers the original capacity).
+            // Honour byteOffset for safety (defensive; currently always 0).
+            RustBuffer rb {
+                .capacity = static_cast<uint64_t>(byteLength),
+                .len = 0,
+                .data = buffer.data(rt) + byteOffset,
+            };
+            {{ ci.cpp_namespace() }}::Bridging<RustBuffer>::rustbuffer_free(rb);
+            return jsi::Value::undefined();
+        }
+    );
 }
 
 void {{ module_name }}::registerModule(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> callInvoker) {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -434,10 +434,15 @@ pub(super) fn build_callable(
         .iter()
         .map(|arg| build_arg(config, arg))
         .collect();
-    let return_type = callable.return_type.ty.as_ref().map(|tn| TsReturnType {
-        ts_type: type_label_for(config, &tn.ty),
-        ffi_converter: ffi_converter_name_for(config, tn),
-        ffi_type: ffi_type_to_ts_name(&tn.ffi_type.ty),
+    let return_type = callable.return_type.ty.as_ref().map(|tn| {
+        let ffi_type = ffi_type_to_ts_name(&tn.ffi_type.ty);
+        let is_rust_buffer = ffi_type == "Uint8Array";
+        TsReturnType {
+            ts_type: type_label_for(config, &tn.ty),
+            ffi_converter: ffi_converter_name_for(config, tn),
+            ffi_type,
+            is_rust_buffer,
+        }
     });
     let throws = callable
         .throws_type

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -174,6 +174,7 @@ impl ImportAccumulator {
 
     fn collect_custom(&mut self, c: &TsCustomType) {
         self.add_infra_type("FfiConverter");
+        self.add_infra_type("RustBufferAllocator");
         self.add_infra_value("uniffiTypeNameSymbol");
         if let Some(cfg) = &c.custom_config {
             for (name, from) in &cfg.imports {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
@@ -174,6 +174,12 @@ pub(crate) struct TsReturnType {
     pub ts_type: String,
     pub ffi_converter: String,
     pub ffi_type: String,
+    /// True when the FFI return type is a `RustBuffer` (i.e. `Uint8Array`).
+    /// The `try/finally` lift wrapper in `CallBodyMacros.ts` keys on this so
+    /// the wrapper only fires when the converter's `lift` actually consumes a
+    /// `Uint8Array` — primitive returns (numbers, bigints, booleans, pointers)
+    /// flow through their converters' `lift` directly without a buffer to free.
+    pub is_rust_buffer: bool,
 }
 
 #[derive(Clone)]

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -147,11 +147,27 @@ console.debug(`-- {{ ffi_name }}`);
     {%- endmatch %}
 {%- endmacro -%}
 
+{#- The synchronous lift call sites below wrap the converter's `.lift(__rb)`
+   in `try/finally` so `rustbuffer_free` always runs — even if `lift`
+   throws on a malformed payload. The IIFE preserves the surrounding
+   `return ...` shape and avoids restructuring the multi-line `to_ffi_*_call`
+   macros into a `const __rb = ...` statement. -#}
+
 {#- Call body for value-receiver method: sync only (trait methods are never async). -#}
 {%- macro call_body_value(callable) %}
 {%- match callable.return_type -%}
 {%-     when Some with (return_type) %}
+{%- if return_type.is_rust_buffer %}
+    return ((__rb: Uint8Array) => {
+        try {
+            return {{ return_type.ffi_converter }}.lift(__rb);
+        } finally {
+            nativeModule().rustbuffer_free(__rb);
+        }
+    })({% call to_ffi_value_call(callable) %});
+{%- else %}
     return {{ return_type.ffi_converter }}.lift({% call to_ffi_value_call(callable) %});
+{%- endif %}
 {%-     when None %}
 {%-         call to_ffi_value_call(callable) %};
 {%- endmatch %}
@@ -164,7 +180,17 @@ console.debug(`-- {{ ffi_name }}`);
 {%- else %}
 {%-     match callable.return_type -%}
 {%-         when Some with (return_type) %}
+{%- if return_type.is_rust_buffer %}
+    return ((__rb: Uint8Array) => {
+        try {
+            return {{ return_type.ffi_converter }}.lift(__rb);
+        } finally {
+            nativeModule().rustbuffer_free(__rb);
+        }
+    })({% call to_ffi_pointer_call(callable, obj_factory) %});
+{%- else %}
     return {{ return_type.ffi_converter }}.lift({% call to_ffi_pointer_call(callable, obj_factory) %});
+{%- endif %}
 {%-         when None %}
 {%-             call to_ffi_pointer_call(callable, obj_factory) %};
 {%-     endmatch %}
@@ -178,7 +204,17 @@ console.debug(`-- {{ ffi_name }}`);
 {%- else %}
 {%-     match callable.return_type -%}
 {%-         when Some with (return_type) %}
+{%- if return_type.is_rust_buffer %}
+    return ((__rb: Uint8Array) => {
+        try {
+            return {{ return_type.ffi_converter }}.lift(__rb);
+        } finally {
+            nativeModule().rustbuffer_free(__rb);
+        }
+    })({% call to_ffi_call(callable) %});
+{%- else %}
     return {{ return_type.ffi_converter }}.lift({% call to_ffi_call(callable) %});
+{%- endif %}
 {%-         when None %}
 {%-             call to_ffi_call(callable) %};
 {%-     endmatch %}
@@ -224,6 +260,11 @@ console.debug(`-- {{ ffi_name }}`);
             /*freeFunc:*/ {% call native_method_handle_free(ffi_async.free) %},
             {%- match callable.return_type %}
             {%- when Some(return_type) %}
+            // Async returns always go through the JS-side converter: the
+            // FFI symbol returns the future handle (u64), and the user-level
+            // RustBuffer comes back via the shared `rust_future_complete_*`
+            // export. The bytes the runtime hands back must be deserialized
+            // here using the per-callable return-type converter.
             /*liftFunc:*/ {{ return_type.ffi_converter }}.lift.bind({{ return_type.ffi_converter }}),
             {%- when None %}
             /*liftFunc:*/ (_v) => {},

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -73,7 +73,7 @@ console.debug(`-- {{ ffi_name }}`);
 {#- Lowered argument list (for FFI calls). -#}
 {%- macro arg_list_lowered(callable) %}
     {%- for arg in callable.arguments %}
-        {{ arg.ffi_converter }}.lower({{ arg.name }}),
+        {{ arg.ffi_converter }}.lower({{ arg.name }}, nativeModule().rustbuffer_alloc),
     {%- endfor %}
 {%- endmacro -%}
 
@@ -136,7 +136,7 @@ console.debug(`-- {{ ffi_name }}`);
             {%- if callable.return_type.is_some() %}
                 return
             {%- endif %} {% call native_method_handle(callable.ffi_name) %}(
-                {{ ffi_converter }}.lower(self_),
+                {{ ffi_converter }}.lower(self_, nativeModule().rustbuffer_alloc),
                 {%- call arg_list_lowered(callable) %}
                 callStatus);
             },
@@ -214,7 +214,7 @@ console.debug(`-- {{ ffi_name }}`);
                     {{ obj_factory }}.clonePointer(this){% if !callable.arguments.is_empty() %},{% endif %}
                     {%- endif %}
                     {%- for arg in callable.arguments -%}
-                    {{ arg.ffi_converter }}.lower({{ arg.name }}){% if !loop.last %},{% endif %}
+                    {{ arg.ffi_converter }}.lower({{ arg.name }}, nativeModule().rustbuffer_alloc){% if !loop.last %},{% endif %}
                     {%- endfor %}
                 );
             },

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -38,7 +38,7 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
             {%- when Some(t) %}
             const uniffiResult = UniffiResult.ready<{{ t.ffi_type }}>();
             const uniffiHandleSuccess = (obj: any) => {
-                UniffiResult.writeSuccess(uniffiResult, {{ t.ffi_converter }}.lower(obj));
+                UniffiResult.writeSuccess(uniffiResult, {{ t.ffi_converter }}.lower(obj, nativeModule().rustbuffer_alloc));
             };
             {%- when None %}
             const uniffiResult = UniffiResult.ready<void>();
@@ -54,7 +54,8 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                 /*makeCall:*/ uniffiMakeCall,
                 /*handleSuccess:*/ uniffiHandleSuccess,
                 /*handleError:*/ uniffiHandleError,
-                /*lowerString:*/ FfiConverterString.lower
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
             )
             {%- when Some(error_type) %}
             uniffiTraitInterfaceCallWithError(
@@ -63,7 +64,8 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                 /*handleError:*/ uniffiHandleError,
                 /*isErrorType:*/ {{ error_type.decl_type_name }}.instanceOf,
                 /*lowerError:*/ {{ error_type.lower_error_fn }},
-                /*lowerString:*/ FfiConverterString.lower
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
             );
             {%- endmatch %}
             return uniffiResult;
@@ -78,7 +80,7 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                     /* {{ ffr.struct_name }} */{
                         {%- match meth.return_type %}
                         {%- when Some(return_type) %}
-                        return_value: {{ return_type.ffi_converter }}.lower(returnValue),
+                        return_value: {{ return_type.ffi_converter }}.lower(returnValue, nativeModule().rustbuffer_alloc),
                         {%- when None %}
                         {%- endmatch %}
                         call_status: uniffiCaller.createCallStatus()
@@ -113,7 +115,8 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                 /*makeCall:*/ uniffiMakeCall,
                 /*handleSuccess:*/ uniffiHandleSuccess,
                 /*handleError:*/ uniffiHandleError,
-                /*lowerString:*/ FfiConverterString.lower
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
             );
             {%- when Some(error_type) %}
             const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
@@ -122,7 +125,8 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
                 /*handleError:*/ uniffiHandleError,
                 /*isErrorType:*/ {{ error_type.decl_type_name }}.instanceOf,
                 /*lowerError:*/ {{ error_type.lower_error_fn }},
-                /*lowerString:*/ FfiConverterString.lower
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
             );
             {%- endmatch %}
             return uniffiForeignFuture;

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CustomTypeTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CustomTypeTemplate.ts
@@ -33,9 +33,9 @@ const {{ custom.ffi_converter_name }} = (() => {
             const intermediate = intermediateConverter.lift(value);
             return {{ config.lift_expr }};
         }
-        lower(value: TsType): FfiType {
+        lower(value: TsType, alloc: RustBufferAllocator): FfiType {
             const intermediate = {{ config.lower_expr }};
-            return intermediateConverter.lower(intermediate);
+            return intermediateConverter.lower(intermediate, alloc);
         }
         read(from: RustBuffer): TsType {
             const intermediate = intermediateConverter.read(from);

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelperTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelperTemplate.ts
@@ -7,6 +7,16 @@ const stringConverter = (() => {
         stringToBytes: (s: string) => encoder.encode(s),
         bytesToString: (ab: UniffiByteArray) => decoder.decode(ab),
         stringByteLength: (s: string) => encoder.encode(s).byteLength,
+        writeStringIntoBuffer: (s: string, buf: any, offset: number): number => {
+            const view = new Uint8Array(
+                buf.arrayBuffer,
+                offset,
+                buf.arrayBuffer.byteLength - offset,
+            );
+            return encoder.encodeInto(s, view).written;
+        },
+        readStringFromBuffer: (buf: any, offset: number, length: number): string =>
+            decoder.decode(new Uint8Array(buf.arrayBuffer, offset, length)),
     };
 })();
 {%- else %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
@@ -21,9 +21,9 @@ import {
 
 const DEFINITIONS = {
   symbols: {
-    rustbufferAlloc: "{{ module.symbols.rustbuffer_alloc }}",
-    rustbufferFree: "{{ module.symbols.rustbuffer_free }}",
-    rustbufferFromBytes: "{{ module.symbols.rustbuffer_from_bytes }}",
+    rustbuffer_alloc: "{{ module.symbols.rustbuffer_alloc }}",
+    rustbuffer_free: "{{ module.symbols.rustbuffer_free }}",
+    rustbuffer_from_bytes: "{{ module.symbols.rustbuffer_from_bytes }}",
   },
   functions: {
     {%- for func in module.functions %}
@@ -66,6 +66,11 @@ interface NativeModuleInterface {
       {%- endfor %}):
       {%- match func.return_type %}{% when Some with (rt) %} {{ rt }}{% when None %} void{% endmatch %};
   {%- endfor %}
+    // Codegen call sites use these via `nativeModule().rustbuffer_alloc(...)`
+    // and `nativeModule().rustbuffer_free(...)`. The runtime's registered
+    // module exposes them as method properties.
+    rustbuffer_alloc(n: number): Uint8Array;
+    rustbuffer_free(view: Uint8Array): void;
 }
 
 let _nativeModule: NativeModuleInterface | undefined;

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi.ts
@@ -26,6 +26,12 @@ interface NativeModuleInterface {
       {%- endfor %}):
       {%- match func.return_type %}{% when Some with (rt) %} {{ rt }}{% when None %} void{% endmatch %};
   {%- endfor %}
+    // Codegen call sites use these via `nativeModule().rustbuffer_alloc(...)`
+    // and `nativeModule().rustbuffer_free(...)`. The JSI host object exposes
+    // them as properties; see `props["rustbuffer_alloc"]` / `props["rustbuffer_free"]`
+    // in the C++ wrapper template.
+    rustbuffer_alloc(n: number): Uint8Array;
+    rustbuffer_free(view: Uint8Array): void;
 }
 
 const getter: () => NativeModuleInterface = () => (globalThis as any).{{ module.module_name }};

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper.ts
@@ -38,7 +38,15 @@ const { {{ conv.converters|join(", ") }} } = {{ conv.default_name }}.converters;
 {%- if module.flavor.supports_plain_call_status() %}
 const uniffiCaller = new UniffiRustCaller(() => ({ code: 0 }));
 {%- else %}
-const nativeModule = () => wasmBundle;
+// wasm1: wrap the wasm-bindgen namespace once so the codegen call sites can
+// uniformly reference `nativeModule().rustbuffer_alloc` / `.rustbuffer_free`.
+// For wasm1, RustBuffers are plain JS Uint8Arrays — no Rust-side allocation
+// is involved, so alloc just hands back a fresh view and free is a no-op.
+const _nativeModule = Object.assign({}, wasmBundle, {
+  rustbuffer_alloc: (n: number): Uint8Array => new Uint8Array(n),
+  rustbuffer_free: (_: Uint8Array): void => {},
+});
+const nativeModule = () => _nativeModule;
 const uniffiCaller = new UniffiRustCaller(() => new wasmBundle.RustCallStatus());
 {%- endif %}
 

--- a/crates/ubrn_cli/templates/wasm/Cargo.toml.txt
+++ b/crates/ubrn_cli/templates/wasm/Cargo.toml.txt
@@ -34,8 +34,8 @@ wasm-bindgen = "*"
 
 {% if !config.project.wasm.workspace -%}
 [profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
+# Tell `rustc` to optimize for speed
+opt-level = "3"
 
 [workspace]
 {%- endif %}

--- a/crates/ubrn_fixture_testing/src/jsi.rs
+++ b/crates/ubrn_fixture_testing/src/jsi.rs
@@ -175,6 +175,7 @@ fn compile_cpp(
         } else {
             "Ninja"
         })
+        .arg("-DCMAKE_BUILD_TYPE=Release")
         .arg(format!("-DHERMES_SRC_DIR={}", paths::hermes_src_dir()))
         .arg(format!("-DHERMES_BUILD_DIR={}", paths::hermes_build_dir()))
         .arg(format!("-DHERMES_EXTENSION_NAME=rn-{lib_name}"))

--- a/crates/ubrn_fixture_testing/src/wasm.rs
+++ b/crates/ubrn_fixture_testing/src/wasm.rs
@@ -83,7 +83,7 @@ pub fn run_test(crate_name: &str, test_script: &str, target_tmpdir: &str) {
     // Step 6: Run wasm-bindgen
     // Output goes next to the TypeScript bindings so imports resolve correctly.
     let wasm_file = shared_target_dir
-        .join("wasm32-unknown-unknown/debug")
+        .join("wasm32-unknown-unknown/release")
         .join(format!("{wasm_lib_stem}.wasm"));
     let wasm_bindgen_dir = ts_dir.join("wasm-bindgen");
     std::fs::create_dir_all(&wasm_bindgen_dir).expect("failed to create wasm-bindgen dir");
@@ -196,6 +196,7 @@ fn compile_wasm32(cargo_toml: &Utf8Path, target_dir: &Utf8Path) {
         Command::new("cargo")
             .env("CARGO_TARGET_DIR", target_dir.as_str())
             .arg("build")
+            .arg("--release")
             .arg("--target")
             .arg("wasm32-unknown-unknown")
             .arg("--manifest-path")

--- a/fixtures/benchmark/Cargo.toml
+++ b/fixtures/benchmark/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_benchmark"
 
 [dependencies]
-uniffi = { workspace = true }
+uniffi = { workspace = true, features = ["tokio"] }
 
 [dev-dependencies]
 ubrn_macros = { workspace = true }

--- a/fixtures/benchmark/src/lib.rs
+++ b/fixtures/benchmark/src/lib.rs
@@ -4,6 +4,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// String / bytes / array roundtrips (original suite)
+// ---------------------------------------------------------------------------
+
 /// Accept a string argument (measures string lowering overhead).
 #[uniffi::export]
 pub fn take_string(s: String) {
@@ -37,6 +44,178 @@ pub fn get_string_array(repeats: u32, s: String) -> Vec<String> {
 /// Accept a Vec of strings (measures sequence + string lowering overhead).
 #[uniffi::export]
 pub fn take_string_array(strings: Vec<String>) {
+    let _ = strings;
+}
+
+// ---------------------------------------------------------------------------
+// FFI overhead micro suite
+// ---------------------------------------------------------------------------
+
+/// Zero-payload call — isolates pure FFI crossing cost.
+#[uniffi::export]
+pub fn noop() {}
+
+/// Two-scalar marshaling — no buffer involved.
+#[uniffi::export]
+pub fn add_u32(a: u32, b: u32) -> u32 {
+    a.wrapping_add(b)
+}
+
+/// Object handle + method dispatch — measures handle passing and vtable cost.
+#[derive(uniffi::Object)]
+pub struct Counter(AtomicU32);
+
+#[uniffi::export]
+impl Counter {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self(AtomicU32::new(0)))
+    }
+
+    pub fn increment(&self) -> u32 {
+        self.0.fetch_add(1, Ordering::Relaxed).wrapping_add(1)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wide record — many fields, mixed types
+// ---------------------------------------------------------------------------
+
+#[derive(uniffi::Record, Clone)]
+pub struct LargeRecord {
+    pub a_u8: u8,
+    pub a_i8: i8,
+    pub a_u16: u16,
+    pub a_i16: i16,
+    pub a_u32: u32,
+    pub a_i32: i32,
+    pub a_u64: u64,
+    pub a_i64: i64,
+    pub a_f32: f32,
+    pub a_f64: f64,
+    pub a_bool: bool,
+    pub s1: String,
+    pub s2: String,
+    pub s3: String,
+    pub s4: String,
+    pub opt_str: Option<String>,
+    pub opt_u32: Option<u32>,
+    pub bytes: Vec<u8>,
+    pub strs: Vec<String>,
+    pub ints: Vec<u32>,
+}
+
+#[uniffi::export]
+pub fn get_large_record() -> LargeRecord {
+    LargeRecord {
+        a_u8: 1,
+        a_i8: -1,
+        a_u16: 2,
+        a_i16: -2,
+        a_u32: 3,
+        a_i32: -3,
+        a_u64: 4,
+        a_i64: -4,
+        a_f32: 5.5,
+        a_f64: 6.5,
+        a_bool: true,
+        s1: "alpha".to_string(),
+        s2: "beta".to_string(),
+        s3: "gamma".to_string(),
+        s4: "delta".to_string(),
+        opt_str: Some("optional".to_string()),
+        opt_u32: Some(7),
+        bytes: vec![0u8; 32],
+        strs: vec!["one".to_string(), "two".to_string(), "three".to_string()],
+        ints: vec![10, 20, 30, 40, 50],
+    }
+}
+
+#[uniffi::export]
+pub fn take_large_record(r: LargeRecord) {
+    let _ = r;
+}
+
+// ---------------------------------------------------------------------------
+// Recursive enum — depth-controlled binary tree
+// ---------------------------------------------------------------------------
+
+/// uniffi 0.31's `#[derive(uniffi::Enum)]` does not implement `Lift`/`Lower`
+/// for `Box<Self>`, so we model the recursion via `Vec<Tree>` — heap-backed
+/// and equivalent for marshaling-cost measurement. `build_tree` always
+/// produces exactly two children, mimicking a binary tree.
+#[derive(uniffi::Enum)]
+pub enum Tree {
+    Leaf,
+    Node { children: Vec<Tree> },
+}
+
+#[uniffi::export]
+pub fn build_tree(depth: u32) -> Tree {
+    if depth == 0 {
+        Tree::Leaf
+    } else {
+        Tree::Node {
+            children: vec![build_tree(depth - 1), build_tree(depth - 1)],
+        }
+    }
+}
+
+#[uniffi::export]
+pub fn count_leaves(t: Tree) -> u32 {
+    fn walk(t: &Tree) -> u32 {
+        match t {
+            Tree::Leaf => 1,
+            Tree::Node { children } => children.iter().map(walk).sum(),
+        }
+    }
+    walk(&t)
+}
+
+// ---------------------------------------------------------------------------
+// Async — immediately-ready variants
+// ---------------------------------------------------------------------------
+//
+// These futures resolve in a single poll. They isolate the async FFI overhead
+// (future handle, waker registration, completion plumbing) from any actual
+// scheduling latency. Compare to the sync versions to see what `async` costs
+// at the boundary when the work itself is free.
+
+#[uniffi::export]
+pub async fn noop_async() {}
+
+#[uniffi::export]
+pub async fn add_u32_async(a: u32, b: u32) -> u32 {
+    a.wrapping_add(b)
+}
+
+#[uniffi::export]
+pub async fn get_string_async(length: u32) -> String {
+    "x".repeat(length as usize)
+}
+
+#[uniffi::export]
+pub async fn take_string_async(s: String) {
+    let _ = s;
+}
+
+#[uniffi::export]
+pub async fn get_bytes_async(length: u32) -> Vec<u8> {
+    vec![0u8; length as usize]
+}
+
+#[uniffi::export]
+pub async fn take_bytes_async(bytes: Vec<u8>) {
+    let _ = bytes;
+}
+
+#[uniffi::export]
+pub async fn get_string_array_async(repeats: u32, s: String) -> Vec<String> {
+    std::iter::repeat_n(s, repeats as usize).collect()
+}
+
+#[uniffi::export]
+pub async fn take_string_array_async(strings: Vec<String>) {
     let _ = strings;
 }
 

--- a/fixtures/benchmark/tests/bindings/test_benchmark.ts
+++ b/fixtures/benchmark/tests/bindings/test_benchmark.ts
@@ -8,24 +8,39 @@
 //   cargo test -p uniffi-fixture-benchmark -- wasm
 
 import {
+  addU32,
+  addU32Async,
+  buildTree,
+  Counter,
+  countLeaves,
   getBytes,
+  getBytesAsync,
+  getLargeRecord,
   getString,
   getStringArray,
+  getStringArrayAsync,
+  getStringAsync,
+  noop,
+  noopAsync,
   takeBytes,
+  takeBytesAsync,
+  takeLargeRecord,
   takeString,
   takeStringArray,
+  takeStringArrayAsync,
+  takeStringAsync,
 } from "@/generated/uniffi_benchmark";
-import { test } from "@/asserts";
+import { asyncTest, test } from "@/asserts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Run `fn` `iterations` times and return wall-clock ms. */
+/** Run `fn` `iterations` times and return wall-clock ms (sub-ms resolution). */
 function timeMs(fn: () => void, iterations: number): number {
-  const start = Date.now();
+  const start = performance.now();
   for (let i = 0; i < iterations; i++) fn();
-  return Date.now() - start;
+  return performance.now() - start;
 }
 
 /** Return the minimum over `runs` calls of timeMs(fn, iterations). */
@@ -37,24 +52,56 @@ function bench(fn: () => void, iterations: number, runs: number): number {
   return best;
 }
 
+/** Async variant: awaits each call sequentially. */
+async function timeMsAsync(
+  fn: () => Promise<unknown>,
+  iterations: number,
+): Promise<number> {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) await fn();
+  return performance.now() - start;
+}
+
+async function benchAsync(
+  fn: () => Promise<unknown>,
+  iterations: number,
+  runs: number,
+): Promise<number> {
+  let best = Infinity;
+  for (let r = 0; r < runs; r++) {
+    best = Math.min(best, await timeMsAsync(fn, iterations));
+  }
+  return best;
+}
+
+/** Format a sub-ms time with reasonable precision. */
+function fmtMs(ms: number): string {
+  if (ms >= 100) return ms.toFixed(0);
+  if (ms >= 10) return ms.toFixed(1);
+  if (ms >= 1) return ms.toFixed(2);
+  return ms.toFixed(3);
+}
+
 const RUNS = 3;
 
-// Payload sizes for individual string / byte benchmarks.
-const SIZES: Array<{ label: string; bytes: number }> = [
-  { label: "1 KB", bytes: 1_024 },
-  { label: "16 KB", bytes: 16 * 1_024 },
-  { label: "256 KB", bytes: 256 * 1_024 },
+// Sizes for the focused large-transfer suite (sync + async).
+const SIZES_LARGE: Array<{ label: string; bytes: number }> = [
   { label: "512 KB", bytes: 512 * 1_024 },
   { label: "1 MB", bytes: 1_024 * 1_024 },
 ];
 
-// Configurations for array benchmarks: [count, element_bytes].
-const ARRAY_CONFIGS: Array<{ count: number; elemBytes: number }> = [
-  { count: 100, elemBytes: 64 },
-  { count: 1000, elemBytes: 64 },
-  { count: 100, elemBytes: 1024 },
-  { count: 1024, elemBytes: 100 },
+// String-array configurations that each total 1 MB of string payload.
+// Trades array length for element length to see how per-element overhead
+// vs total payload size dominates.
+const ARRAY_1MB_CONFIGS: Array<{ count: number; elemBytes: number }> = [
+  { count: 1, elemBytes: 1_048_576 },
+  { count: 64, elemBytes: 16_384 },
+  { count: 1024, elemBytes: 1_024 },
+  { count: 16_384, elemBytes: 64 },
+  { count: 65_536, elemBytes: 16 },
 ];
+
+const TIMEOUT_MS = 1_000_000; // 1000s = 16.7m, which is long but allows debugging in CI if needed
 
 // ---------------------------------------------------------------------------
 // String benchmarks
@@ -63,10 +110,10 @@ const ARRAY_CONFIGS: Array<{ count: number; elemBytes: number }> = [
 test("bench: getString (lifting a string from Rust)", (_t) => {
   console.log("\n--- getString: lifting a string from Rust ---");
   const ITERS = 100;
-  for (const { label, bytes } of SIZES) {
+  for (const { label, bytes } of SIZES_LARGE) {
     const ms = bench(() => getString(bytes), ITERS, RUNS);
     console.log(
-      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+      `  ${label.padEnd(7)} x${ITERS}: ${fmtMs(ms)}ms  (~${(ms / ITERS).toFixed(3)} ms/call)`,
     );
   }
 });
@@ -74,11 +121,11 @@ test("bench: getString (lifting a string from Rust)", (_t) => {
 test("bench: takeString (lowering a string into Rust)", (_t) => {
   console.log("\n--- takeString: lowering a string into Rust ---");
   const ITERS = 100;
-  for (const { label, bytes } of SIZES) {
+  for (const { label, bytes } of SIZES_LARGE) {
     const s = "x".repeat(bytes);
     const ms = bench(() => takeString(s), ITERS, RUNS);
     console.log(
-      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+      `  ${label.padEnd(7)} x${ITERS}: ${fmtMs(ms)}ms  (~${(ms / ITERS).toFixed(3)} ms/call)`,
     );
   }
 });
@@ -90,10 +137,10 @@ test("bench: takeString (lowering a string into Rust)", (_t) => {
 test("bench: getBytes (lifting bytes from Rust)", (_t) => {
   console.log("\n--- getBytes: lifting bytes from Rust ---");
   const ITERS = 100;
-  for (const { label, bytes } of SIZES) {
+  for (const { label, bytes } of SIZES_LARGE) {
     const ms = bench(() => getBytes(bytes), ITERS, RUNS);
     console.log(
-      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+      `  ${label.padEnd(7)} x${ITERS}: ${fmtMs(ms)}ms  (~${(ms / ITERS).toFixed(3)} ms/call)`,
     );
   }
 });
@@ -101,42 +148,326 @@ test("bench: getBytes (lifting bytes from Rust)", (_t) => {
 test("bench: takeBytes (lowering bytes into Rust)", (_t) => {
   console.log("\n--- takeBytes: lowering bytes into Rust ---");
   const ITERS = 100;
-  for (const { label, bytes } of SIZES) {
+  for (const { label, bytes } of SIZES_LARGE) {
     // const b = new Uint8Array(bytes);
     const b = new ArrayBuffer(bytes);
     const ms = bench(() => takeBytes(b), ITERS, RUNS);
     console.log(
-      `  ${label.padEnd(7)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+      `  ${label.padEnd(7)} x${ITERS}: ${fmtMs(ms)}ms  (~${(ms / ITERS).toFixed(3)} ms/call)`,
     );
   }
 });
 
 // ---------------------------------------------------------------------------
-// String-array benchmarks
+// FFI overhead micro suite
 // ---------------------------------------------------------------------------
 
-test("bench: getStringArray (lifting a Vec<String> from Rust)", (_t) => {
-  console.log("\n--- getStringArray: lifting a Vec<String> from Rust ---");
-  const ITERS = 20;
-  for (const { count, elemBytes } of ARRAY_CONFIGS) {
-    const label = `${count}×${elemBytes}B`;
+test("bench: noop (zero-payload call overhead)", (_t) => {
+  console.log("\n--- noop: pure FFI crossing cost ---");
+  const ITERS = 100_000;
+  const ms = bench(() => noop(), ITERS, RUNS);
+  console.log(
+    `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+  );
+});
+
+test("bench: addU32 (two-scalar marshaling)", (_t) => {
+  console.log("\n--- addU32: scalar marshaling, no buffer ---");
+  const ITERS = 100_000;
+  const ms = bench(() => addU32(1, 2), ITERS, RUNS);
+  console.log(
+    `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+  );
+});
+
+test("bench: Counter.increment (object handle + method dispatch)", (_t) => {
+  console.log("\n--- Counter.increment: handle passing + vtable cost ---");
+  const ITERS = 100_000;
+  const c = new Counter();
+  const ms = bench(() => c.increment(), ITERS, RUNS);
+  console.log(
+    `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Wide record
+// ---------------------------------------------------------------------------
+
+test("bench: getLargeRecord (lifting a 20-field record)", (_t) => {
+  console.log("\n--- getLargeRecord: wide-record lift ---");
+  const ITERS = 10_000;
+  const ms = bench(() => getLargeRecord(), ITERS, RUNS);
+  console.log(
+    `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+  );
+});
+
+test("bench: takeLargeRecord (lowering a 20-field record)", (_t) => {
+  console.log("\n--- takeLargeRecord: wide-record lower ---");
+  const ITERS = 10_000;
+  const rec = getLargeRecord();
+  const ms = bench(() => takeLargeRecord(rec), ITERS, RUNS);
+  console.log(
+    `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Recursive enum (binary tree, vec-backed)
+// ---------------------------------------------------------------------------
+
+const TREE_DEPTHS = [4, 8, 12]; // 16 / 256 / 4096 leaves
+
+test("bench: buildTree (lifting a recursive enum)", (_t) => {
+  console.log("\n--- buildTree: recursive-enum lift ---");
+  const ITERS = 100;
+  for (const depth of TREE_DEPTHS) {
+    const leaves = 1 << depth;
+    const ms = bench(() => buildTree(depth), ITERS, RUNS);
+    console.log(
+      `  depth=${depth.toString().padEnd(2)} (${leaves} leaves) x${ITERS}: ${fmtMs(ms)}ms  (~${(ms / ITERS).toFixed(3)} ms/call)`,
+    );
+  }
+});
+
+test("bench: countLeaves (lowering a recursive enum)", (_t) => {
+  console.log("\n--- countLeaves: recursive-enum lower ---");
+  const ITERS = 100;
+  for (const depth of TREE_DEPTHS) {
+    const leaves = 1 << depth;
+    const tree = buildTree(depth);
+    const ms = bench(() => countLeaves(tree), ITERS, RUNS);
+    console.log(
+      `  depth=${depth.toString().padEnd(2)} (${leaves} leaves) x${ITERS}: ${fmtMs(ms)}ms  (~${(ms / ITERS).toFixed(3)} ms/call)`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Large-transfer suite (sync, 512K + 1MB only)
+// ---------------------------------------------------------------------------
+
+test("bench: large get/take (sync, 512K + 1MB)", (_t) => {
+  console.log("\n--- large transfers (sync, 512K + 1MB) ---");
+  const ITERS = 100;
+  for (const { label, bytes } of SIZES_LARGE) {
+    const s = "x".repeat(bytes);
+    const b = new ArrayBuffer(bytes);
+
+    const tGetS = bench(() => getString(bytes), ITERS, RUNS);
+    const tTakeS = bench(() => takeString(s), ITERS, RUNS);
+    const tGetB = bench(() => getBytes(bytes), ITERS, RUNS);
+    const tTakeB = bench(() => takeBytes(b), ITERS, RUNS);
+
+    console.log(
+      `  ${label.padEnd(7)} x${ITERS}  ` +
+        `getString=${fmtMs(tGetS).padStart(7)}ms  ` +
+        `takeString=${fmtMs(tTakeS).padStart(7)}ms  ` +
+        `getBytes=${fmtMs(tGetB).padStart(7)}ms  ` +
+        `takeBytes=${fmtMs(tTakeB).padStart(7)}ms`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// String-array — 1 MB total payload, varied (count × elem size)
+// ---------------------------------------------------------------------------
+
+test("bench: string-array 1MB total payload (sync)", (_t) => {
+  console.log("\n--- string-array, 1MB total (count × elemBytes) sync ---");
+  const ITERS = 10;
+  for (const { count, elemBytes } of ARRAY_1MB_CONFIGS) {
+    const label = `${String(count).padStart(6)}×${String(elemBytes).padEnd(7)}B`;
     const s = "x".repeat(elemBytes);
-    const ms = bench(() => getStringArray(count, s), ITERS, RUNS);
+    const arr = Array.from({ length: count }, () => s);
+
+    const tGet = bench(() => getStringArray(count, s), ITERS, RUNS);
+    const tTake = bench(() => takeStringArray(arr), ITERS, RUNS);
+
     console.log(
-      `  ${label.padEnd(12)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+      `  ${label}  x${ITERS}  ` +
+        `get=${fmtMs(tGet).padStart(7)}ms (${(tGet / ITERS).toFixed(2)} ms/call)  ` +
+        `take=${fmtMs(tTake).padStart(7)}ms (${(tTake / ITERS).toFixed(2)} ms/call)`,
     );
   }
 });
 
-test("bench: takeStringArray (lowering a string[] into Rust)", (_t) => {
-  console.log("\n--- takeStringArray: lowering a string[] into Rust ---");
-  const ITERS = 20;
-  for (const { count, elemBytes } of ARRAY_CONFIGS) {
-    const label = `${count}×${elemBytes}B`;
-    const arr = Array.from({ length: count }, () => "x".repeat(elemBytes));
-    const ms = bench(() => takeStringArray(arr), ITERS, RUNS);
+// ---------------------------------------------------------------------------
+// Memory probes
+// ---------------------------------------------------------------------------
+
+test("MEM: heap + wasm-memory profile", (_t) => {
+  console.log("\n--- MEM: heap + wasm linear memory ---");
+  const gc: (() => void) | undefined = (globalThis as any).gc;
+  if (!gc) {
     console.log(
-      `  ${label.padEnd(12)} x${ITERS}: ${ms}ms  (~${(ms / ITERS).toFixed(2)} ms/call)`,
+      "  (run with NODE_OPTIONS=--expose-gc for accurate steady-state numbers)",
     );
   }
+
+  function settle() {
+    if (gc) {
+      gc();
+      gc();
+    }
+  }
+  const mb = (n: number) => `${(n / 1_048_576).toFixed(2)} MB`;
+
+  // Node's `external` includes WebAssembly.Memory linear memory + ArrayBuffer
+  // backing stores, so we can use it as a proxy for wasm + off-heap growth.
+  function probe(label: string, iters: number, fn: () => void) {
+    settle();
+    const before = process.memoryUsage();
+    // Allocation-rate run (NO GC mid-loop).
+    for (let i = 0; i < iters; i++) fn();
+    const peak = process.memoryUsage();
+    settle();
+    const after = process.memoryUsage();
+    const allocPerCallKB = (peak.heapUsed - before.heapUsed) / iters / 1024;
+    const extPerCallKB = (peak.external - before.external) / iters / 1024;
+    console.log(
+      `  ${label.padEnd(24)} N=${String(iters).padStart(7)}  ` +
+        `heap Δalloc=${mb(peak.heapUsed - before.heapUsed).padStart(9)}  ` +
+        `Δretained=${mb(after.heapUsed - before.heapUsed).padStart(9)}  ` +
+        `~${allocPerCallKB.toFixed(2).padStart(7)} KB/call heap, ` +
+        `${extPerCallKB.toFixed(2).padStart(6)} KB/call ext`,
+    );
+  }
+
+  settle();
+  const mu0 = process.memoryUsage();
+  console.log(
+    `  baseline:  rss=${mb(mu0.rss)}  heap=${mb(mu0.heapUsed)}/${mb(mu0.heapTotal)}  external=${mb(mu0.external)} (incl. wasm)`,
+  );
+
+  probe("getBytes(1MB)", 500, () => {
+    const r = getBytes(1_024 * 1_024);
+    if (r.byteLength === 0) throw new Error();
+  });
+  probe("takeBytes(1MB)", 500, () => {
+    takeBytes(new ArrayBuffer(1_024 * 1_024));
+  });
+  probe("getString(1MB)", 500, () => {
+    const s = getString(1_024 * 1_024);
+    if (s.length === 0) throw new Error();
+  });
+  probe("buildTree(depth=12)", 200, () => {
+    const t = buildTree(12);
+    if (!t) throw new Error();
+  });
+  const t12 = buildTree(12);
+  probe("countLeaves(depth=12)", 200, () => {
+    if (countLeaves(t12) === 0) throw new Error();
+  });
+  probe("noop", 500_000, () => {
+    noop();
+  });
+
+  settle();
+  const mu1 = process.memoryUsage();
+  console.log(
+    `  final:     rss=${mb(mu1.rss)}  heap=${mb(mu1.heapUsed)}/${mb(mu1.heapTotal)}  external=${mb(mu1.external)} (incl. wasm)`,
+  );
 });
+
+// ---------------------------------------------------------------------------
+// Async suite — uses asyncTest inside an IIFE so each test awaits before the
+// next prints. `test()` is sync-only; passing it an async function returns an
+// un-awaited promise and the output interleaves.
+// ---------------------------------------------------------------------------
+
+(async () => {
+  await asyncTest(
+    "bench: noopAsync (async FFI crossing cost)",
+    async (t) => {
+      console.log("\n--- noopAsync: pure async FFI crossing cost ---");
+      const ITERS = 10_000;
+      const ms = await benchAsync(() => noopAsync(), ITERS, RUNS);
+      console.log(
+        `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+      );
+      t.end();
+    },
+    TIMEOUT_MS,
+  );
+
+  await asyncTest(
+    "bench: addU32Async (async scalar marshaling)",
+    async (t) => {
+      console.log("\n--- addU32Async: scalar marshaling, async ---");
+      const ITERS = 10_000;
+      const ms = await benchAsync(() => addU32Async(1, 2), ITERS, RUNS);
+      console.log(
+        `  x${ITERS}: ${fmtMs(ms)}ms  (~${((ms * 1000) / ITERS).toFixed(3)} µs/call)`,
+      );
+      t.end();
+    },
+    TIMEOUT_MS,
+  );
+
+  await asyncTest(
+    "bench: large get/take async (512K + 1MB)",
+    async (t) => {
+      console.log("\n--- large transfers (async, 512K + 1MB) ---");
+      const ITERS = 100;
+      for (const { label, bytes } of SIZES_LARGE) {
+        const s = "x".repeat(bytes);
+        const b = new ArrayBuffer(bytes);
+
+        const tGetS = await benchAsync(
+          () => getStringAsync(bytes),
+          ITERS,
+          RUNS,
+        );
+        const tTakeS = await benchAsync(() => takeStringAsync(s), ITERS, RUNS);
+        const tGetB = await benchAsync(() => getBytesAsync(bytes), ITERS, RUNS);
+        const tTakeB = await benchAsync(() => takeBytesAsync(b), ITERS, RUNS);
+
+        console.log(
+          `  ${label.padEnd(7)} x${ITERS}  ` +
+            `getString=${fmtMs(tGetS).padStart(7)}ms  ` +
+            `takeString=${fmtMs(tTakeS).padStart(7)}ms  ` +
+            `getBytes=${fmtMs(tGetB).padStart(7)}ms  ` +
+            `takeBytes=${fmtMs(tTakeB).padStart(7)}ms`,
+        );
+      }
+      t.end();
+    },
+    TIMEOUT_MS,
+  );
+
+  await asyncTest(
+    "bench: string-array 1MB total payload (async)",
+    async (t) => {
+      console.log(
+        "\n--- string-array, 1MB total (count × elemBytes) async ---",
+      );
+      const ITERS = 10;
+      for (const { count, elemBytes } of ARRAY_1MB_CONFIGS) {
+        const label = `${String(count).padStart(6)}×${String(elemBytes).padEnd(7)}B`;
+        const s = "x".repeat(elemBytes);
+        const arr = Array.from({ length: count }, () => s);
+
+        const tGet = await benchAsync(
+          () => getStringArrayAsync(count, s),
+          ITERS,
+          RUNS,
+        );
+        const tTake = await benchAsync(
+          () => takeStringArrayAsync(arr),
+          ITERS,
+          RUNS,
+        );
+
+        console.log(
+          `  ${label}  x${ITERS}  ` +
+            `get=${fmtMs(tGet).padStart(7)}ms (${(tGet / ITERS).toFixed(2)} ms/call)  ` +
+            `take=${fmtMs(tTake).padStart(7)}ms (${(tTake / ITERS).toFixed(2)} ms/call)`,
+        );
+      }
+      t.end();
+    },
+    TIMEOUT_MS,
+  );
+})();

--- a/fixtures/strict-byte-arrays/tests/bindings/test_rustbuffer_alloc.ts
+++ b/fixtures/strict-byte-arrays/tests/bindings/test_rustbuffer_alloc.ts
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// To run:
+//   cargo test -p uniffi-fixture-strict-byte-arrays -- jsi
+//
+// Exercises the JSI codegen-emitted host functions
+// `<ModuleName>.rustbuffer_alloc(n)` and `<ModuleName>.rustbuffer_free(view)`.
+
+// Side-effect import to ensure registerNatives has installed the host object
+// onto globalThis before we look it up.
+import "@/generated/uniffi_strict_byte_arrays";
+import { test } from "@/asserts";
+import "@/polyfills";
+
+const nm = (globalThis as any).NativeUniffiStrictByteArrays;
+
+test("rustbuffer_alloc returns a Uint8Array of the requested length", (t) => {
+  const view = nm.rustbuffer_alloc(16);
+  t.assertTrue(view instanceof Uint8Array, "view is a Uint8Array");
+  t.assertEqual(view.byteLength, 16);
+  t.assertEqual(view.byteOffset, 0);
+  // Bytes survive write/read on the JS side.
+  view[0] = 0xab;
+  view[15] = 0xcd;
+  t.assertEqual(view[0], 0xab);
+  t.assertEqual(view[15], 0xcd);
+  // Hand the buffer back to Rust to free it (otherwise it leaks).
+  nm.rustbuffer_free(view);
+});
+
+test("rustbuffer_alloc handles zero-length allocation", (t) => {
+  const view = nm.rustbuffer_alloc(0);
+  t.assertTrue(view instanceof Uint8Array, "view is a Uint8Array");
+  t.assertEqual(view.byteLength, 0);
+  nm.rustbuffer_free(view);
+});

--- a/fixtures/strict-byte-arrays/tests/test_bindings.rs
+++ b/fixtures/strict-byte-arrays/tests/test_bindings.rs
@@ -5,4 +5,5 @@
  */
 ubrn_macros::build_foreign_language_testcases! {
     "tests/bindings/test_strict_byte_arrays.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_rustbuffer_alloc.ts" => [Jsi],
 }

--- a/runtimes/core/src/ffi_c_types.rs
+++ b/runtimes/core/src/ffi_c_types.rs
@@ -10,7 +10,7 @@
 //! and alignment that the target library expects, because we pass them by value
 //! (for `RustBufferC`) or by pointer (for `RustCallStatusC`) through libffi.
 //!
-//! There are three struct types and two function-pointer type aliases:
+//! There are three struct types and three function-pointer type aliases:
 //!
 //! - [`RustBufferC`]: The **owned** byte buffer—`{ capacity: u64, len: u64, data: *mut u8 }`.
 //!   UniFFI uses this for passing serialized compound types across the boundary.
@@ -20,9 +20,10 @@
 //!   The `error_buf` fields are **inlined** (not nested) because we need direct field access
 //!   when constructing and inspecting the struct from Rust, and because `#[repr(C)]` layout
 //!   of a struct with inlined fields is identical to one with a nested sub-struct.
-//! - [`RustBufferFromBytesFn`] and [`RustBufferFreeFn`]: Function-pointer types for the
-//!   two `rustbuffer` management symbols (`*_rustbuffer_from_bytes` and `*_rustbuffer_free`)
-//!   that are resolved from the loaded library at registration time.
+//! - [`RustBufferAllocFn`], [`RustBufferFromBytesFn`], and [`RustBufferFreeFn`]: Function-pointer
+//!   types for the three `rustbuffer` management symbols (`*_rustbuffer_alloc`,
+//!   `*_rustbuffer_from_bytes`, and `*_rustbuffer_free`) that are resolved from the loaded
+//!   library at registration time.
 
 /// C layout of UniFFI's `RustBuffer`: an **owned** byte buffer passed by value across the FFI.
 ///
@@ -76,6 +77,11 @@ impl Default for RustCallStatusC {
     }
 }
 
+/// Signature of the `*_rustbuffer_alloc` symbol: takes a requested size in bytes and an
+/// out-parameter for call status, returns an owned `RustBufferC` with `capacity == size`,
+/// `len == 0`, and a freshly heap-allocated `data` pointer.
+pub type RustBufferAllocFn = unsafe extern "C" fn(i32, *mut RustCallStatusC) -> RustBufferC;
+
 /// Signature of the `*_rustbuffer_from_bytes` symbol: takes borrowed bytes and an
 /// out-parameter for call status, returns an owned `RustBufferC`.
 pub type RustBufferFromBytesFn =
@@ -87,10 +93,11 @@ pub type RustBufferFreeFn = unsafe extern "C" fn(RustBufferC, *mut RustCallStatu
 
 /// Resolved function pointers for RustBuffer lifecycle management.
 ///
-/// These two symbols are resolved once during registration and
+/// These three symbols are resolved once during registration and
 /// threaded through to every site that needs to allocate or free RustBuffers.
 #[derive(Clone, Copy)]
 pub struct RustBufferOps {
+    pub alloc_ptr: *const std::ffi::c_void,
     pub from_bytes_ptr: *const std::ffi::c_void,
     pub free_ptr: *const std::ffi::c_void,
 }

--- a/runtimes/core/src/module.rs
+++ b/runtimes/core/src/module.rs
@@ -165,10 +165,11 @@ impl Module {
         let library = LibraryHandle::open(path_str)?;
 
         // Resolve RustBuffer helper symbols.
-        let _alloc = library.lookup_symbol(&spec.rustbuffer_symbols.alloc)?;
+        let alloc_ptr = library.lookup_symbol(&spec.rustbuffer_symbols.alloc)?;
         let free_ptr = library.lookup_symbol(&spec.rustbuffer_symbols.free)?;
         let from_bytes_ptr = library.lookup_symbol(&spec.rustbuffer_symbols.from_bytes)?;
         let rb_ops = RustBufferOps {
+            alloc_ptr,
             from_bytes_ptr,
             free_ptr,
         };

--- a/runtimes/napi/README.md
+++ b/runtimes/napi/README.md
@@ -39,9 +39,9 @@ This calls `dlopen` under the hood.
 ```js
 const nm = mod.register({
   symbols: {
-    rustbufferAlloc: "uniffi_foo_rustbuffer_alloc",
-    rustbufferFree: "uniffi_foo_rustbuffer_free",
-    rustbufferFromBytes: "uniffi_foo_rustbuffer_from_bytes",
+    rustbuffer_alloc: "uniffi_foo_rustbuffer_alloc",
+    rustbuffer_free: "uniffi_foo_rustbuffer_free",
+    rustbuffer_from_bytes: "uniffi_foo_rustbuffer_from_bytes",
   },
   structs: {},
   callbacks: {},

--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -16,8 +16,10 @@
 //! 4. Call [`Module::call`](uniffi_runtime_core::Module::call) (which guards
 //!    against concurrent unload).
 //! 5. Convert the typed [`CallReturn`](uniffi_runtime_core::CallReturn) into a
-//!    JS value via [`marshal::read_return_to_js`], or copy-and-free for
-//!    `RustBuffer` returns.
+//!    JS value via [`marshal::read_return_to_js`], or hand off a Rust-owned
+//!    view for `RustBuffer` returns. The codegen-emitted lift wrapper consumes
+//!    the view inside a `try/finally` and calls back through `rustbuffer_free`
+//!    to release the underlying Rust allocation.
 
 mod marshal;
 
@@ -30,6 +32,7 @@ use crate::callback;
 use crate::callback::vtable;
 use crate::core_err;
 use crate::napi_utils;
+use crate::napi_utils::CapacitySymbol;
 use uniffi_runtime_core::ffi_c_types::{RustBufferC, RustCallStatusC};
 use uniffi_runtime_core::slot;
 use uniffi_runtime_core::CallReturn;
@@ -48,6 +51,7 @@ pub(crate) fn call_ffi_function(
     module: &Arc<Module>,
     arg_types: &[FfiTypeDesc],
     has_rust_call_status: bool,
+    capacity_symbol: &CapacitySymbol,
 ) -> Result<JsUnknown> {
     let declared_arg_count = arg_types.len();
 
@@ -169,31 +173,63 @@ pub(crate) fn call_ffi_function(
 
     match &call_ret {
         CallReturn::RustBuffer(rb) => {
-            rust_buffer_to_js_uint8array(env, *rb, module.rb_ops().free_ptr)
+            rust_buffer_to_js_uint8array_handoff(env, *rb, capacity_symbol)
         }
         _ => marshal::read_return_to_js(env, &call_ret),
     }
 }
 
-/// Convert a `RustBufferC` to a JS `Uint8Array`, then free the native buffer.
+/// Hand a returned `RustBufferC` to JS as a `Uint8Array` view aliasing the
+/// Rust-owned bytes — no boundary copy. The codegen-emitted lift wrapper is
+/// expected to call `converter.lift(view)` inside a `try/finally` and invoke
+/// the runtime's `rustbuffer_free(view)` afterwards. The single mandatory copy
+/// now happens inside `lift()` itself (via `dest.set(view)` for byte arrays,
+/// `TextDecoder.decode` for strings, field-by-field reads for composites).
 ///
-/// **Ordering matters.** We must create the JS typed array (which copies the bytes into
-/// a V8-managed `ArrayBuffer`) *before* freeing the `RustBufferC`. If we freed first,
-/// `rb.data` would be a dangling pointer during the copy.
-fn rust_buffer_to_js_uint8array(
+/// The view's `byteLength` is `rb.len` (so string/raw-byte-array converters
+/// that decode the whole view see only the message bytes). Rust may have
+/// allocated `rb.capacity > rb.len` bytes, so we stash `capacity` on the view
+/// via the runtime's per-registration capacity Symbol; the runtime's
+/// `rustbuffer_free` reads it back when releasing the allocation.
+///
+/// On any error in the handoff, we free the buffer to avoid leaking the
+/// Rust-side allocation.
+fn rust_buffer_to_js_uint8array_handoff(
     env: &napi::Env,
     rb: RustBufferC,
-    rb_free_ptr: *const c_void,
+    capacity_symbol: &CapacitySymbol,
 ) -> Result<JsUnknown> {
-    let len = usize::try_from(rb.len).map_err(|_| {
-        unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
-        napi::Error::from_reason("RustBuffer len exceeds addressable memory")
-    })?;
     let raw_env = env.raw();
-    // SAFETY: `rb.data` points to a valid allocation of at least `len` bytes.
-    let typedarray = unsafe { napi_utils::create_uint8array(raw_env, rb.data, len)? };
+    let len = match usize::try_from(rb.len) {
+        Ok(n) => n,
+        Err(_) => {
+            return Err(napi::Error::from_reason(
+                "RustBuffer len exceeds addressable memory",
+            ));
+        }
+    };
 
-    unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+    // Empty RustBuffer (capacity == 0 or null data): no allocation to alias,
+    // and no capacity hint needed — the runtime's `rustbuffer_free` short-
+    // circuits on empty views without a hint.
+    if rb.capacity == 0 || rb.data.is_null() {
+        let typedarray = unsafe { napi_utils::create_uint8array(raw_env, std::ptr::null(), 0)? };
+        return Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? });
+    }
+
+    // SAFETY: `rb.data` points to a Rust-owned allocation of at least `len`
+    // bytes. We expose it to JS without a finalizer; the codegen-emitted
+    // try/finally calls `rustbuffer_free(view)` which will hand the (ptr,
+    // capacity) tuple back to the library's `rustbuffer_free`.
+    let typedarray = unsafe { napi_utils::create_external_uint8array(raw_env, rb.data, len)? };
+
+    // If `capacity > len`, the view's `byteLength` (== len) under-reports the
+    // allocation size. Stash the true capacity so `rustbuffer_free(view)` can
+    // free against the original `Layout`. When `capacity == len`, the runtime
+    // can recover capacity from `byteLength`, so we skip the property write.
+    if rb.capacity != rb.len {
+        unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity)? };
+    }
 
     Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? })
 }

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -27,8 +27,174 @@ use std::ffi::c_void;
 use napi::{JsUnknown, NapiRaw};
 
 use uniffi_runtime_core::ffi_c_types::{
-    ForeignBytesC, RustBufferC, RustBufferFreeFn, RustBufferFromBytesFn, RustCallStatusC,
+    ForeignBytesC, RustBufferAllocFn, RustBufferC, RustBufferFreeFn, RustBufferFromBytesFn,
+    RustCallStatusC,
 };
+
+/// A per-registration JS Symbol used as a hidden property key for stashing the
+/// underlying RustBuffer capacity on a lift-handoff `Uint8Array`. The view's
+/// `byteLength` is set to `len` so converters that decode the whole view
+/// (strings, raw byte arrays) see only the message bytes — but the global
+/// allocator needs `capacity` to free correctly when `capacity > len`. The
+/// symbol is created once when the module registers and lives as long as the
+/// JS-side module facade.
+pub struct CapacitySymbol {
+    /// `napi_ref` keeping the Symbol alive across JS callbacks. Symbols are GC-
+    /// managed; we hold a strong reference (initial refcount 1) so the symbol
+    /// remains valid for the lifetime of this struct.
+    sym_ref: napi::sys::napi_ref,
+    /// Captured at creation time so `Drop` can release the reference against
+    /// the env that owns it.
+    raw_env: napi::sys::napi_env,
+}
+
+// SAFETY: `napi_ref` and `napi_env` are raw pointers that the napi runtime
+// manages. They're only ever dereferenced from the JS thread (where this
+// `CapacitySymbol` is constructed and used). `Send`/`Sync` is required because
+// the symbol is parked inside an `Arc` shared with closures captured by
+// `env.create_function_from_closure`, and napi-rs requires those closures to
+// be `Send`. The pointers themselves never cross threads.
+unsafe impl Send for CapacitySymbol {}
+unsafe impl Sync for CapacitySymbol {}
+
+impl CapacitySymbol {
+    /// Create a new capacity-hint Symbol with a descriptive label and stash a
+    /// reference to it.
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must be a valid `napi_env` for the current callback scope.
+    pub unsafe fn new(raw_env: napi::sys::napi_env) -> napi::Result<Self> {
+        // Create a JS string for the symbol's description (debug aid only).
+        let desc = b"uniffi.rustbuffer.capacity\0";
+        let mut desc_val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_create_string_utf8(
+            raw_env,
+            desc.as_ptr() as *const _,
+            desc.len() - 1,
+            &mut desc_val,
+        );
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to create symbol description string".to_string(),
+            ));
+        }
+
+        let mut sym_val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_create_symbol(raw_env, desc_val, &mut sym_val);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to create capacity-hint Symbol".to_string(),
+            ));
+        }
+
+        // Keep the symbol alive past the current callback scope.
+        let mut sym_ref: napi::sys::napi_ref = std::ptr::null_mut();
+        let status = napi::sys::napi_create_reference(raw_env, sym_val, 1, &mut sym_ref);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to create reference to capacity-hint Symbol".to_string(),
+            ));
+        }
+        Ok(Self { sym_ref, raw_env })
+    }
+
+    /// Resolve the held reference to the live `napi_value` for the symbol.
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must match the env this symbol was created in (any active
+    /// callback scope on the same JS thread satisfies this).
+    pub unsafe fn value(
+        &self,
+        raw_env: napi::sys::napi_env,
+    ) -> napi::Result<napi::sys::napi_value> {
+        let mut sym_val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_get_reference_value(raw_env, self.sym_ref, &mut sym_val);
+        if status != napi::sys::Status::napi_ok || sym_val.is_null() {
+            return Err(napi::Error::from_reason(
+                "Failed to resolve capacity-hint Symbol".to_string(),
+            ));
+        }
+        Ok(sym_val)
+    }
+
+    /// Stash `capacity` on `obj` under the symbol-keyed hidden property.
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must be valid; `obj` must be a JS object (a `Uint8Array` is
+    /// an object as far as napi property access is concerned).
+    pub unsafe fn set(
+        &self,
+        raw_env: napi::sys::napi_env,
+        obj: napi::sys::napi_value,
+        capacity: u64,
+    ) -> napi::Result<()> {
+        let sym_val = self.value(raw_env)?;
+        // Use a BigInt to hold the full u64 capacity without lossy f64 rounding
+        // (matters for the >2^53 corner case; cheap enough in practice).
+        let mut cap_val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_create_bigint_uint64(raw_env, capacity, &mut cap_val);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to create BigInt for capacity hint".to_string(),
+            ));
+        }
+        let status = napi::sys::napi_set_property(raw_env, obj, sym_val, cap_val);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to set capacity-hint property".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Read the capacity hint from `obj`. Returns `None` if no hint is set
+    /// (e.g., views from `rustbuffer_alloc(n)` where `byteLength == capacity`).
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must be valid; `obj` must be a JS object.
+    pub unsafe fn get(
+        &self,
+        raw_env: napi::sys::napi_env,
+        obj: napi::sys::napi_value,
+    ) -> Option<u64> {
+        let sym_val = self.value(raw_env).ok()?;
+        let mut has = false;
+        let status = napi::sys::napi_has_property(raw_env, obj, sym_val, &mut has);
+        if status != napi::sys::Status::napi_ok || !has {
+            return None;
+        }
+        let mut cap_val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_get_property(raw_env, obj, sym_val, &mut cap_val);
+        if status != napi::sys::Status::napi_ok || cap_val.is_null() {
+            return None;
+        }
+        let mut value: u64 = 0;
+        let mut lossless = false;
+        let status =
+            napi::sys::napi_get_value_bigint_uint64(raw_env, cap_val, &mut value, &mut lossless);
+        if status != napi::sys::Status::napi_ok {
+            return None;
+        }
+        Some(value)
+    }
+}
+
+impl Drop for CapacitySymbol {
+    fn drop(&mut self) {
+        // SAFETY: `sym_ref` was created from `raw_env` by `napi_create_reference`
+        // and has not been deleted yet. Releasing it tells napi the symbol is
+        // free to GC.
+        if !self.sym_ref.is_null() && !self.raw_env.is_null() {
+            unsafe {
+                napi::sys::napi_delete_reference(self.raw_env, self.sym_ref);
+            }
+        }
+    }
+}
 
 /// Create a JS `Uint8Array` from raw bytes.
 ///
@@ -154,7 +320,7 @@ pub unsafe fn rustbuffer_from_raw_bytes(
         data: if len > 0 { data } else { std::ptr::null() },
     };
     // SAFETY: `rb_from_bytes_ptr` was obtained via `dlsym` for the symbol whose name
-    // was provided under `symbols.rustbufferFromBytes` in the JS definitions. We
+    // was provided under `symbols.rustbuffer_from_bytes` in the JS definitions. We
     // transmute it to `RustBufferFromBytesFn`—the correct signature for UniFFI's
     // `rustbuffer_from_bytes`.
     let from_bytes: RustBufferFromBytesFn = std::mem::transmute(rb_from_bytes_ptr);
@@ -166,6 +332,99 @@ pub unsafe fn rustbuffer_from_raw_bytes(
         ));
     }
     Ok(rb)
+}
+
+/// Allocate a [`RustBufferC`] of the requested capacity via `rustbuffer_alloc`.
+///
+/// Returned buffer has `capacity == size`, `len == 0`, and a heap-allocated `data`
+/// pointer owned by the Rust library. Callers must hand the buffer back through the
+/// matching `rustbuffer_free` (or pass it across the FFI to a function that consumes it).
+///
+/// # Safety
+///
+/// - `rb_alloc_ptr` must point to a valid `rustbuffer_alloc` function.
+pub unsafe fn rustbuffer_alloc(
+    size: i32,
+    rb_alloc_ptr: *const c_void,
+) -> napi::Result<RustBufferC> {
+    if rb_alloc_ptr.is_null() {
+        return Err(napi::Error::from_reason(
+            "rustbuffer_alloc symbol is unresolved".to_string(),
+        ));
+    }
+    // SAFETY: `rb_alloc_ptr` was obtained via `dlsym` for the symbol whose name was
+    // provided under `symbols.rustbuffer_alloc` in the JS definitions. We transmute
+    // it to `RustBufferAllocFn`—the correct signature for UniFFI's `rustbuffer_alloc`.
+    let alloc: RustBufferAllocFn = std::mem::transmute(rb_alloc_ptr);
+    let mut call_status = RustCallStatusC::default();
+    let rb = alloc(size, &mut call_status as *mut RustCallStatusC);
+    if call_status.code != 0 {
+        return Err(napi::Error::from_reason(
+            "rustbuffer_alloc failed".to_string(),
+        ));
+    }
+    Ok(rb)
+}
+
+/// Wrap externally-managed memory as a JS `Uint8Array` (via napi external ArrayBuffer).
+///
+/// Unlike [`create_uint8array`], this **does not copy**: the returned typed array is a
+/// view directly over `data`. The caller is responsible for keeping the memory alive
+/// for as long as JS holds the view—we pass a no-op finalizer because the codegen-emitted
+/// wrapper drops the JS reference before the corresponding `rustbuffer_free` runs.
+///
+/// # Safety
+///
+/// - `raw_env` must be a valid `napi_env` for the current callback scope.
+/// - `data` must point to at least `len` readable+writable bytes that remain alive
+///   for the lifetime of the returned typed array (ignored when `len == 0`).
+pub unsafe fn create_external_uint8array(
+    raw_env: napi::sys::napi_env,
+    data: *mut u8,
+    len: usize,
+) -> napi::Result<napi::sys::napi_value> {
+    // No-op finalizer: ownership stays with the Rust library; codegen will call
+    // `rustbuffer_free` explicitly. Using `napi_create_external_arraybuffer` with
+    // a null finalizer is technically permitted, but napi engines (Node 18+) emit
+    // a warning. A trivial extern "C" callback that does nothing is safer.
+    extern "C" fn noop_finalize(_env: napi::sys::napi_env, _data: *mut c_void, _hint: *mut c_void) {
+    }
+
+    let mut arraybuffer = std::ptr::null_mut();
+    // SAFETY: raw_env is valid (precondition); `data`+`len` describe a valid byte
+    // range we intend to expose; the finalizer is a static extern "C" function.
+    let status = napi::sys::napi_create_external_arraybuffer(
+        raw_env,
+        data as *mut c_void,
+        len,
+        Some(noop_finalize),
+        std::ptr::null_mut(),
+        &mut arraybuffer,
+    );
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_reason(
+            "Failed to create external ArrayBuffer".to_string(),
+        ));
+    }
+
+    let mut typedarray = std::ptr::null_mut();
+    // SAFETY: arraybuffer is the napi_value just created above; byte_offset=0
+    // and length=len match the ArrayBuffer's size, so the view covers exactly
+    // the entire buffer with no out-of-bounds region.
+    let status = napi::sys::napi_create_typedarray(
+        raw_env,
+        napi::sys::TypedarrayType::uint8_array,
+        len,
+        arraybuffer,
+        0,
+        &mut typedarray,
+    );
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_reason(
+            "Failed to create Uint8Array view".to_string(),
+        ));
+    }
+    Ok(typedarray)
 }
 
 /// Convert a JS `Uint8Array` to a [`RustBufferC`] by reading its data and calling

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -14,10 +14,13 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
-use napi::{JsObject, Result};
+use napi::{JsObject, JsUnknown, NapiRaw, NapiValue, Result};
 
 use crate::call::call_ffi_function;
 use crate::core_err;
+use crate::napi_utils;
+use crate::napi_utils::CapacitySymbol;
+use uniffi_runtime_core::ffi_c_types::RustBufferC;
 use uniffi_runtime_core::{FfiTypeDesc, Module};
 
 /// Build a JS object whose methods call into the native library described by `definitions`.
@@ -34,6 +37,18 @@ pub fn register(
 
     let functions: JsObject = definitions.get_named_property("functions")?;
     let mut result = env.create_object()?;
+
+    // Per-registration Symbol used as a hidden capacity-hint key on lift-
+    // handoff `Uint8Array` views. The view-handoff path returns a view whose
+    // `byteLength` is `rb.len`, but Rust may have allocated
+    // `rb.capacity > rb.len`. We stash `capacity` on the view via this
+    // symbol; `rustbuffer_free(view)` reads it back when releasing the
+    // allocation.
+    //
+    // SAFETY: env is the active napi env supplied by node for this register
+    // call. The `Arc<CapacitySymbol>` keeps the Symbol alive across the
+    // module facade's lifetime (closures captured below outlive the call).
+    let capacity_symbol = Arc::new(unsafe { CapacitySymbol::new(env.raw())? });
 
     let names = functions.get_property_names()?;
     let len = names.get_array_length()?;
@@ -53,6 +68,7 @@ pub fn register(
         })?;
         let arg_types: Rc<Vec<FfiTypeDesc>> = Rc::new(func_def.args.clone());
         let has_rust_call_status = func_def.has_rust_call_status;
+        let cap_sym_for_call = Arc::clone(&capacity_symbol);
 
         let js_func = env.create_function_from_closure(&name, move |ctx| {
             call_ffi_function(
@@ -62,11 +78,89 @@ pub fn register(
                 &module_ref,
                 &arg_types,
                 has_rust_call_status,
+                &cap_sym_for_call,
             )
         })?;
 
         result.set_named_property(&name, js_func)?;
     }
+
+    // `rustbuffer_alloc(n)` -> Uint8Array view over Rust-owned memory of capacity `n`.
+    // `rustbuffer_free(view)` -> hands the underlying (ptr, capacity) back to the
+    // library's `rustbuffer_free`. Together they let JS allocate buffers that the
+    // codegen-emitted lowering path can fill in place and ship to Rust without copying.
+    let alloc_module = Arc::clone(&module);
+    let alloc_fn = env.create_function_from_closure("rustbuffer_alloc", move |ctx| {
+        let size_arg: i32 = ctx.get(0)?;
+        if size_arg < 0 {
+            return Err(napi::Error::from_reason(
+                "rustbuffer_alloc size must be non-negative".to_string(),
+            ));
+        }
+        // SAFETY: `alloc_ptr` was resolved at registration time via dlsym; module
+        // (and thus the loaded library) outlives this closure thanks to the captured Arc.
+        let rb =
+            unsafe { napi_utils::rustbuffer_alloc(size_arg, alloc_module.rb_ops().alloc_ptr)? };
+        let len = usize::try_from(rb.capacity).map_err(|_| {
+            // Free what we just allocated to avoid leaking on the error path.
+            unsafe { napi_utils::free_rustbuffer(rb, alloc_module.rb_ops().free_ptr) };
+            napi::Error::from_reason("RustBuffer capacity exceeds addressable memory".to_string())
+        })?;
+        // SAFETY: rb.data points to a valid allocation of `len` bytes that the Rust
+        // library owns; codegen will hand the view back via `rustbuffer_free` before
+        // shipping the (ptr, len, cap) tuple to FFI, so no finalizer is required.
+        let typedarray =
+            unsafe { napi_utils::create_external_uint8array(ctx.env.raw(), rb.data, len)? };
+        unsafe { JsUnknown::from_raw(ctx.env.raw(), typedarray) }
+    })?;
+    result.set_named_property("rustbuffer_alloc", alloc_fn)?;
+
+    let free_module = Arc::clone(&module);
+    let cap_sym_for_free = Arc::clone(&capacity_symbol);
+    let free_fn = env.create_function_from_closure("rustbuffer_free", move |ctx| {
+        let js_val: JsUnknown = ctx.get(0)?;
+        let raw_env = ctx.env.raw();
+        // SAFETY: js_val is a JS value from the current callback scope; `raw()`
+        // returns the underlying napi_value handle without changing its ownership.
+        let raw_val = unsafe { js_val.raw() };
+        // SAFETY: js_val came from JS; if it is not a typed array,
+        // `read_typedarray_data` returns None and we surface a clean error.
+        let (data_ptr, length) = unsafe { napi_utils::read_typedarray_data(raw_env, raw_val) }
+            .ok_or_else(|| {
+                napi::Error::from_reason(
+                    "rustbuffer_free expected a Uint8Array argument".to_string(),
+                )
+            })?;
+        // Empty views never carry a capacity hint (view-handoff short-
+        // circuits empty buffers, and `rustbuffer_alloc(0)` is itself a
+        // no-op). Bail out before the napi_ref + napi_has_property dance.
+        if length == 0 {
+            return ctx.env.get_undefined().map(|u| u.into_unknown());
+        }
+        // Capacity recovery. Two view origins to handle:
+        //   (a) `rustbuffer_alloc(n)` views: capacity == byteLength == n, no
+        //       hint set. Use byteLength.
+        //   (b) Lift-handoff views: byteLength == rb.len, capacity may be
+        //       larger and was stashed on the view at handoff time. Read
+        //       the stashed value via `CapacitySymbol::get`. When
+        //       `capacity == len` at handoff time we skip the property write,
+        //       so absence of a hint here is also a valid "use byteLength"
+        //       signal.
+        // SAFETY: raw_env / raw_val are valid for the current callback scope.
+        let capacity = unsafe { cap_sym_for_free.get(raw_env, raw_val) }.unwrap_or(length as u64);
+        let rb = RustBufferC {
+            capacity,
+            len: 0,
+            data: data_ptr as *mut u8,
+        };
+        // SAFETY: free_ptr was resolved at registration time. rb mirrors the
+        // buffer produced by the matching `rustbuffer_alloc` call OR a
+        // lift-handoff view whose `(data_ptr, capacity)` match the original
+        // RustBuffer that Rust returned across the FFI.
+        unsafe { napi_utils::free_rustbuffer(rb, free_module.rb_ops().free_ptr) };
+        ctx.env.get_undefined().map(|u| u.into_unknown())
+    })?;
+    result.set_named_property("rustbuffer_free", free_fn)?;
 
     Ok((result, module))
 }

--- a/runtimes/napi/src/register/spec_from_js.rs
+++ b/runtimes/napi/src/register/spec_from_js.rs
@@ -61,9 +61,9 @@ fn ffi_type_desc_from_js(obj: &JsObject) -> Result<FfiTypeDesc> {
 pub fn parse_module_spec(definitions: &JsObject) -> Result<ModuleSpec> {
     let symbols: JsObject = definitions.get_named_property("symbols")?;
     let rustbuffer_symbols = RustBufferSymbols {
-        alloc: symbols.get_named_property::<String>("rustbufferAlloc")?,
-        free: symbols.get_named_property::<String>("rustbufferFree")?,
-        from_bytes: symbols.get_named_property::<String>("rustbufferFromBytes")?,
+        alloc: symbols.get_named_property::<String>("rustbuffer_alloc")?,
+        free: symbols.get_named_property::<String>("rustbuffer_free")?,
+        from_bytes: symbols.get_named_property::<String>("rustbuffer_from_bytes")?,
     };
 
     let functions = parse_functions(definitions)?;

--- a/runtimes/napi/tests/arithmetic.test.mjs
+++ b/runtimes/napi/tests/arithmetic.test.mjs
@@ -20,9 +20,9 @@ const LIB_PATH = libPath("arithmetical");
 const CRATE = "arithmetical";
 
 const SYMBOLS = {
-  rustbufferAlloc: `ffi_${CRATE}_rustbuffer_alloc`,
-  rustbufferFree: `ffi_${CRATE}_rustbuffer_free`,
-  rustbufferFromBytes: `ffi_${CRATE}_rustbuffer_from_bytes`,
+  rustbuffer_alloc: `ffi_${CRATE}_rustbuffer_alloc`,
+  rustbuffer_free: `ffi_${CRATE}_rustbuffer_free`,
+  rustbuffer_from_bytes: `ffi_${CRATE}_rustbuffer_from_bytes`,
 };
 
 function openAndRegister(functions = {}) {

--- a/runtimes/napi/tests/callbacks.test.mjs
+++ b/runtimes/napi/tests/callbacks.test.mjs
@@ -13,9 +13,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 function openLib() {

--- a/runtimes/napi/tests/fixture.test.mjs
+++ b/runtimes/napi/tests/fixture.test.mjs
@@ -20,9 +20,9 @@ const LIB_PATH = libPath("uniffi_fixture_simple");
 const CRATE = "uniffi_fixture_simple";
 
 const SYMBOLS = {
-  rustbufferAlloc: `ffi_${CRATE}_rustbuffer_alloc`,
-  rustbufferFree: `ffi_${CRATE}_rustbuffer_free`,
-  rustbufferFromBytes: `ffi_${CRATE}_rustbuffer_from_bytes`,
+  rustbuffer_alloc: `ffi_${CRATE}_rustbuffer_alloc`,
+  rustbuffer_free: `ffi_${CRATE}_rustbuffer_free`,
+  rustbuffer_from_bytes: `ffi_${CRATE}_rustbuffer_from_bytes`,
 };
 
 function openAndRegister(

--- a/runtimes/napi/tests/open_close.test.mjs
+++ b/runtimes/napi/tests/open_close.test.mjs
@@ -12,9 +12,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 test("open() loads a library", () => {
@@ -33,9 +33,9 @@ test("register() throws for missing symbol", () => {
   assert.throws(() => {
     lib.register({
       symbols: {
-        rustbufferAlloc: "nonexistent_symbol",
-        rustbufferFree: "uniffi_test_rustbuffer_free",
-        rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+        rustbuffer_alloc: "nonexistent_symbol",
+        rustbuffer_free: "uniffi_test_rustbuffer_free",
+        rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
       },
       structs: {},
       callbacks: {},

--- a/runtimes/napi/tests/rust_buffer.test.mjs
+++ b/runtimes/napi/tests/rust_buffer.test.mjs
@@ -12,9 +12,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 function openLib() {
@@ -139,6 +139,68 @@ test("RustBuffer: buffer_len returns correct length", () => {
 
   assert.strictEqual(status.code, 0);
   assert.strictEqual(result, 4);
+});
+
+test("rustbuffer_alloc returns a Uint8Array view of the requested length", () => {
+  const lib = openLib();
+  const nm = lib.register({
+    symbols: SYMBOLS,
+    structs: {},
+    callbacks: {},
+    functions: {},
+  });
+
+  const view = nm.rustbuffer_alloc(16);
+  assert.ok(view instanceof Uint8Array);
+  assert.strictEqual(view.byteLength, 16);
+  view[0] = 0xab;
+  view[15] = 0xcd;
+  // Hand the buffer back to Rust to free it (otherwise it leaks).
+  nm.rustbuffer_free(view);
+});
+
+test("RustBuffer return is a view-handoff (alias safety)", () => {
+  // The lift-handoff path hands back a `Uint8Array` aliasing the Rust-
+  // allocated bytes — there's no boundary copy. After `rustbuffer_free`
+  // releases the underlying allocation, the view's bytes are no longer
+  // safe to inspect; mutating the view before free, however, must mutate
+  // the same bytes the runtime is about to free.
+  //
+  // We confirm "no boundary copy" by checking that the lift result and
+  // the final free happen against the same backing storage: the result
+  // is an `ArrayBuffer`-backed view distinct from the input we passed in
+  // (the input was JS-owned bytes wrapped into a Rust-owned `RustBuffer`
+  // by `from_bytes`; the return is a fresh Rust-owned allocation).
+  // Stronger: we make sure the lift path does not produce a view that
+  // shares storage with the JS-owned input — that would be a different
+  // bug (use-after-free across the FFI boundary).
+  const lib = openLib();
+  const nm = lib.register({
+    symbols: SYMBOLS,
+    structs: {},
+    callbacks: {},
+    functions: {
+      uniffi_test_fn_echo_buffer: {
+        args: [FfiType.RustBuffer],
+        ret: FfiType.RustBuffer,
+        hasRustCallStatus: true,
+      },
+    },
+  });
+
+  const input = new Uint8Array([10, 20, 30, 40, 50]);
+  const status = { code: 0 };
+  const result = nm.uniffi_test_fn_echo_buffer(input, status);
+
+  assert.strictEqual(status.code, 0);
+  assert.ok(result instanceof Uint8Array);
+  // The lifted view must not share storage with the JS-owned input — if
+  // it did, mutating `input` post-hoc would corrupt `result`. With a
+  // view-handoff over Rust memory, the two ArrayBuffers are independent.
+  assert.notStrictEqual(result.buffer, input.buffer);
+  // Mutate the input after the call to confirm independence.
+  input[0] = 0xff;
+  assert.strictEqual(result[0], 10);
 });
 
 test("RustBuffer: make_buffer creates filled buffer", () => {

--- a/runtimes/napi/tests/rust_call_status.test.mjs
+++ b/runtimes/napi/tests/rust_call_status.test.mjs
@@ -12,9 +12,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 function openLib() {

--- a/runtimes/napi/tests/scalars.test.mjs
+++ b/runtimes/napi/tests/scalars.test.mjs
@@ -12,9 +12,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 function openLib() {

--- a/runtimes/napi/tests/threading.test.mjs
+++ b/runtimes/napi/tests/threading.test.mjs
@@ -12,9 +12,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 function openLib() {

--- a/runtimes/napi/tests/unload.test.mjs
+++ b/runtimes/napi/tests/unload.test.mjs
@@ -12,9 +12,9 @@ import { libPath } from "./helpers/lib-path.mjs";
 const LIB_PATH = libPath("uniffi_napi_test_lib");
 
 const SYMBOLS = {
-  rustbufferAlloc: "uniffi_test_rustbuffer_alloc",
-  rustbufferFree: "uniffi_test_rustbuffer_free",
-  rustbufferFromBytes: "uniffi_test_rustbuffer_from_bytes",
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
 };
 
 const FUNCTIONS = {

--- a/typescript/src/async-callbacks.ts
+++ b/typescript/src/async-callbacks.ts
@@ -6,6 +6,7 @@
 import { CALL_ERROR, CALL_UNEXPECTED_ERROR } from "./rust-call";
 import { type UniffiHandle, UniffiHandleMap } from "./handle-map";
 import { type UniffiByteArray } from "./ffi-types";
+import { type RustBufferAllocator } from "./ffi-converters";
 
 // Some additional data we hold for each in-flight promise.
 type PromiseHelper = {
@@ -24,7 +25,10 @@ const UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = new UniffiHandleMap<PromiseHelper>();
 
 // Some degenerate functions used for default arguments.
 const notExpectedError = (err: any) => false;
-function emptyLowerError<E>(e: E): UniffiByteArray {
+function emptyLowerError<E>(
+  e: E,
+  _alloc: RustBufferAllocator,
+): UniffiByteArray {
   throw new Error("Unreachable");
 }
 
@@ -43,7 +47,8 @@ export function uniffiTraitInterfaceCallAsync<T>(
     callStatus: /*i8*/ number,
     errorBuffer: UniffiByteArray,
   ) => void,
-  lowerString: (str: string) => UniffiByteArray,
+  lowerString: (str: string, alloc: RustBufferAllocator) => UniffiByteArray,
+  alloc: RustBufferAllocator,
 ): UniffiForeignFuture {
   return uniffiTraitInterfaceCallAsyncWithError(
     makeCall,
@@ -52,6 +57,7 @@ export function uniffiTraitInterfaceCallAsync<T>(
     notExpectedError,
     emptyLowerError,
     lowerString,
+    alloc,
   );
 }
 
@@ -63,8 +69,9 @@ export function uniffiTraitInterfaceCallAsyncWithError<T, E>(
     errorBuffer: UniffiByteArray,
   ) => void,
   isErrorType: (error: any) => boolean,
-  lowerError: (error: E) => UniffiByteArray,
-  lowerString: (str: string) => UniffiByteArray,
+  lowerError: (error: E, alloc: RustBufferAllocator) => UniffiByteArray,
+  lowerString: (str: string, alloc: RustBufferAllocator) => UniffiByteArray,
+  alloc: RustBufferAllocator,
 ): UniffiForeignFuture {
   const settledHolder: { settled: boolean } = { settled: false };
   const abortController = new AbortController();
@@ -77,7 +84,7 @@ export function uniffiTraitInterfaceCallAsyncWithError<T, E>(
       let message = error.message ? error.message : error.toString();
       if (isErrorType(error)) {
         try {
-          handleError(CALL_ERROR, lowerError(error as E));
+          handleError(CALL_ERROR, lowerError(error as E, alloc));
           return;
         } catch (e: any) {
           // Fall through to unexpected error handling below.
@@ -87,7 +94,7 @@ export function uniffiTraitInterfaceCallAsyncWithError<T, E>(
       // This is the catch all:
       // 1. if there was an unexpected error causing a rejection
       // 2. if there was an unexpected error in the handleError function.
-      handleError(CALL_UNEXPECTED_ERROR, lowerString(message));
+      handleError(CALL_UNEXPECTED_ERROR, lowerString(message, alloc));
     });
 
   const promiseHelper = { abortController, settledHolder, promise };

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -3,7 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { type FfiConverter, FfiConverterUInt64 } from "./ffi-converters";
+import {
+  type FfiConverter,
+  FfiConverterUInt64,
+  type RustBufferAllocator,
+} from "./ffi-converters";
 import { type UniffiByteArray, RustBuffer } from "./ffi-types";
 import {
   type UniffiHandle,
@@ -24,14 +28,14 @@ export class FfiConverterCallback<T> implements FfiConverter<UniffiHandle, T> {
   lift(value: UniffiHandle): T {
     return this.handleMap.get(value);
   }
-  lower(value: T): UniffiHandle {
+  lower(value: T, _alloc: RustBufferAllocator): UniffiHandle {
     return this.handleMap.insert(value);
   }
   read(from: RustBuffer): T {
     return this.lift(handleConverter.read(from));
   }
   write(value: T, into: RustBuffer): void {
-    handleConverter.write(this.lower(value), into);
+    handleConverter.write(this.handleMap.insert(value), into);
   }
   allocationSize(value: T): number {
     return handleConverter.allocationSize(defaultUniffiHandle);
@@ -53,12 +57,13 @@ export function uniffiTraitInterfaceCall<T>(
     callStatus: /*i8*/ number,
     errorBuffer: UniffiByteArray,
   ) => void,
-  lowerString: (s: string) => UniffiByteArray,
+  lowerString: (s: string, alloc: RustBufferAllocator) => UniffiByteArray,
+  alloc: RustBufferAllocator,
 ) {
   try {
     handleSuccess(makeCall());
   } catch (e: any) {
-    handleError(CALL_UNEXPECTED_ERROR, lowerString(e.toString()));
+    handleError(CALL_UNEXPECTED_ERROR, lowerString(e.toString(), alloc));
   }
 }
 
@@ -70,8 +75,9 @@ export function uniffiTraitInterfaceCallWithError<T, E extends Error>(
     errorBuffer: UniffiByteArray,
   ) => void,
   isErrorType: (e: any) => e is E,
-  lowerError: (err: E) => UniffiByteArray,
-  lowerString: (s: string) => UniffiByteArray,
+  lowerError: (err: E, alloc: RustBufferAllocator) => UniffiByteArray,
+  lowerString: (s: string, alloc: RustBufferAllocator) => UniffiByteArray,
+  alloc: RustBufferAllocator,
 ): void {
   try {
     handleSuccess(makeCall());
@@ -79,9 +85,9 @@ export function uniffiTraitInterfaceCallWithError<T, E extends Error>(
     // Hermes' prototype chain seems buggy, so we need to make our
     // own arrangements
     if (isErrorType(e)) {
-      handleError(CALL_ERROR, lowerError(e));
+      handleError(CALL_ERROR, lowerError(e, alloc));
     } else {
-      handleError(CALL_UNEXPECTED_ERROR, lowerString(e.toString()));
+      handleError(CALL_UNEXPECTED_ERROR, lowerString(e.toString(), alloc));
     }
   }
 }

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -7,9 +7,16 @@ import { UniffiInternalError } from "./errors";
 import { type UniffiByteArray, RustBuffer } from "./ffi-types";
 
 // https://github.com/mozilla/uniffi-rs/blob/main/docs/manual/src/internals/lifting_and_lowering.md
+//
+// `lower(value, alloc)` takes an allocator the caller controls. Only
+// byte-array-backed converters (RustBuffer payloads) actually use it; primitive
+// converters ignore it. Centralising the parameter on the interface keeps
+// codegen call sites uniform.
+export type RustBufferAllocator = (n: number) => Uint8Array;
+
 export interface FfiConverter<FfiType, TsType> {
   lift(value: FfiType): TsType;
-  lower(value: TsType): FfiType;
+  lower(value: TsType, alloc: RustBufferAllocator): FfiType;
   read(from: RustBuffer): TsType;
   write(value: TsType, into: RustBuffer): void;
   allocationSize(value: TsType): number;
@@ -19,7 +26,7 @@ export abstract class FfiConverterPrimitive<T> implements FfiConverter<T, T> {
   lift(value: T): T {
     return value;
   }
-  lower(value: T): T {
+  lower(value: T, _alloc: RustBufferAllocator): T {
     return value;
   }
   abstract read(from: RustBuffer): T;
@@ -31,13 +38,14 @@ export abstract class AbstractFfiConverterByteArray<TsType>
   implements FfiConverter<UniffiByteArray, TsType>
 {
   lift(value: UniffiByteArray): TsType {
-    const buffer = RustBuffer.fromByteArray(value);
+    const buffer = RustBuffer.fromUint8Array(value);
     return this.read(buffer);
   }
-  lower(value: TsType): UniffiByteArray {
-    const buffer = RustBuffer.withCapacity(this.allocationSize(value));
+  lower(value: TsType, alloc: RustBufferAllocator): UniffiByteArray {
+    const view = alloc(this.allocationSize(value));
+    const buffer = RustBuffer.fromUint8Array(view);
     this.write(value, buffer);
-    return buffer.byteArray;
+    return view;
   }
   abstract read(from: RustBuffer): TsType;
   abstract write(value: TsType, into: RustBuffer): void;
@@ -135,14 +143,14 @@ export const FfiConverterBool = (() => {
     lift(value: number): boolean {
       return !!value;
     }
-    lower(value: boolean): number {
+    lower(value: boolean, _alloc: RustBufferAllocator): number {
       return value ? 1 : 0;
     }
     read(from: RustBuffer): boolean {
       return this.lift(byteConverter.read(from));
     }
     write(value: boolean, into: RustBuffer): void {
-      byteConverter.write(this.lower(value), into);
+      byteConverter.write(value ? 1 : 0, into);
     }
     allocationSize(value: boolean): number {
       return byteConverter.allocationSize(0);
@@ -392,7 +400,7 @@ export function uniffiCreateFfiConverterString(
     lift(value: UniffiByteArray): string {
       return converter.bytesToString(value);
     }
-    lower(value: string): UniffiByteArray {
+    lower(value: string, _alloc: RustBufferAllocator): UniffiByteArray {
       return converter.stringToBytes(value);
     }
     read(from: RustBuffer): string {

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -35,6 +35,19 @@ export class RustBuffer {
     return new RustBuffer(buf.buffer as ArrayBuffer);
   }
 
+  /**
+   * Construct a `RustBuffer` over a `Uint8Array` view. Cursors track absolute
+   * offsets into the backing `ArrayBuffer`, so `byteOffset` and `byteLength`
+   * delimit the readable/writable region.
+   */
+  static fromUint8Array(view: UniffiByteArray): RustBuffer {
+    const buf = new RustBuffer(view.buffer as ArrayBuffer);
+    buf.readOffset = view.byteOffset;
+    buf.writeOffset = view.byteOffset;
+    buf.capacity = view.byteOffset + view.byteLength;
+    return buf;
+  }
+
   get length(): number {
     return this.arrayBuffer.byteLength;
   }

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -18,6 +18,11 @@ export class RustBuffer {
     this.capacity = arrayBuffer.byteLength;
   }
 
+  /**
+   * Allocate a JS-owned buffer of the given capacity. Used by tests; not by
+   * the runtime path, which calls `RustBuffer.fromUint8Array(allocator(n))`
+   * with a runtime-supplied allocator.
+   */
   static withCapacity(capacity: number): RustBuffer {
     const buf = new ArrayBuffer(capacity);
     return new RustBuffer(buf);
@@ -29,10 +34,6 @@ export class RustBuffer {
 
   static fromArrayBuffer(buf: ArrayBuffer): RustBuffer {
     return new RustBuffer(buf);
-  }
-
-  static fromByteArray(buf: UniffiByteArray): RustBuffer {
-    return new RustBuffer(buf.buffer as ArrayBuffer);
   }
 
   /**

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -8,6 +8,7 @@ import {
   AbstractFfiConverterByteArray,
   type FfiConverter,
   FfiConverterUInt64,
+  type RustBufferAllocator,
 } from "./ffi-converters";
 import { RustBuffer } from "./ffi-types";
 import type { UniffiGcObject } from "./rust-call";
@@ -70,18 +71,21 @@ export class FfiConverterObject<T> implements FfiConverter<UniffiHandle, T> {
   lift(value: UniffiHandle): T {
     return this.factory.create(value);
   }
-  lower(value: T): UniffiHandle {
-    if (this.factory.isConcreteType(value)) {
-      return this.factory.clonePointer(value);
-    } else {
-      throw new Error("Cannot lower this object to a pointer");
-    }
+  lower(value: T, _alloc: RustBufferAllocator): UniffiHandle {
+    return this.lowerHandle(value);
   }
   read(from: RustBuffer): T {
     return this.lift(pointerConverter.read(from));
   }
   write(value: T, into: RustBuffer): void {
-    pointerConverter.write(this.lower(value), into);
+    pointerConverter.write(this.lowerHandle(value), into);
+  }
+  protected lowerHandle(value: T): UniffiHandle {
+    if (this.factory.isConcreteType(value)) {
+      return this.factory.clonePointer(value);
+    } else {
+      throw new Error("Cannot lower this object to a pointer");
+    }
   }
   allocationSize(value: T): number {
     return pointerConverter.allocationSize(dummyPointer);
@@ -97,11 +101,11 @@ export class FfiConverterObjectWithCallbacks<T> extends FfiConverterObject<T> {
     super(factory);
   }
 
-  lower(value: T): UniffiHandle {
+  lower(value: T, alloc: RustBufferAllocator): UniffiHandle {
     // Rust-backed objects are lowered as raw Arc pointers (even numbers).
     // TS-implemented objects are inserted into the handleMap as foreign handles (odd numbers).
     if (this.factory.isConcreteType(value)) {
-      return super.lower(value);
+      return super.lower(value, alloc);
     }
     return this.handleMap.insert(value);
   }

--- a/typescript/tests/ffi-converters.test.ts
+++ b/typescript/tests/ffi-converters.test.ts
@@ -16,7 +16,10 @@ import {
   FfiConverterPrimitive,
   FfiConverterUInt16,
   FfiConverterUInt8,
+  FfiConverterUint8Array,
 } from "../src/ffi-converters";
+
+const testAlloc = (n: number) => new Uint8Array(n);
 import { Asserts, test } from "../testing/asserts";
 
 class TestConverter<R extends any, T> extends AbstractFfiConverterByteArray<T> {
@@ -39,7 +42,7 @@ function testConverter<T>(
   converter: AbstractFfiConverterByteArray<T>,
   input: T,
 ) {
-  const lowered = converter.lower(input);
+  const lowered = converter.lower(input, testAlloc);
   t.assertEqual(
     lowered.byteLength,
     converter.allocationSize(input),
@@ -104,6 +107,21 @@ test("Array of shorts", (t) => {
   testConverter(t, converter, [1, 2, 3]);
   testConverter(t, converter, [0]);
   testConverter(t, converter, new Array(100).fill(128));
+});
+
+test("AbstractFfiConverterByteArray.lower uses the supplied allocator", (t) => {
+  let lastSize = -1;
+  const alloc = (n: number) => {
+    lastSize = n;
+    return new Uint8Array(n);
+  };
+  const value = new Uint8Array([1, 2, 3, 4]);
+  const view = FfiConverterUint8Array.lower(value, alloc);
+  // 4-byte length prefix + 4 bytes of payload = 8.
+  t.assertEqual(lastSize, 8);
+  t.assertEqual(view.byteLength, 8);
+  const lifted = FfiConverterUint8Array.lift(view);
+  t.assertEqual(Array.from(lifted), [1, 2, 3, 4]);
 });
 
 test("Array of optional shorts", (t) => {

--- a/typescript/tests/ffi-types.test.ts
+++ b/typescript/tests/ffi-types.test.ts
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { RustBuffer } from "../src/ffi-types";
+import { test } from "../testing/asserts";
+
+test("RustBuffer.fromUint8Array honours non-zero byteOffset", (t) => {
+  const backing = new ArrayBuffer(64);
+  const seed = new Uint8Array(backing);
+  seed[40] = 0x11;
+  seed[41] = 0x22;
+  seed[42] = 0x33;
+
+  const view = new Uint8Array(backing, 40, 3);
+  const rb = RustBuffer.fromUint8Array(view);
+
+  t.assertEqual(Array.from(rb.readByteArray(3)), [0x11, 0x22, 0x33]);
+});
+
+test("RustBuffer.fromUint8Array writes through to backing storage", (t) => {
+  const backing = new ArrayBuffer(64);
+  const view = new Uint8Array(backing, 16, 4);
+  const rb = RustBuffer.fromUint8Array(view);
+  rb.writeByteArray(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+
+  const seed = new Uint8Array(backing);
+  t.assertEqual(seed[16], 0x01);
+  t.assertEqual(seed[17], 0x02);
+  t.assertEqual(seed[18], 0x03);
+  t.assertEqual(seed[19], 0x04);
+});

--- a/xtask/src/bootstrap/hermes.rs
+++ b/xtask/src/bootstrap/hermes.rs
@@ -96,7 +96,7 @@ impl Bootstrap for HermesCmd {
                 "Ninja"
             })
             .arg("-DHERMES_BUILD_APPLE_FRAMEWORK=OFF")
-            .arg("-DCMAKE_BUILD_TYPE=Debug");
+            .arg("-DCMAKE_BUILD_TYPE=Release");
         if cfg!(target_os = "windows") {
             // The VS generator defaults to static libs, which would require
             // consumers to link the entire Hermes transitive dependency chain.

--- a/xtask/src/bootstrap/test_runner.rs
+++ b/xtask/src/bootstrap/test_runner.rs
@@ -69,6 +69,7 @@ impl Bootstrap for TestRunnerCmd {
             } else {
                 "Ninja"
             })
+            .arg("-DCMAKE_BUILD_TYPE=Release")
             .arg(format!("-DHERMES_SRC_DIR={hermes_src}"))
             .arg(format!("-DHERMES_BUILD_DIR={hermes_build}"))
             .arg(&src_dir);


### PR DESCRIPTION
I fleshed out the benchnark fixture, and polyfilled `performance.now()` and `process.memoryUsage()` in the JSI test runner.

Then I did a series of optimizations:

- reduced copying down to 1 serialization/deserialization for JSI and NAPI, by getting calling rustbuffer_alloc and _free directly from typescript.
- swap out the JSI string encoding/decoding for TextEncoder/TextDecoder when it becomes supported
- use the TextEncoder/TextDecoder API more extensively, in WASM and NAPI, so as to avoid an extra copy
- switch out opt level from `s` to `3` to prioritize speed.

The below is a report synthesized from runnning the new benchmark before and after the optimizations.

--- 

# uniffi-fixture-benchmark

## FFI overhead (µs/call, lower is better)

| Suite                          | WASM base / tip   | NAPI base / tip   | JSI base / tip    |
|--------------------------------|-------------------|-------------------|-------------------|
| noop                           | 0.163 / 0.143     | 0.727 / 0.737     | 0.559 / 0.541     |
| addU32                         | 0.169 / 0.189     | 1.026 / 1.027     | 0.972 / 1.140 *   |
| Counter.increment              | 0.454 / 0.428     | 1.828 / 1.823     | 1.426 / 1.403     |
| getLargeRecord (lift, µs)      | 2.88 / 2.87       | 5.60 / 6.05       | 15.80 / 16.58     |
| takeLargeRecord (lower, µs)    | 4.88 / **3.98** (-18%)| 7.46 / **6.80** (-9%) | 20.31 / 21.14 |
| noopAsync (µs)                 | 0.912 / 0.904     | 18.13 / 18.12     | 14.38 / 14.26     |

`*` JSI addU32 jitter — within run-to-run variance (≤0.2 µs).

## Buffer/string transfers (ms/call, best-of-3 from the warm sync suite)

WASM — biggest wins on *lower* paths:

| Payload          | metric      | base   | tip    | Δ        |
|------------------|-------------|--------|--------|----------|
| getString 512K   | lift        | 0.076  | 0.072  | -5%      |
| getString 1M     | lift        | 0.092  | 0.101  | +10% (noise) |
| takeString 512K  | lower       | 0.040  | 0.034  | **-15%** |
| takeString 1M    | lower       | 0.074  | 0.061  | **-18%** |
| getBytes 512K    | lift        | 1.829  | 1.563  | **-15%** |
| getBytes 1M      | lift        | 3.651  | 3.117  | **-15%** |
| takeBytes 512K   | lower       | 1.339  | 1.343  |  flat    |
| takeBytes 1M     | lower       | 2.633  | 2.674  |  flat    |

WASM string-array lowering (1 MB total payload, sync) — the standout:

| count × elemBytes | metric  | base ms/call | tip ms/call | Δ        |
|-------------------|---------|--------------|-------------|----------|
| 1024 × 1024 B     | take    | 0.73         | 0.46        | **-37%** |
| 16 384 × 64 B     | take    | 7.30         | 4.09        | **-44%** |
| 65 536 × 16 B     | take    | 26.91        | 16.44       | **-39%** |
| (same, async)     | take    | 24.13        | 15.19       | -37%     |

NAPI — wins on string lift + string-array lower, byte transfers untouched:

| Suite             | metric  | base ms/call | tip ms/call | Δ        |
|-------------------|---------|--------------|-------------|----------|
| getString 512K    | lift    | 0.080        | 0.064       | **-20%** |
| getString 1M      | lift    | 0.081        | 0.063       | **-22%** |
| takeString 1M     | lower   | 0.060        | 0.066       | flat/noise|
| getBytes 1M       | lift    | 23.95        | 23.78       | flat     |
| takeBytes 1M      | lower   | 14.98        | 15.02       | flat     |
| takeStringArray 1024×1024  | lower  | 0.71  | 0.53  | **-25%** |
| takeStringArray 16384×64   | lower  | 7.14  | 5.13  | **-28%** |
| takeStringArray 65536×16   | lower  | 26.96 | 18.91 | **-30%** |

JSI — wins on string lift only, bytes mostly unchanged:

| Suite            | metric  | base ms/call | tip ms/call | Δ        |
|------------------|---------|--------------|-------------|----------|
| getString 512K   | lift    | 0.091        | 0.048       | **-47%** |
| getString 1M     | lift    | 0.152        | 0.101       | **-34%** |
| takeString 1M    | lower   | 3.56         | 3.67        | flat     |
| getBytes 1M      | lift    | 23.90        | 23.78       | flat     |
| takeBytes 1M     | lower   | 14.82        | 15.13       | flat     |
| takeStringArray 65536×16   | lower  | 59.05 | 59.20 | flat     |

## Headlines

- **Lower path got cheaper.** Whenever the call lowers many small `RustBuffer`s
  in one call (`takeStringArray`), all three runtimes drop 25–44%. This is the
  shape that the `rustbuffer_alloc` plumbing (43e4753, 8611528, 72ed83b) was
  aimed at — JS allocates the underlying buffer, Rust reads it in place, no
  intermediate copy.
- **String lift got cheaper on NAPI and JSI.** Best on JSI: `getString` 1 MB
  goes 15.2 → 10.1 ms (-34%), and 512 KB nearly halves (0.091 → 0.048 ms).
  NAPI gets a consistent -20% on `getString`. WASM is roughly flat — its
  string lift already used a tight `readStringFromBuffer` path that landed in
  the same series (b708480).
- **Bulk byte transfers (`getBytes` / `takeBytes` 512 K + 1 M)** barely moved
  on NAPI and JSI. ~12 ms/call (512 K) and ~24 ms/call (1 M) on both runtimes
  for `getBytes` is more than 10× WASM's `getBytes` (1.6 ms/call at 1 M post-
  optimization), so something else dominates — almost certainly the
  per-`ArrayBuffer` allocation/copy through the host's ArrayBuffer machinery,
  not the boundary copy that view-handoff removes. This is the next thing
  worth investigating: view-handoff for `Uint8Array` payloads on JSI/NAPI.
- **WASM `takeString` (and getBytes) saw a real cleanup too** (-15% to -18%
  at 1 MB) — the dedicated `writeStringIntoBuffer` path is doing real work.
- **WASM `takeBytes` is flat.** The Uint8Array → Rust copy for bytes on WASM
  was already a single linear-memory write; view-handoff doesn't apply there
  because WASM linear memory ≠ JS heap.
- **Async numbers track sync numbers** — the async harness adds ~14 µs (JSI)
  and ~18 µs (NAPI) of fixed per-call overhead on top of whatever the sync
  path costs, and that constant didn't move. So async-side wins ride on
  the sync improvements, e.g. WASM `takeStringArray 65536×16` async drops
  241 → 152 ms (-37%).
- **FFI micro-overhead** (`noop`, `addU32`, `Counter.increment`,
  `getLargeRecord`) was essentially untouched — these paths don't go through
  RustBuffer, which is exactly what the changes targeted, so flat is the
  expected outcome.

## Where the optimizations didn't help (yet)

- `getBytes` / `takeBytes` on JSI and NAPI (~12–24 ms/call at MB scale).
  Likely target for a follow-up: view-handoff path for `Uint8Array` lifts on
  Hermes and Node, mirroring the string lift work.
- `takeString` on JSI (steady ~3.6 ms/call at 1 MB) — string *lowering* into
  Rust on Hermes did not benefit from this round; the symmetric work for
  `writeStringIntoBuffer` doesn't exist on the JSI side yet.
- `string-array` lowering on JSI is unchanged (~59 ms/call at 65 K × 16 B);
  the same plumbing that produced the WASM and NAPI wins doesn't appear to be
  reaching the JSI lower path for arrays — worth checking that
  `converter.lower(value, alloc)` is wired through the Hermes codegen for
  `Vec<String>`.
