### PR TITLE
Rename uniffi-runtime/napi to @ubjs/node

### DIFF
--- a/.github/workflows/napi-publish.yml
+++ b/.github/workflows/napi-publish.yml
@@ -1,4 +1,4 @@
-name: Publish @uniffi-runtime/napi
+name: Publish @ubjs/node
 
 on:
   release:
@@ -46,6 +46,14 @@ jobs:
             runner: ubuntu-latest
             build-flags: --zig
           - target: aarch64-unknown-linux-musl
+            runner: ubuntu-latest
+            build-flags: --zig
+
+          # Additional architectures with official Node.js binaries
+          - target: armv7-unknown-linux-gnueabihf
+            runner: ubuntu-latest
+            build-flags: --zig
+          - target: s390x-unknown-linux-gnu
             runner: ubuntu-latest
             build-flags: --zig
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
@@ -8,7 +8,7 @@ use camino::Utf8PathBuf;
 
 /// How the generated player should locate the cdylib at load time.
 ///
-/// Maps 1:1 to the three resolveLibPath modes in `@uniffi-runtime/napi`.
+/// Maps 1:1 to the three resolveLibPath modes in `@ubjs/node`.
 #[derive(Clone, Debug)]
 pub enum LibResolution {
     /// Look for the conventional filename next to the binding.

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
@@ -7,7 +7,7 @@
 // @ts-nocheck
 {%- endif %}
 
-import lib from "@uniffi-runtime/napi";
+import lib from "@ubjs/node";
 const { UniffiNativeModule, FfiType, resolveLibPath } = lib;
 
 import {

--- a/crates/ubrn_fixture_testing/src/lib.rs
+++ b/crates/ubrn_fixture_testing/src/lib.rs
@@ -186,9 +186,7 @@ fn tsconfig_runtimes(flavor: Flavor, rel_root: &Utf8PathBuf) -> String {
         r#""uniffi-bindgen-react-native": ["{rel_root}/typescript/src/index"]"#
     )];
     if flavor == Flavor::Napi {
-        runtime_paths.push(format!(
-            r#""@uniffi-runtime/napi": ["{rel_root}/runtimes/napi/lib"]"#
-        ));
+        runtime_paths.push(format!(r#""@ubjs/node": ["{rel_root}/runtimes/napi/lib"]"#));
     }
     runtime_paths.join(",\n      ")
 }

--- a/runtimes/napi/index.js
+++ b/runtimes/napi/index.js
@@ -37,7 +37,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.android-arm64.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-android-arm64')
+            nativeBinding = require('@ubjs/node-android-arm64')
           }
         } catch (e) {
           loadError = e
@@ -49,7 +49,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.android-arm-eabi.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-android-arm-eabi')
+            nativeBinding = require('@ubjs/node-android-arm-eabi')
           }
         } catch (e) {
           loadError = e
@@ -69,7 +69,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.win32-x64-msvc.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-win32-x64-msvc')
+            nativeBinding = require('@ubjs/node-win32-x64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -83,7 +83,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.win32-ia32-msvc.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-win32-ia32-msvc')
+            nativeBinding = require('@ubjs/node-win32-ia32-msvc')
           }
         } catch (e) {
           loadError = e
@@ -97,7 +97,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.win32-arm64-msvc.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-win32-arm64-msvc')
+            nativeBinding = require('@ubjs/node-win32-arm64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -113,7 +113,7 @@ switch (platform) {
       if (localFileExisted) {
         nativeBinding = require('./uniffi-runtime-napi.darwin-universal.node')
       } else {
-        nativeBinding = require('@uniffi-runtime/napi-darwin-universal')
+        nativeBinding = require('@ubjs/node-darwin-universal')
       }
       break
     } catch {}
@@ -124,7 +124,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.darwin-x64.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-darwin-x64')
+            nativeBinding = require('@ubjs/node-darwin-x64')
           }
         } catch (e) {
           loadError = e
@@ -138,7 +138,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.darwin-arm64.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-darwin-arm64')
+            nativeBinding = require('@ubjs/node-darwin-arm64')
           }
         } catch (e) {
           loadError = e
@@ -157,7 +157,7 @@ switch (platform) {
       if (localFileExisted) {
         nativeBinding = require('./uniffi-runtime-napi.freebsd-x64.node')
       } else {
-        nativeBinding = require('@uniffi-runtime/napi-freebsd-x64')
+        nativeBinding = require('@ubjs/node-freebsd-x64')
       }
     } catch (e) {
       loadError = e
@@ -174,7 +174,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-x64-musl.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-x64-musl')
+              nativeBinding = require('@ubjs/node-linux-x64-musl')
             }
           } catch (e) {
             loadError = e
@@ -187,7 +187,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-x64-gnu.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-x64-gnu')
+              nativeBinding = require('@ubjs/node-linux-x64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -203,7 +203,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-arm64-musl.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-arm64-musl')
+              nativeBinding = require('@ubjs/node-linux-arm64-musl')
             }
           } catch (e) {
             loadError = e
@@ -216,7 +216,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-arm64-gnu.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-arm64-gnu')
+              nativeBinding = require('@ubjs/node-linux-arm64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -232,7 +232,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-arm-musleabihf.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-arm-musleabihf')
+              nativeBinding = require('@ubjs/node-linux-arm-musleabihf')
             }
           } catch (e) {
             loadError = e
@@ -245,7 +245,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-arm-gnueabihf.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-arm-gnueabihf')
+              nativeBinding = require('@ubjs/node-linux-arm-gnueabihf')
             }
           } catch (e) {
             loadError = e
@@ -261,7 +261,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-riscv64-musl.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-riscv64-musl')
+              nativeBinding = require('@ubjs/node-linux-riscv64-musl')
             }
           } catch (e) {
             loadError = e
@@ -274,7 +274,7 @@ switch (platform) {
             if (localFileExisted) {
               nativeBinding = require('./uniffi-runtime-napi.linux-riscv64-gnu.node')
             } else {
-              nativeBinding = require('@uniffi-runtime/napi-linux-riscv64-gnu')
+              nativeBinding = require('@ubjs/node-linux-riscv64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -289,7 +289,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./uniffi-runtime-napi.linux-s390x-gnu.node')
           } else {
-            nativeBinding = require('@uniffi-runtime/napi-linux-s390x-gnu')
+            nativeBinding = require('@ubjs/node-linux-s390x-gnu')
           }
         } catch (e) {
           loadError = e

--- a/runtimes/napi/package-lock.json
+++ b/runtimes/napi/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@uniffi-runtime/napi",
+  "name": "@ubjs/node",
   "version": "0.31.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@uniffi-runtime/napi",
+      "name": "@ubjs/node",
       "version": "0.31.0-2",
       "license": "MPL-2.0",
       "devDependencies": {

--- a/runtimes/napi/package.json
+++ b/runtimes/napi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uniffi-runtime/napi",
+  "name": "@ubjs/node",
   "version": "0.31.0-2",
   "description": "Call Rust libraries from Node.js without hand-written glue — the N-API runtime backend for uniffi-bindgen-react-native.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/runtimes/napi",
@@ -52,8 +52,8 @@
   ],
   "scripts": {
     "build:ts": "tsc -p typescript",
-    "build": "npm run build:ts && napi build --platform --release --js-package-name @uniffi-runtime/napi",
-    "build:debug": "npm run build:ts && napi build --platform --js-package-name @uniffi-runtime/napi",
+    "build": "npm run build:ts && napi build --platform --release --js-package-name @ubjs/node",
+    "build:debug": "npm run build:ts && napi build --platform --js-package-name @ubjs/node",
     "artifacts": "napi artifacts --dir artifacts",
     "create-npm-dirs": "napi create-npm-dir -t .",
     "assemble-root": "node ./scripts/assemble-root.mjs",


### PR DESCRIPTION
This PR is the culmination of a few decisions:

- registering the `@ubjs` organization in npmjs.
- renaming the `@uniffi-runtime/napi` to `@ubjs/node`.
- rotating the NPM_TOKEN in Github CI.

It's quite hard to test, so there may be churn on this branch before landing (or crash landing on main).