### PR TITLE
Fix wasm template optimization setting for release profile

### DIFF
--- a/crates/ubrn_cli/templates/wasm/Cargo.toml.txt
+++ b/crates/ubrn_cli/templates/wasm/Cargo.toml.txt
@@ -35,7 +35,7 @@ wasm-bindgen = "*"
 {% if !config.project.wasm.workspace -%}
 [profile.release]
 # Tell `rustc` to optimize for speed
-opt-level = "3"
+opt-level = 3
 
 [workspace]
 {%- endif %}


### PR DESCRIPTION
Updates the generated wasm template to use the correct numeric value for `opt-level` in the release profile.

Before
```toml
[profile.release]
# Tell `rustc` to optimize for speed
opt-level = "3"
```
After
```toml
[profile.release]
# Tell `rustc` to optimize for speed
opt-level = 3
```

According to the Cargo profile documentation, opt-level accepts integer values (0-3) or specific string values such as "s" and "z".

Reference:
https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level

