### PR TITLE
Expose require for library resolution in command line

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/mod.rs
@@ -8,8 +8,8 @@ mod builder;
 mod nodes;
 mod type_mapping;
 
-pub use nodes::LibResolution;
 pub(crate) use nodes::PlayerFfiModule;
+pub use nodes::{LibResolution, TripleStyle};
 
 /// Render a minimal player template for snapshot testing. Hidden from API docs.
 #[doc(hidden)]

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
@@ -15,8 +15,36 @@ pub enum LibResolution {
     Colocated,
     /// Bake an absolute path into the generated code.
     Absolute(Utf8PathBuf),
-    /// Resolve via `<base>-<triple>` platform packages.
-    Require(String),
+    /// Resolve via `<base><triple>` platform npm packages.
+    ///
+    /// `base` is the literal prefix joined to the triple — callers are
+    /// responsible for any separator (`-`, `/`, `_`); the runtime concatenates
+    /// without inserting one. `triple_style` selects between cargo-style and
+    /// node-style triple naming.
+    Require {
+        base: String,
+        triple_style: TripleStyle,
+    },
+}
+
+/// Which platform-triple naming convention the consuming npm packages use.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TripleStyle {
+    /// `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, … (cargo `--target`).
+    #[default]
+    Cargo,
+    /// `darwin-arm64`, `linux-x64-gnu`, … (napi-rs convention).
+    Node,
+}
+
+impl TripleStyle {
+    /// String tag passed through to the runtime in generated TS.
+    pub fn as_runtime_tag(self) -> &'static str {
+        match self {
+            TripleStyle::Cargo => "cargo",
+            TripleStyle::Node => "node",
+        }
+    }
 }
 
 /// IR for the player-style `{namespace}-ffi.ts`.

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
@@ -83,8 +83,9 @@ const getter: () => NativeModuleInterface = () => {
       {%- when LibResolution::Colocated %}
       {%- when LibResolution::Absolute with (path) %}
       override: "{{ path }}",
-      {%- when LibResolution::Require with (base) %}
+      {%- when LibResolution::Require { base, triple_style } %}
       npmPackageBase: "{{ base }}",
+      tripleStyle: "{{ triple_style.as_runtime_tag() }}",
       {%- endmatch %}
     });
     const mod_ = UniffiNativeModule.open(libPath);

