### PR TITLE
CI: Cross compile x86_64-apple-darwin on Apple Silicon

### DIFF
--- a/.github/workflows/napi-publish.yml
+++ b/.github/workflows/napi-publish.yml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macOS
+          # macOS (both targets cross-compile from Apple Silicon runners)
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
           - target: aarch64-apple-darwin
             runner: macos-latest
 


### PR DESCRIPTION
[Github retired macos-13 runners][announce] on [4 December 2025][changelog].

This PR cross compiles from Apple Silicon.

[announce]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
[changelog]: https://github.com/actions/runner-images/issues/13046