### PR TITLE
Export package.json subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "types": "./typescript/dist/esm/index.d.ts",
       "import": "./typescript/dist/esm/index.js",
       "require": "./typescript/dist/cjs/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "ubrn": "./bin/cli.cjs",


### PR DESCRIPTION
## Summary

Export `./package.json` from the root package `exports` map.

## Why

The generated Android CMake resolves the package root with `require.resolve('uniffi-bindgen-react-native/package.json')`. When Node enforces package `exports`, that subpath currently fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` because only `.` is exported.

## Validation

Ran:

```sh
node -p "require.resolve('uniffi-bindgen-react-native/package.json')"
git diff --check
```

The resolver now returns the package `package.json` file successfully.

Fixes #404.