--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -313,7 +313,7 @@ fn generate_ffi_from_pipeline(
             AbiFlavor::Napi => {
                 let lib_resolution = lib_resolution.clone().ok_or_else(|| {
                     anyhow::anyhow!(
-                        "napi codegen requires a LibResolution; pass --lib-colocated or --lib-absolute"
+                        "napi codegen requires a LibResolution; pass --lib-colocated, --lib-absolute, or --lib-package-base"
                     )
                 })?;
                 let crate_name = namespace.crate_name.clone();

--- a/crates/ubrn_bindgen/src/lib.rs
+++ b/crates/ubrn_bindgen/src/lib.rs
@@ -17,12 +17,12 @@ pub use self::{
 };
 
 pub mod ffi_module_player_lib_resolution {
-    pub use crate::bindings::gen_typescript::ffi_module_player::LibResolution;
+    pub use crate::bindings::gen_typescript::ffi_module_player::{LibResolution, TripleStyle};
 }
 
 #[doc(hidden)]
 pub mod __player_template_test {
     pub use crate::bindings::gen_typescript::ffi_module_player::{
-        render_minimal_for_test, LibResolution,
+        render_minimal_for_test, LibResolution, TripleStyle,
     };
 }

--- a/crates/ubrn_bindgen/tests/player_template_snapshots.rs
+++ b/crates/ubrn_bindgen/tests/player_template_snapshots.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use expect_test::expect;
-use ubrn_bindgen::__player_template_test::{render_minimal_for_test, LibResolution};
+use ubrn_bindgen::__player_template_test::{render_minimal_for_test, LibResolution, TripleStyle};
 
 fn extract_getter_block(rendered: &str) -> String {
     let start = rendered
@@ -61,9 +61,14 @@ fn template_absolute() {
 }
 
 #[test]
-fn template_require() {
-    let rendered =
-        render_minimal_for_test(LibResolution::Require("@scope/foo".to_string()), "my_crate");
+fn template_require_cargo() {
+    let rendered = render_minimal_for_test(
+        LibResolution::Require {
+            base: "@scope/foo-".to_string(),
+            triple_style: TripleStyle::Cargo,
+        },
+        "my_crate",
+    );
     expect![[r#"
         let _nativeModule: NativeModuleInterface | undefined;
         const getter: () => NativeModuleInterface = () => {
@@ -71,7 +76,8 @@ fn template_require() {
             const libPath = resolveLibPath({
               crateName: "my_crate",
               callerUrl: import.meta.url,
-              npmPackageBase: "@scope/foo",
+              npmPackageBase: "@scope/foo-",
+              tripleStyle: "cargo",
             });
             const mod_ = UniffiNativeModule.open(libPath);
             _nativeModule = mod_.register(DEFINITIONS) as unknown as NativeModuleInterface;
@@ -80,6 +86,51 @@ fn template_require() {
         };
         export default getter;"#]]
     .assert_eq(&extract_getter_block(&rendered));
+}
+
+#[test]
+fn template_require_node() {
+    let rendered = render_minimal_for_test(
+        LibResolution::Require {
+            base: "@scope/foo-".to_string(),
+            triple_style: TripleStyle::Node,
+        },
+        "my_crate",
+    );
+    expect![[r#"
+        let _nativeModule: NativeModuleInterface | undefined;
+        const getter: () => NativeModuleInterface = () => {
+          if (!_nativeModule) {
+            const libPath = resolveLibPath({
+              crateName: "my_crate",
+              callerUrl: import.meta.url,
+              npmPackageBase: "@scope/foo-",
+              tripleStyle: "node",
+            });
+            const mod_ = UniffiNativeModule.open(libPath);
+            _nativeModule = mod_.register(DEFINITIONS) as unknown as NativeModuleInterface;
+          }
+          return _nativeModule;
+        };
+        export default getter;"#]]
+    .assert_eq(&extract_getter_block(&rendered));
+}
+
+#[test]
+fn template_require_preserves_non_hyphen_separator() {
+    // Subpath layout: `@scope/foo/<triple>` — base ends with `/` so no `-` is added.
+    let rendered = render_minimal_for_test(
+        LibResolution::Require {
+            base: "@scope/foo/".to_string(),
+            triple_style: TripleStyle::Cargo,
+        },
+        "my_crate",
+    );
+    let block = extract_getter_block(&rendered);
+    assert!(
+        block.contains(r#"npmPackageBase: "@scope/foo/""#),
+        "expected subpath base verbatim, got:\n{block}"
+    );
 }
 
 #[test]

--- a/crates/ubrn_cli/src/napi/generate.rs
+++ b/crates/ubrn_cli/src/napi/generate.rs
@@ -8,7 +8,8 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::{ArgGroup, Args, Subcommand};
 use ubrn_bindgen::{
-    ffi_module_player_lib_resolution::LibResolution, AbiFlavor, OutputArgs, SourceArgs, SwitchArgs,
+    ffi_module_player_lib_resolution::{LibResolution, TripleStyle},
+    AbiFlavor, OutputArgs, SourceArgs, SwitchArgs,
 };
 
 #[derive(Args, Debug)]
@@ -46,7 +47,7 @@ impl Cmd {
 #[derive(Args, Debug)]
 #[command(group(
     ArgGroup::new("lib_resolution")
-        .args(["lib_colocated", "lib_absolute"])
+        .args(["lib_colocated", "lib_absolute", "lib_package_base"])
         .multiple(false)
         .required(true)
 ))]
@@ -71,10 +72,34 @@ pub(crate) struct BindingsArgs {
     /// Requires --library; the path must be absolute.
     #[clap(long = "lib-absolute", requires = "library_mode")]
     pub(crate) lib_absolute: bool,
+
+    /// Generated bindings resolve the cdylib via `<BASE><triple>` platform npm
+    /// packages (e.g. `@scope/foo-aarch64-apple-darwin`) using `require.resolve`.
+    /// If BASE ends with an alphanumeric character, a `-` is appended so the
+    /// joined name is `BASE-<triple>`; otherwise the trailing character is
+    /// used as the literal separator (`@scope/foo/<triple>` for `@scope/foo/`,
+    /// `@scope/foo_<triple>` for `@scope/foo_`, etc.). Requires --library so
+    /// the crate name can be derived.
+    #[clap(
+        long = "lib-package-base",
+        value_name = "BASE",
+        requires = "library_mode"
+    )]
+    pub(crate) lib_package_base: Option<String>,
+
+    /// With --lib-package-base, emit node-style triples (e.g. `darwin-arm64`,
+    /// `linux-x64-gnu`, `win32-x64-msvc`) instead of cargo-style triples.
+    /// Has no effect without --lib-package-base; rejected at runtime if used
+    /// with --lib-colocated or --lib-absolute.
+    #[clap(long = "lib-node-triple")]
+    pub(crate) lib_node_triple: bool,
 }
 
 impl BindingsArgs {
     fn resolve_lib_resolution(&self) -> Result<LibResolution> {
+        if self.lib_node_triple && self.lib_package_base.is_none() {
+            anyhow::bail!("--lib-node-triple requires --lib-package-base");
+        }
         if self.lib_colocated {
             return Ok(LibResolution::Colocated);
         }
@@ -95,8 +120,32 @@ impl BindingsArgs {
             let normalized = Utf8PathBuf::from(path.as_str().replace('\\', "/"));
             return Ok(LibResolution::Absolute(normalized));
         }
+        if let Some(base) = &self.lib_package_base {
+            if base.is_empty() {
+                anyhow::bail!("--lib-package-base requires a non-empty package base");
+            }
+            let base = normalize_package_base(base);
+            let triple_style = if self.lib_node_triple {
+                TripleStyle::Node
+            } else {
+                TripleStyle::Cargo
+            };
+            return Ok(LibResolution::Require { base, triple_style });
+        }
         // clap's ArgGroup(required = true) on lib_resolution rejects this case at parse.
         unreachable!("clap should have rejected: no --lib-* flag passed")
+    }
+}
+
+/// Normalize a `--lib-package-base` value into a literal prefix.
+///
+/// If the last character is alphanumeric (ASCII), append `-` so the runtime
+/// produces `BASE-<triple>`. Otherwise leave the value untouched and let the
+/// trailing punctuation (`/`, `_`, `-`, …) act as the separator.
+fn normalize_package_base(base: &str) -> String {
+    match base.chars().next_back() {
+        Some(c) if c.is_ascii_alphanumeric() => format!("{base}-"),
+        _ => base.to_string(),
     }
 }
 
@@ -197,11 +246,183 @@ mod tests {
     }
 
     #[test]
+    fn lib_package_base_with_library_parses_defaults_to_cargo() {
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo",
+            "--library",
+            "/tmp/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        let res = b.resolve_lib_resolution().expect("resolve");
+        match res {
+            LibResolution::Require { base, triple_style } => {
+                assert_eq!(base, "@scope/foo-");
+                assert_eq!(triple_style, TripleStyle::Cargo);
+            }
+            other => panic!("expected Require, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lib_package_base_with_node_triple() {
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo",
+            "--lib-node-triple",
+            "--library",
+            "/tmp/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        let res = b.resolve_lib_resolution().expect("resolve");
+        match res {
+            LibResolution::Require { base, triple_style } => {
+                assert_eq!(base, "@scope/foo-");
+                assert_eq!(triple_style, TripleStyle::Node);
+            }
+            other => panic!("expected Require, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lib_node_triple_without_package_base_errors() {
+        // --lib-node-triple without --lib-package-base parses (clap accepts) but
+        // resolve_lib_resolution rejects it explicitly.
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-colocated",
+            "--lib-node-triple",
+            "--library",
+            "/tmp/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        let err = b.resolve_lib_resolution().expect_err("should reject");
+        assert!(err.to_string().contains("--lib-node-triple"), "got: {err}");
+    }
+
+    #[test]
+    fn lib_package_base_preserves_explicit_separator() {
+        // Trailing `/` means the user wants `@scope/foo/<triple>` (subpath layout).
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo/",
+            "--library",
+            "/tmp/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        match b.resolve_lib_resolution().expect("resolve") {
+            LibResolution::Require { base, .. } => assert_eq!(base, "@scope/foo/"),
+            other => panic!("expected Require, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lib_package_base_preserves_trailing_hyphen() {
+        // Trailing `-` is already a separator; don't double it.
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo-",
+            "--library",
+            "/tmp/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        match b.resolve_lib_resolution().expect("resolve") {
+            LibResolution::Require { base, .. } => assert_eq!(base, "@scope/foo-"),
+            other => panic!("expected Require, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lib_package_base_without_library_errors() {
+        // --lib-package-base requires --library (via clap requires = "library_mode")
+        let r = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo",
+            "/tmp/foo.udl",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn lib_package_base_conflicts_with_colocated() {
+        let r = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo",
+            "--lib-colocated",
+            "--library",
+            "/tmp/foo.dylib",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn lib_package_base_conflicts_with_absolute() {
+        let r = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "@scope/foo",
+            "--lib-absolute",
+            "--library",
+            "/tmp/foo.dylib",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn lib_package_base_empty_errors() {
+        let cli = parse(&[
+            "--ts-dir",
+            "/tmp/ts",
+            "--lib-package-base",
+            "",
+            "--library",
+            "/tmp/foo.dylib",
+        ])
+        .expect("clap should accept");
+        let Cmd::Bindings(b) = cli.cmd;
+        assert!(b.resolve_lib_resolution().is_err());
+    }
+
+    #[test]
     fn lib_absolute_normalizes_backslashes_in_path() {
         // Cross-platform string-level normalization (we can't exercise
         // resolve_lib_resolution end-to-end on non-Windows hosts because
         // Utf8Path::is_absolute() rejects "C:\..." on Unix).
         let backslash_path = "C:\\Users\\foo\\lib.dll";
         assert_eq!(backslash_path.replace('\\', "/"), "C:/Users/foo/lib.dll");
+    }
+
+    #[test]
+    fn normalize_package_base_appends_hyphen_for_alphanumeric_end() {
+        assert_eq!(normalize_package_base("@scope/foo"), "@scope/foo-");
+        assert_eq!(normalize_package_base("foo"), "foo-");
+        assert_eq!(normalize_package_base("foo9"), "foo9-");
+    }
+
+    #[test]
+    fn normalize_package_base_preserves_existing_separator() {
+        assert_eq!(normalize_package_base("@scope/foo-"), "@scope/foo-");
+        assert_eq!(normalize_package_base("@scope/foo/"), "@scope/foo/");
+        assert_eq!(normalize_package_base("foo_"), "foo_");
+        assert_eq!(normalize_package_base("foo."), "foo.");
     }
 }

--- a/runtimes/napi/tests/resolve-lib.test.mjs
+++ b/runtimes/napi/tests/resolve-lib.test.mjs
@@ -45,73 +45,154 @@ function fakeProcess(platform, arch, { glibc = false } = {}) {
   };
 }
 
-test("triple: darwin arm64", () => {
+test("node triple: darwin arm64", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("darwin", "arm64")),
+    detectTripleForTesting(fakeProcess("darwin", "arm64"), "node"),
     "darwin-arm64",
   );
 });
 
-test("triple: darwin x64", () => {
+test("node triple: darwin x64", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("darwin", "x64")),
+    detectTripleForTesting(fakeProcess("darwin", "x64"), "node"),
     "darwin-x64",
   );
 });
 
-test("triple: linux x64 gnu", () => {
+test("node triple: linux x64 gnu", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("linux", "x64", { glibc: true })),
+    detectTripleForTesting(
+      fakeProcess("linux", "x64", { glibc: true }),
+      "node",
+    ),
     "linux-x64-gnu",
   );
 });
 
-test("triple: linux x64 musl", () => {
+test("node triple: linux x64 musl", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("linux", "x64", { glibc: false })),
+    detectTripleForTesting(
+      fakeProcess("linux", "x64", { glibc: false }),
+      "node",
+    ),
     "linux-x64-musl",
   );
 });
 
-test("triple: linux arm64 gnu", () => {
+test("node triple: linux arm64 gnu", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("linux", "arm64", { glibc: true })),
+    detectTripleForTesting(
+      fakeProcess("linux", "arm64", { glibc: true }),
+      "node",
+    ),
     "linux-arm64-gnu",
   );
 });
 
-test("triple: linux arm64 musl", () => {
+test("node triple: linux arm64 musl", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("linux", "arm64", { glibc: false })),
+    detectTripleForTesting(
+      fakeProcess("linux", "arm64", { glibc: false }),
+      "node",
+    ),
     "linux-arm64-musl",
   );
 });
 
-test("triple: win32 x64", () => {
+test("node triple: win32 x64", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("win32", "x64")),
+    detectTripleForTesting(fakeProcess("win32", "x64"), "node"),
     "win32-x64-msvc",
   );
 });
 
-test("triple: win32 arm64", () => {
+test("node triple: win32 arm64", () => {
   assert.equal(
-    detectTripleForTesting(fakeProcess("win32", "arm64")),
+    detectTripleForTesting(fakeProcess("win32", "arm64"), "node"),
     "win32-arm64-msvc",
   );
 });
 
-test("triple: unsupported platform throws", () => {
+test("node triple: unsupported platform throws", () => {
   assert.throws(
-    () => detectTripleForTesting(fakeProcess("freebsd", "x64")),
+    () => detectTripleForTesting(fakeProcess("freebsd", "x64"), "node"),
     /Unsupported platform.*freebsd.*x64/,
   );
 });
 
-test("triple: unsupported arch throws", () => {
+test("node triple: unsupported arch throws", () => {
   assert.throws(
-    () => detectTripleForTesting(fakeProcess("darwin", "ia32")),
+    () => detectTripleForTesting(fakeProcess("darwin", "ia32"), "node"),
     /Unsupported platform.*darwin.*ia32/,
+  );
+});
+
+test("cargo triple: darwin arm64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("darwin", "arm64"), "cargo"),
+    "aarch64-apple-darwin",
+  );
+});
+
+test("cargo triple: darwin x64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("darwin", "x64"), "cargo"),
+    "x86_64-apple-darwin",
+  );
+});
+
+test("cargo triple: linux x64 gnu", () => {
+  assert.equal(
+    detectTripleForTesting(
+      fakeProcess("linux", "x64", { glibc: true }),
+      "cargo",
+    ),
+    "x86_64-unknown-linux-gnu",
+  );
+});
+
+test("cargo triple: linux arm64 musl", () => {
+  assert.equal(
+    detectTripleForTesting(
+      fakeProcess("linux", "arm64", { glibc: false }),
+      "cargo",
+    ),
+    "aarch64-unknown-linux-musl",
+  );
+});
+
+test("cargo triple: win32 x64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("win32", "x64"), "cargo"),
+    "x86_64-pc-windows-msvc",
+  );
+});
+
+test("cargo triple: win32 arm64", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("win32", "arm64"), "cargo"),
+    "aarch64-pc-windows-msvc",
+  );
+});
+
+test("cargo triple: unsupported arch throws", () => {
+  assert.throws(
+    () => detectTripleForTesting(fakeProcess("darwin", "ia32"), "cargo"),
+    /Unsupported.*ia32/,
+  );
+});
+
+test("cargo triple: unsupported platform throws", () => {
+  assert.throws(
+    () => detectTripleForTesting(fakeProcess("freebsd", "x64"), "cargo"),
+    /Unsupported/,
+  );
+});
+
+test("detectTripleForTesting: defaults to cargo style when style omitted", () => {
+  assert.equal(
+    detectTripleForTesting(fakeProcess("darwin", "arm64")),
+    "aarch64-apple-darwin",
   );
 });
 
@@ -226,40 +307,117 @@ test("colocated: missing file throws", () => {
   }
 });
 
-function buildSyntheticPackage(rootDir, base, triple, libFile) {
-  const pkgDir = join(rootDir, "node_modules", `${base}-${triple}`);
+/** Build a synthetic npm package at `<rootDir>/node_modules/<pkgName>`. */
+function buildSyntheticPackageNamed(rootDir, pkgName, libFile) {
+  const pkgDir = join(rootDir, "node_modules", pkgName);
   mkdirSync(pkgDir, { recursive: true });
   writeFileSync(
     join(pkgDir, "package.json"),
-    JSON.stringify({ name: `${base}-${triple}`, version: "0.0.0" }),
+    JSON.stringify({ name: pkgName, version: "0.0.0" }),
   );
   if (libFile !== null) writeFileSync(join(pkgDir, libFile), "");
   return pkgDir;
 }
 
-test("npmPackageBase: package + binary present returns binary path", () => {
+function platformLibFile() {
+  const ext =
+    process.platform === "darwin"
+      ? "dylib"
+      : process.platform === "win32"
+        ? "dll"
+        : "so";
+  return process.platform === "win32" ? `foo.${ext}` : `libfoo.${ext}`;
+}
+
+test("npmPackageBase (cargo): base with trailing '-' joined to cargo triple", () => {
   const { dir, cleanup } = makeTempDir();
-  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  const restore = setDetectTripleForTesting(() => "aarch64-apple-darwin");
   try {
-    const ext =
-      process.platform === "darwin"
-        ? "dylib"
-        : process.platform === "win32"
-          ? "dll"
-          : "so";
-    const libFile =
-      process.platform === "win32" ? `foo.${ext}` : `libfoo.${ext}`;
-    const pkgDir = buildSyntheticPackage(
+    const libFile = platformLibFile();
+    const pkgDir = buildSyntheticPackageNamed(
       dir,
-      "@scope/foo",
-      "darwin-arm64",
+      "@scope/foo-aarch64-apple-darwin",
       libFile,
     );
     const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
     const got = resolveLibPath({
       crateName: "foo",
       callerUrl,
-      npmPackageBase: "@scope/foo",
+      npmPackageBase: "@scope/foo-",
+      tripleStyle: "cargo",
+    });
+    assert.equal(got, join(realpathSync(pkgDir), libFile));
+  } finally {
+    setDetectTripleForTesting(restore);
+    cleanup();
+  }
+});
+
+test("npmPackageBase (node): base with trailing '-' joined to node triple", () => {
+  const { dir, cleanup } = makeTempDir();
+  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  try {
+    const libFile = platformLibFile();
+    const pkgDir = buildSyntheticPackageNamed(
+      dir,
+      "@scope/foo-darwin-arm64",
+      libFile,
+    );
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    const got = resolveLibPath({
+      crateName: "foo",
+      callerUrl,
+      npmPackageBase: "@scope/foo-",
+      tripleStyle: "node",
+    });
+    assert.equal(got, join(realpathSync(pkgDir), libFile));
+  } finally {
+    setDetectTripleForTesting(restore);
+    cleanup();
+  }
+});
+
+test("npmPackageBase: defaults to cargo when tripleStyle omitted", () => {
+  const { dir, cleanup } = makeTempDir();
+  const restore = setDetectTripleForTesting((style) => {
+    assert.equal(style, "cargo", "expected default style 'cargo'");
+    return "aarch64-apple-darwin";
+  });
+  try {
+    const libFile = platformLibFile();
+    buildSyntheticPackageNamed(
+      dir,
+      "@scope/foo-aarch64-apple-darwin",
+      libFile,
+    );
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    resolveLibPath({
+      crateName: "foo",
+      callerUrl,
+      npmPackageBase: "@scope/foo-",
+    });
+  } finally {
+    setDetectTripleForTesting(restore);
+    cleanup();
+  }
+});
+
+test("npmPackageBase: trailing '/' uses subpath layout (no implicit '-')", () => {
+  const { dir, cleanup } = makeTempDir();
+  const restore = setDetectTripleForTesting(() => "aarch64-apple-darwin");
+  try {
+    const libFile = platformLibFile();
+    const pkgDir = buildSyntheticPackageNamed(
+      dir,
+      "@scope/foo/aarch64-apple-darwin",
+      libFile,
+    );
+    const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
+    const got = resolveLibPath({
+      crateName: "foo",
+      callerUrl,
+      npmPackageBase: "@scope/foo/",
+      tripleStyle: "cargo",
     });
     assert.equal(got, join(realpathSync(pkgDir), libFile));
   } finally {
@@ -270,21 +428,22 @@ test("npmPackageBase: package + binary present returns binary path", () => {
 
 test("npmPackageBase: package missing throws and names triple + base", () => {
   const { dir, cleanup } = makeTempDir();
-  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  const restore = setDetectTripleForTesting(() => "aarch64-apple-darwin");
   try {
     const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
     try {
       resolveLibPath({
         crateName: "foo",
         callerUrl,
-        npmPackageBase: "@scope/foo",
+        npmPackageBase: "@scope/foo-",
+        tripleStyle: "cargo",
       });
       assert.fail("expected throw");
     } catch (e) {
       assert.ok(e instanceof ResolveLibPathError);
       assert.equal(e.mode, "npmPackageBase");
-      assert.match(e.message, /@scope\/foo-darwin-arm64/);
-      assert.match(e.message, /darwin-arm64/);
+      assert.match(e.message, /@scope\/foo-aarch64-apple-darwin/);
+      assert.match(e.message, /aarch64-apple-darwin/);
     }
   } finally {
     setDetectTripleForTesting(restore);
@@ -294,15 +453,16 @@ test("npmPackageBase: package missing throws and names triple + base", () => {
 
 test("npmPackageBase: package present but binary missing throws malformed", () => {
   const { dir, cleanup } = makeTempDir();
-  const restore = setDetectTripleForTesting(() => "darwin-arm64");
+  const restore = setDetectTripleForTesting(() => "aarch64-apple-darwin");
   try {
-    buildSyntheticPackage(dir, "@scope/foo", "darwin-arm64", null);
+    buildSyntheticPackageNamed(dir, "@scope/foo-aarch64-apple-darwin", null);
     const callerUrl = pathToFileURL(join(dir, "caller.js")).toString();
     try {
       resolveLibPath({
         crateName: "foo",
         callerUrl,
-        npmPackageBase: "@scope/foo",
+        npmPackageBase: "@scope/foo-",
+        tripleStyle: "cargo",
       });
       assert.fail("expected throw");
     } catch (e) {

--- a/runtimes/napi/typescript/src/resolve-lib.ts
+++ b/runtimes/napi/typescript/src/resolve-lib.ts
@@ -15,7 +15,10 @@ interface ProcessLike {
   report?: { getReport(): { header?: { glibcVersionRuntime?: string } } };
 }
 
-function detectTriple(proc: ProcessLike): string {
+/** Which platform-triple naming convention to use. */
+export type TripleStyle = "cargo" | "node";
+
+function detectNodeTriple(proc: ProcessLike): string {
   const { platform, arch } = proc;
   if (platform === "darwin" && arch === "arm64") return "darwin-arm64";
   if (platform === "darwin" && arch === "x64") return "darwin-x64";
@@ -33,9 +36,44 @@ function detectTriple(proc: ProcessLike): string {
   );
 }
 
+function detectCargoTriple(proc: ProcessLike): string {
+  const { platform, arch } = proc;
+  // Cargo uses LLVM target triples: <arch>-<vendor>-<sys>[-<env>].
+  // Map Node's `process.arch` to the LLVM arch name.
+  const archMap: Record<string, string> = {
+    arm64: "aarch64",
+    x64: "x86_64",
+  };
+  const llvmArch = archMap[arch];
+  if (llvmArch === undefined) {
+    throw new Error(
+      `Unsupported platform/arch combination: ${platform}/${arch}. ` +
+        `Supported arches: arm64, x64.`,
+    );
+  }
+  if (platform === "darwin") return `${llvmArch}-apple-darwin`;
+  if (platform === "linux") {
+    const isGnu =
+      proc.report?.getReport()?.header?.glibcVersionRuntime !== undefined;
+    return `${llvmArch}-unknown-linux-${isGnu ? "gnu" : "musl"}`;
+  }
+  if (platform === "win32") return `${llvmArch}-pc-windows-msvc`;
+  throw new Error(
+    `Unsupported platform/arch combination: ${platform}/${arch}. ` +
+      `Supported: darwin, linux, win32.`,
+  );
+}
+
+function detectTriple(proc: ProcessLike, style: TripleStyle): string {
+  return style === "node" ? detectNodeTriple(proc) : detectCargoTriple(proc);
+}
+
 /** Test-only export. Do not use from production code. */
-export function detectTripleForTesting(proc: ProcessLike): string {
-  return detectTriple(proc);
+export function detectTripleForTesting(
+  proc: ProcessLike,
+  style: TripleStyle = "cargo",
+): string {
+  return detectTriple(proc, style);
 }
 
 export type ResolveMode = "override" | "npmPackageBase" | "colocated";
@@ -66,9 +104,13 @@ export type ResolveLibPathOptions = {
   crateName: string;
   callerUrl: string;
 } & (
-  | { override: string; npmPackageBase?: never }
-  | { npmPackageBase: string; override?: never }
-  | { override?: never; npmPackageBase?: never }
+  | { override: string; npmPackageBase?: never; tripleStyle?: never }
+  | { npmPackageBase: string; tripleStyle?: TripleStyle; override?: never }
+  | {
+      override?: never;
+      npmPackageBase?: never;
+      tripleStyle?: never;
+    }
 );
 
 function callerDir(callerUrl: string): string {
@@ -93,6 +135,7 @@ export function resolveLibPath(opts: ResolveLibPathOptions): string {
       opts.crateName,
       opts.callerUrl,
       opts.npmPackageBase,
+      opts.tripleStyle ?? "cargo",
     );
   }
   return resolveColocated(opts.crateName, opts.callerUrl);
@@ -134,11 +177,13 @@ function resolveOverride(crateName: string, path: string): string {
   return path;
 }
 
-let _detectTripleImpl: () => string = () =>
-  detectTriple(process as ProcessLike);
+let _detectTripleImpl: (style: TripleStyle) => string = (style) =>
+  detectTriple(process as ProcessLike, style);
 
 /** Test-only seam to override triple detection. Returns the previous impl. */
-export function setDetectTripleForTesting(fn: () => string): () => string {
+export function setDetectTripleForTesting(
+  fn: (style: TripleStyle) => string,
+): (style: TripleStyle) => string {
   const prev = _detectTripleImpl;
   _detectTripleImpl = fn;
   return prev;
@@ -148,9 +193,12 @@ function resolveNpmPackage(
   crateName: string,
   callerUrl: string,
   npmPackageBase: string,
+  tripleStyle: TripleStyle,
 ): string {
-  const triple = _detectTripleImpl();
-  const pkgName = `${npmPackageBase}-${triple}`;
+  const triple = _detectTripleImpl(tripleStyle);
+  // Caller-supplied base carries its own separator (a trailing `-`, `/`, etc.);
+  // we concatenate literally so subpath layouts (`@scope/foo/<triple>`) work.
+  const pkgName = `${npmPackageBase}${triple}`;
   const require_ = createRequire(callerUrl);
 
   let pkgJsonPath: string;


### PR DESCRIPTION
Before this PR, the code generation could use `require` to resolve the binary library, but did not expose it to the bindgen command line.

This PR exposes it. 

It also adds the ability to customize how the triple iis exposed, either rust style or node style.