### PR TITLE
Add `forceAsync` to `uniffi.toml`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-force-async"
+version = "0.1.0"
+dependencies = [
+ "ubrn_fixture_testing",
+ "ubrn_macros",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-force-async-list"
+version = "0.1.0"
+dependencies = [
+ "ubrn_fixture_testing",
+ "ubrn_macros",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
 dependencies = [

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -693,6 +693,7 @@ pub(super) fn build_object(
         supports_finalization_registry,
         has_callback_interface,
         strict_object_types,
+        force_async,
     }
 }
 
@@ -811,6 +812,7 @@ pub(super) fn build_callback_interface(
     let ts_name = rewrite_js_builtins(&cbi.name.to_upper_camel_case());
     // Callback interfaces use `FfiConverterType{Name}` (not `FfiConverter{canonical_name}`).
     let ffi_converter_name = format!("FfiConverterType{ts_name}");
+    let force_async = config.force_async.is_forced(&cbi.name);
 
     let docstring = cbi.docstring.as_deref().map(format_docstring);
 
@@ -836,6 +838,7 @@ pub(super) fn build_callback_interface(
         methods,
         vtable,
         has_async_methods,
+        force_async,
     }
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -306,21 +306,24 @@ pub(super) fn build_enum(config: &Config, en: &general::Enum, flavor: &AbiFlavor
         .map(|variant| build_variant(config, variant))
         .collect();
 
+    let force_async = config.force_async.is_forced(&en.name);
+
     let uniffi_traits = build_uniffi_traits_value(
         config,
         &en.uniffi_trait_methods,
         &ffi_converter_name,
         flavor,
+        force_async,
     );
     let constructors = en
         .constructors
         .iter()
-        .map(|c| build_constructor_callable(config, c, flavor))
+        .map(|c| build_constructor_callable(config, c, flavor, force_async))
         .collect();
     let methods = en
         .methods
         .iter()
-        .map(|m| build_value_method_callable(config, m, &ffi_converter_name, flavor))
+        .map(|m| build_value_method_callable(config, m, &ffi_converter_name, flavor, force_async))
         .collect();
 
     TsEnum {
@@ -352,21 +355,24 @@ pub(super) fn build_record(config: &Config, rec: &general::Record, flavor: &AbiF
     let has_create_constructor = rec.constructors.iter().any(|c| c.callable.name == "create");
     let has_new_constructor = rec.constructors.iter().any(|c| c.callable.name == "new");
 
+    let force_async = config.force_async.is_forced(&rec.name);
+
     let uniffi_traits = build_uniffi_traits_value(
         config,
         &rec.uniffi_trait_methods,
         &ffi_converter_name,
         flavor,
+        force_async,
     );
     let constructors = rec
         .constructors
         .iter()
-        .map(|c| build_constructor_callable(config, c, flavor))
+        .map(|c| build_constructor_callable(config, c, flavor, force_async))
         .collect();
     let methods = rec
         .methods
         .iter()
-        .map(|m| build_value_method_callable(config, m, &ffi_converter_name, flavor))
+        .map(|m| build_value_method_callable(config, m, &ffi_converter_name, flavor, force_async))
         .collect();
 
     TsRecord {
@@ -427,6 +433,7 @@ pub(super) fn build_callable(
     docstring: &Option<String>,
     receiver: Option<TsReceiver>,
     flavor: &AbiFlavor,
+    force_async: bool,
 ) -> TsCallable {
     let name = fn_name(&callable.name);
     let arguments: Vec<TsArg> = callable
@@ -466,6 +473,7 @@ pub(super) fn build_callable(
         ffi_name: callable_ffi_name,
         ffi_async,
         receiver,
+        force_async,
     }
 }
 
@@ -474,6 +482,7 @@ pub(super) fn build_method_callable(
     method: &general::Method,
     _ffi_clone_name: &str,
     flavor: &AbiFlavor,
+    force_async: bool,
 ) -> TsCallable {
     let receiver = Some(TsReceiver::Pointer);
     build_callable(
@@ -482,6 +491,7 @@ pub(super) fn build_method_callable(
         &method.docstring,
         receiver,
         flavor,
+        force_async,
     )
 }
 
@@ -489,8 +499,16 @@ pub(super) fn build_constructor_callable(
     config: &Config,
     cons: &general::Constructor,
     flavor: &AbiFlavor,
+    force_async: bool,
 ) -> TsCallable {
-    build_callable(config, &cons.callable, &cons.docstring, None, flavor)
+    build_callable(
+        config,
+        &cons.callable,
+        &cons.docstring,
+        None,
+        flavor,
+        force_async,
+    )
 }
 
 fn collect_uniffi_traits(
@@ -534,9 +552,10 @@ pub(super) fn build_uniffi_traits(
     tm: &general::UniffiTraitMethods,
     ffi_clone_name: &str,
     flavor: &AbiFlavor,
+    force_async: bool,
 ) -> Vec<TsUniffiTrait> {
     collect_uniffi_traits(tm, |m| {
-        build_method_callable(config, m, ffi_clone_name, flavor)
+        build_method_callable(config, m, ffi_clone_name, flavor, force_async)
     })
 }
 
@@ -545,6 +564,7 @@ pub(super) fn build_value_method_callable(
     method: &general::Method,
     ffi_converter: &str,
     flavor: &AbiFlavor,
+    force_async: bool,
 ) -> TsCallable {
     let receiver = Some(TsReceiver::Value {
         ffi_converter: ffi_converter.to_string(),
@@ -555,6 +575,7 @@ pub(super) fn build_value_method_callable(
         &method.docstring,
         receiver,
         flavor,
+        force_async,
     )
 }
 
@@ -563,9 +584,10 @@ pub(super) fn build_uniffi_traits_value(
     tm: &general::UniffiTraitMethods,
     ffi_converter: &str,
     flavor: &AbiFlavor,
+    force_async: bool,
 ) -> Vec<TsUniffiTrait> {
     collect_uniffi_traits(tm, |m| {
-        build_value_method_callable(config, m, ffi_converter, flavor)
+        build_value_method_callable(config, m, ffi_converter, flavor, force_async)
     })
 }
 
@@ -607,11 +629,13 @@ pub(super) fn build_object(
         ),
     );
 
+    let force_async = config.force_async.is_forced(&interface.name);
+
     let (primary_constructor, alternate_constructors) = {
         let mut primary = None;
         let mut alternates = Vec::new();
         for cons in &interface.constructors {
-            let built = build_constructor_callable(config, cons, flavor);
+            let built = build_constructor_callable(config, cons, flavor, force_async);
             if matches!(
                 cons.callable.kind,
                 general::CallableKind::Constructor { primary: true, .. }
@@ -627,11 +651,16 @@ pub(super) fn build_object(
     let methods: Vec<TsMethod> = interface
         .methods
         .iter()
-        .map(|m| build_method_callable(config, m, &ffi_clone, flavor))
+        .map(|m| build_method_callable(config, m, &ffi_clone, flavor, force_async))
         .collect();
 
-    let uniffi_traits =
-        build_uniffi_traits(config, &interface.uniffi_trait_methods, &ffi_clone, flavor);
+    let uniffi_traits = build_uniffi_traits(
+        config,
+        &interface.uniffi_trait_methods,
+        &ffi_clone,
+        flavor,
+        force_async,
+    );
 
     let supports_finalization_registry = flavor.supports_finalization_registry();
 
@@ -692,7 +721,14 @@ fn build_vtable_field(
     flavor: &AbiFlavor,
 ) -> TsVtableField {
     let name = vm.callable.name.clone();
-    let method = Some(build_callable(config, &vm.callable, &None, None, flavor));
+    let method = Some(build_callable(
+        config,
+        &vm.callable,
+        &None,
+        None,
+        flavor,
+        false,
+    ));
 
     let general::FfiType::Function(ref ffi_fn_name) = vm.ffi_type.ty else {
         return TsVtableField {
@@ -782,7 +818,7 @@ pub(super) fn build_callback_interface(
     let methods: Vec<TsCallable> = cbi
         .methods
         .iter()
-        .map(|m| build_callable(config, &m.callable, &m.docstring, None, flavor))
+        .map(|m| build_callable(config, &m.callable, &m.docstring, None, flavor, false))
         .collect();
 
     let has_async_methods = cbi.methods.iter().any(|m| m.callable.is_async());
@@ -811,7 +847,10 @@ pub(super) fn build_functions(
     namespace
         .functions
         .iter()
-        .map(|f| build_callable(config, &f.callable, &f.docstring, None, flavor))
+        .map(|f| {
+            let force_async = config.force_async.is_forced(&f.callable.name);
+            build_callable(config, &f.callable, &f.docstring, None, flavor, force_async)
+        })
         .collect()
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -458,7 +458,9 @@ impl TsApiModule {
                 || self.type_definitions.iter().any(|td| match td {
                     TsTypeDefinition::Object(o) => {
                         o.methods.iter().any(|m| m.is_ffi_async())
-                            || o.primary_constructor.as_ref().is_some_and(|c| c.is_ffi_async())
+                            || o.primary_constructor
+                                .as_ref()
+                                .is_some_and(|c| c.is_ffi_async())
                             || o.alternate_constructors.iter().any(|c| c.is_ffi_async())
                     }
                     TsTypeDefinition::CallbackInterface(cbi) => cbi.has_async_methods,
@@ -488,7 +490,7 @@ impl TsApiModule {
         namespace: &general::Namespace,
         flavor: AbiFlavor,
         ffi_exported_definitions: Vec<ffi_module::FfiExportedName>,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let module_name = namespace.name.clone();
         let namespace_docstring = namespace.docstring.as_deref().map(format_docstring);
         let supports_rust_backtrace = flavor.supports_rust_backtrace();
@@ -568,6 +570,148 @@ impl TsApiModule {
 
         module.exported_converters = acc.exported_converters;
 
-        module
+        validate_force_async(&module.type_definitions)?;
+
+        Ok(module)
+    }
+}
+
+/// Reject `forceAsync` on a callback interface or `WithForeign` trait interface
+/// that has any synchronous method.
+///
+/// Rust calls into these types through a vtable, and each slot's sync/async ABI
+/// is fixed by the Rust method. On an ordinary outbound call, `forceAsync` only
+/// has to widen the return value into an already-resolved promise. Here it would
+/// instead hand a promise to a synchronous vtable slot, which has no way to
+/// await it. So every method must be async in Rust already.
+pub(super) fn validate_force_async(type_definitions: &[TsTypeDefinition]) -> anyhow::Result<()> {
+    let mut blocks = Vec::new();
+    for td in type_definitions {
+        match td {
+            TsTypeDefinition::CallbackInterface(cbi) if cbi.force_async => {
+                if let Some(block) =
+                    force_async_error_block("callback interface", &cbi.ts_name, &cbi.methods)
+                {
+                    blocks.push(block);
+                }
+            }
+            TsTypeDefinition::Object(o) if o.force_async && o.has_callback_interface => {
+                if let Some(block) =
+                    force_async_error_block("trait interface", &o.ts_name, &o.methods)
+                {
+                    blocks.push(block);
+                }
+            }
+            _ => {}
+        }
+    }
+    if blocks.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(blocks.join("\n\n"))
+    }
+}
+
+/// `Some(error)` when `methods` has any non-async member; `None` when all async.
+fn force_async_error_block(kind: &str, name: &str, methods: &[TsCallable]) -> Option<String> {
+    let sync: Vec<&str> = methods
+        .iter()
+        .filter(|m| !m.is_ffi_async())
+        .map(|m| m.name.as_str())
+        .collect();
+    if sync.is_empty() {
+        return None;
+    }
+    let list = sync
+        .iter()
+        .map(|m| format!("  - {m}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(format!(
+        "forceAsync targets {kind} `{name}`, but these methods are synchronous:\n\
+         {list}\n\
+         A {kind} can only be forced async if every method is already async in Rust.\n\
+         Mark them `async fn` in the Rust trait, or remove `{name}` from forceAsync."
+    ))
+}
+
+#[cfg(test)]
+mod force_async_validation_tests {
+    use super::*;
+
+    fn callable(name: &str, ffi_async: bool) -> TsCallable {
+        TsCallable {
+            name: name.into(),
+            docstring: None,
+            arguments: vec![],
+            return_type: None,
+            throws: None,
+            ffi_name: format!("ffi_{name}"),
+            ffi_async: ffi_async.then(|| TsAsyncFfi {
+                poll: "poll".into(),
+                complete: "complete".into(),
+                free: "free".into(),
+                cancel: "cancel".into(),
+            }),
+            receiver: None,
+            force_async: false,
+        }
+    }
+
+    fn callback_interface(
+        name: &str,
+        force_async: bool,
+        methods: Vec<TsCallable>,
+    ) -> TsTypeDefinition {
+        TsTypeDefinition::CallbackInterface(TsCallbackInterface {
+            protocol_name: name.into(),
+            ts_name: name.into(),
+            ffi_converter_name: format!("FfiConverterType{name}"),
+            trait_impl: format!("uniffiCallbackInterface{name}"),
+            docstring: None,
+            has_async_methods: methods.iter().any(|m| m.is_ffi_async()),
+            methods,
+            vtable: TsVtable {
+                ffi_init_fn: String::new(),
+                fields: vec![],
+            },
+            force_async,
+        })
+    }
+
+    #[test]
+    fn targeted_sync_callback_interface_is_an_error() {
+        let defs = vec![callback_interface(
+            "Logger",
+            true,
+            vec![callable("log", false), callable("flush", false)],
+        )];
+        let err = validate_force_async(&defs).unwrap_err().to_string();
+        assert!(
+            err.contains("callback interface `Logger`"),
+            "message: {err}"
+        );
+        assert!(err.contains("- log"), "message: {err}");
+        assert!(err.contains("- flush"), "message: {err}");
+    }
+
+    #[test]
+    fn untargeted_sync_callback_interface_is_ok() {
+        let defs = vec![callback_interface(
+            "Logger",
+            false,
+            vec![callable("log", false)],
+        )];
+        assert!(validate_force_async(&defs).is_ok());
+    }
+
+    #[test]
+    fn targeted_all_async_callback_interface_is_ok() {
+        let defs = vec![callback_interface(
+            "Logger",
+            true,
+            vec![callable("log", true), callable("flush", true)],
+        )];
+        assert!(validate_force_async(&defs).is_ok());
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -317,7 +317,7 @@ impl ImportAccumulator {
 
         for field in &vtable.fields {
             if let Some(ref method) = field.method {
-                if method.is_async() {
+                if method.is_ffi_async() {
                     if method.is_throwing() {
                         self.add_infra_value("uniffiTraitInterfaceCallAsyncWithError");
                     } else {
@@ -333,7 +333,7 @@ impl ImportAccumulator {
     }
 
     fn collect_callable(&mut self, callable: &TsCallable) {
-        if callable.is_async() {
+        if callable.is_ffi_async() {
             self.add_infra_value("uniffiRustCallAsync");
         }
     }
@@ -454,12 +454,12 @@ impl TsApiModule {
         }
 
         if self.is_verbose {
-            let has_async = self.functions.iter().any(|f| f.is_async())
+            let has_async = self.functions.iter().any(|f| f.is_ffi_async())
                 || self.type_definitions.iter().any(|td| match td {
                     TsTypeDefinition::Object(o) => {
-                        o.methods.iter().any(|m| m.is_async())
-                            || o.primary_constructor.as_ref().is_some_and(|c| c.is_async())
-                            || o.alternate_constructors.iter().any(|c| c.is_async())
+                        o.methods.iter().any(|m| m.is_ffi_async())
+                            || o.primary_constructor.as_ref().is_some_and(|c| c.is_ffi_async())
+                            || o.alternate_constructors.iter().any(|c| c.is_ffi_async())
                     }
                     TsTypeDefinition::CallbackInterface(cbi) => cbi.has_async_methods,
                     _ => false,

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
@@ -137,11 +137,23 @@ pub(crate) struct TsCallable {
     pub ffi_name: String,
     pub ffi_async: Option<TsAsyncFfi>,
     pub receiver: Option<TsReceiver>,
+    /// `forceAsync` names this callable's owning type or function: give it an
+    /// async signature over a synchronous FFI body.
+    pub force_async: bool,
 }
 
 impl TsCallable {
-    pub fn is_async(&self) -> bool {
+    /// True when the Rust side is async, so the call needs the future
+    /// poll/complete/free plumbing, its imports, and the async vtable branch.
+    pub fn is_ffi_async(&self) -> bool {
         self.ffi_async.is_some()
+    }
+
+    /// True when the TypeScript signature is async: the `async` keyword, a
+    /// `Promise<T>` return, a `static async` constructor. Async Rust renders
+    /// async, and so does `forceAsync` — over an unchanged synchronous body.
+    pub fn renders_async(&self) -> bool {
+        self.ffi_async.is_some() || self.force_async
     }
     pub fn is_throwing(&self) -> bool {
         self.throws.is_some()

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
@@ -239,6 +239,9 @@ pub(crate) struct TsObject {
     pub supports_finalization_registry: bool,
     pub has_callback_interface: bool,
     pub strict_object_types: bool,
+    /// `forceAsync` names this type. Kept so validation can reject a
+    /// `WithForeign` trait interface holding any synchronous method.
+    pub force_async: bool,
 }
 
 impl TsObject {
@@ -297,6 +300,9 @@ pub(crate) struct TsCallbackInterface {
     pub methods: Vec<TsCallable>,
     pub vtable: TsVtable,
     pub has_async_methods: bool,
+    /// `forceAsync` names this callback interface. Read by validation only:
+    /// a callback interface's surface is never transformed.
+    pub force_async: bool,
 }
 
 pub(crate) struct InitializationIR {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/config.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/config.rs
@@ -5,6 +5,7 @@
  */
 use std::collections::HashMap;
 
+use heck::ToUpperCamelCase;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -26,6 +27,12 @@ pub(crate) struct TsConfig {
     /// When `true`, emit byte arrays (`Vec<u8>`) as `Uint8Array` instead of `ArrayBuffer`.
     #[serde(default)]
     pub(crate) strict_byte_arrays: bool,
+    /// Render the TypeScript surface of the named types/functions (or all,
+    /// when `true`) as `async`/`Promise<T>` without changing the underlying
+    /// synchronous FFI calls. A migration aid toward off-the-main-thread
+    /// delivery. See docs/superpowers/specs/2026-07-10-force-async-config-design.md.
+    #[serde(default)]
+    pub(crate) force_async: ForceAsync,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -55,6 +62,39 @@ impl TsConfig {
     }
 }
 
+/// `forceAsync` config value: a bool (all / nothing) or an explicit name list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum ForceAsync {
+    /// `forceAsync = true | false`
+    All(bool),
+    /// `forceAsync = ["ProcTraitMethods", "makeFlatTraitEnum"]`
+    Named(Vec<String>),
+}
+
+impl Default for ForceAsync {
+    fn default() -> Self {
+        Self::All(false)
+    }
+}
+
+impl ForceAsync {
+    /// Whether the type or top-level function named `name` should render async.
+    ///
+    /// Both sides are normalized to UpperCamelCase before comparing, so a
+    /// config entry of `traitRecord` also matches `TraitRecord` and
+    /// `trait_record`.
+    pub(crate) fn is_forced(&self, name: &str) -> bool {
+        match self {
+            ForceAsync::All(b) => *b,
+            ForceAsync::Named(names) => {
+                let target = name.to_upper_camel_case();
+                names.iter().any(|n| n.to_upper_camel_case() == target)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub(crate) struct CustomTypeConfig {
@@ -73,5 +113,51 @@ impl CustomTypeConfig {
     }
     pub(crate) fn lower(&self, variable: &str) -> String {
         self.from_custom.replace("{}", variable)
+    }
+}
+
+#[cfg(test)]
+mod force_async_tests {
+    use super::*;
+
+    #[test]
+    fn all_true_forces_everything() {
+        let fa = ForceAsync::All(true);
+        assert!(fa.is_forced("AnyType"));
+        assert!(fa.is_forced("any_function"));
+    }
+
+    #[test]
+    fn default_is_all_false() {
+        let fa = ForceAsync::default();
+        assert!(!fa.is_forced("AnyType"));
+        let cfg = TsConfig::default();
+        assert!(!cfg.force_async.is_forced("AnyType"));
+    }
+
+    #[test]
+    fn named_matches_across_case_conventions() {
+        let fa = ForceAsync::Named(vec!["makeFlatTraitEnum".into(), "TraitRecord".into()]);
+        // Candidates arrive in any spelling; all normalize to UpperCamelCase.
+        assert!(fa.is_forced("make_flat_trait_enum")); // snake_case Rust fn
+        assert!(fa.is_forced("makeFlatTraitEnum")); // lowerCamel TS name
+        assert!(fa.is_forced("MakeFlatTraitEnum")); // UpperCamel
+        assert!(fa.is_forced("TraitRecord"));
+        assert!(fa.is_forced("trait_record"));
+        assert!(!fa.is_forced("SomethingElse"));
+    }
+
+    #[test]
+    fn deserializes_bool_and_list_forms() {
+        let as_bool: TsConfig = toml::from_str("forceAsync = true").unwrap();
+        assert!(as_bool.force_async.is_forced("Whatever"));
+
+        let as_list: TsConfig =
+            toml::from_str(r#"forceAsync = ["ProcTraitMethods", "makeFlatTraitEnum"]"#).unwrap();
+        assert!(as_list.force_async.is_forced("ProcTraitMethods"));
+        assert!(!as_list.force_async.is_forced("TraitRecord"));
+
+        let default: TsConfig = toml::from_str("").unwrap();
+        assert!(!default.force_async.is_forced("Whatever"));
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/config.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/config.rs
@@ -27,10 +27,10 @@ pub(crate) struct TsConfig {
     /// When `true`, emit byte arrays (`Vec<u8>`) as `Uint8Array` instead of `ArrayBuffer`.
     #[serde(default)]
     pub(crate) strict_byte_arrays: bool,
-    /// Render the TypeScript surface of the named types/functions (or all,
-    /// when `true`) as `async`/`Promise<T>` without changing the underlying
-    /// synchronous FFI calls. A migration aid toward off-the-main-thread
-    /// delivery. See docs/superpowers/specs/2026-07-10-force-async-config-design.md.
+    /// Give the named types and functions — or everything, when `true` — an
+    /// `async`/`Promise<T>` surface. The FFI calls underneath stay
+    /// synchronous: this is a migration aid toward moving them off the main
+    /// thread.
     #[serde(default)]
     pub(crate) force_async: ForceAsync,
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -27,7 +27,7 @@ console.debug(`-- {{ ffi_name }}`);
 
 {#- Return type rendering. -#}
 {%- macro return_type(callable) %}
-    {%- if callable.is_async() %}Promise<{% call raw_return_type(callable) %}>
+    {%- if callable.renders_async() %}Promise<{% call raw_return_type(callable) %}>
     {%- else %}
     {%- call raw_return_type(callable) %}
     {%- endif %}
@@ -52,7 +52,7 @@ console.debug(`-- {{ ffi_name }}`);
         {%- if let Some(dv) = arg.default_value %} = {{ dv }}{% endif %}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
-    {%- if callable.is_async() %}
+    {%- if callable.is_ffi_async() %}
     {%-   if !callable.arguments.is_empty() %}, {% endif -%}
     asyncOpts_?: { signal: AbortSignal }
     {%- endif %}
@@ -64,7 +64,7 @@ console.debug(`-- {{ ffi_name }}`);
         {{ arg.name }}: {{ arg.ts_type -}}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
-    {%- if callable.is_async() %}
+    {%- if callable.is_ffi_async() %}
     {%-   if !callable.arguments.is_empty() %}, {% endif -%}
     asyncOpts_?: { signal: AbortSignal }
     {%- endif %}
@@ -175,7 +175,7 @@ console.debug(`-- {{ ffi_name }}`);
 
 {#- Call body for method (pointer receiver): sync or async. -#}
 {%- macro call_body_method(callable, obj_factory) %}
-{%- if callable.is_async() %}
+{%- if callable.is_ffi_async() %}
 {%-   call call_body_async(callable, obj_factory) %}
 {%- else %}
 {%-     match callable.return_type -%}
@@ -199,7 +199,7 @@ console.debug(`-- {{ ffi_name }}`);
 
 {#- Call body for function (no receiver): sync or async. -#}
 {%- macro call_body_function(callable) %}
-{%- if callable.is_async() %}
+{%- if callable.is_ffi_async() %}
 {%-   call call_body_async(callable, "unreachable") %}
 {%- else %}
 {%-     match callable.return_type -%}
@@ -278,7 +278,7 @@ console.debug(`-- {{ ffi_name }}`);
             {% endmatch %}
         )
 {%- when None %}
-{#- unreachable: caller guards with is_async() -#}
+{#- unreachable: caller guards with is_ffi_async() -#}
 {%- endmatch %}
 {%- endmacro %}
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallbackInterfaceImpl.ts
@@ -15,24 +15,24 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
             {%- endfor -%}
         ) => {
             const uniffiMakeCall = {# space #}
-            {%- if meth.is_async() %}
+            {%- if meth.is_ffi_async() %}
             async (signal: AbortSignal)
             {%- else %}
             ()
             {%- endif %}
             : {% call cb::return_type(meth) %} => {
                 const jsCallback = {{ ffi_converter_name }}.lift(uniffiHandle);
-                return {% if meth.is_async() %}await {% endif %}jsCallback.{{ meth.name }}(
+                return {% if meth.is_ffi_async() %}await {% endif %}jsCallback.{{ meth.name }}(
                     {%- for arg in meth.arguments %}
                     {{ arg.ffi_converter }}.lift({{ arg.name }}){% if !loop.last %}, {% endif %}
                     {%- endfor %}
-                    {%- if meth.is_async() -%}
+                    {%- if meth.is_ffi_async() -%}
                     {%-   if !meth.arguments.is_empty() %}, {% endif -%}
                     { signal }
                     {%- endif %}
                 )
             };
-            {%- if !meth.is_async() %}
+            {%- if !meth.is_ffi_async() %}
             {#- // Synchronous callback method #}
             {%- match meth.return_type %}
             {%- when Some(t) %}
@@ -69,7 +69,7 @@ const {{ trait_impl }}: { vtable: any; register: () => void; } = {
             );
             {%- endmatch %}
             return uniffiResult;
-            {%- else %} {#- // is_async = true #}
+            {%- else %} {#- // is_ffi_async = true #}
             {#- // Asynchronous callback method #}
             const uniffiHandleSuccess = (returnValue: {% call cb::raw_return_type(meth) %}) => {
                 uniffiFutureCallback.call(

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts
@@ -20,39 +20,39 @@ export namespace {{ e.ts_name }} {
 {%- for ut in e.uniffi_traits %}
 {%- match ut %}
 {%- when TsUniffiTrait::Display { method } %}
-    export function toString(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
+    export {% if method.renders_async() %}async {% endif %}function {% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
     }
 {%- when TsUniffiTrait::Debug { method } %}
-    export function toDebugString(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
+    export {% if method.renders_async() %}async {% endif %}function toDebugString(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
     }
 {%- if !e.has_display_trait() %}
-    export function toString(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
+    export {% if method.renders_async() %}async {% endif %}function {% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
     }
 {%- endif %}
 {%- when TsUniffiTrait::Eq { eq, ne } %}
-    export function equals(self_: {{ e.ts_name }}, {% call cb::arg_list_decl(eq) %}): {% call cb::return_type(eq) %} {
+    export {% if eq.renders_async() %}async {% endif %}function equals(self_: {{ e.ts_name }}, {% call cb::arg_list_decl(eq) %}): {% call cb::return_type(eq) %} {
         {% call cb::call_body_value(eq) %}
     }
 {%- when TsUniffiTrait::Hash { method } %}
-    export function hashCode(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
+    export {% if method.renders_async() %}async {% endif %}function hashCode(self_: {{ e.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
     }
 {%- when TsUniffiTrait::Ord { cmp } %}
-    export function compareTo(self_: {{ e.ts_name }}, {% call cb::arg_list_decl(cmp) %}): {% call cb::return_type(cmp) %} {
+    export {% if cmp.renders_async() %}async {% endif %}function compareTo(self_: {{ e.ts_name }}, {% call cb::arg_list_decl(cmp) %}): {% call cb::return_type(cmp) %} {
         {% call cb::call_body_value(cmp) %}
     }
 {%- endmatch %}
 {%- endfor %}
 {%- for cons in e.constructors %}
-    export function {{ cons.name }}({% call cb::arg_list_decl(cons) %}): {% call cb::return_type(cons) %} {
+    export {% if cons.renders_async() %}async {% endif %}function {{ cons.name }}({% call cb::arg_list_decl(cons) %}): {% call cb::return_type(cons) %} {
 {%- call cb::call_body_function(cons) %}
     }
 {%- endfor %}
 {%- for method in e.methods %}
-    export function {{ method.name }}(self_: {{ e.ts_name }}{% if !method.arguments.is_empty() %}, {% endif %}{% call cb::arg_list_decl(method) %}): {% call cb::return_type(method) %} {
+    export {% if method.renders_async() %}async {% endif %}function {{ method.name }}(self_: {{ e.ts_name }}{% if !method.arguments.is_empty() %}, {% endif %}{% call cb::arg_list_decl(method) %}): {% call cb::return_type(method) %} {
 {%- call cb::call_body_value(method) %}
     }
 {%- endfor %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ObjectTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ObjectTemplate.ts
@@ -50,28 +50,28 @@ export class {{ obj.impl_class_name }} extends UniffiAbstractObject
     {%- for tm in obj.uniffi_traits %}
     {%      match tm %}
     {%-         when TsUniffiTrait::Display { method } %}
-    toString(): string {
+    {% if method.renders_async() %}async {% endif %}{% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(): {% call cb::return_type(method) %} {
         {% call cb::call_body_method(method, obj.obj_factory) %}
     }
     {%-         when TsUniffiTrait::Debug { method } %}
-    toDebugString(): string {
+    {% if method.renders_async() %}async {% endif %}toDebugString(): {% call cb::return_type(method) %} {
         {% call cb::call_body_method(method, obj.obj_factory) %}
     }
     {%-            if !obj.has_display_trait() %}
-    toString(): string {
+    {% if method.renders_async() %}async asyncToString(): Promise<string>{% else %}toString(): string{% endif %} {
         return this.toDebugString();
     }
     {%            endif %}
     {%-         when TsUniffiTrait::Eq { eq, ne } %}
-    equals(other: {{ obj.impl_class_name }}): {% call cb::return_type(eq) %} {
+    {% if eq.renders_async() %}async {% endif %}equals(other: {{ obj.impl_class_name }}): {% call cb::return_type(eq) %} {
         {% call cb::call_body_method(eq, obj.obj_factory) %}
     }
     {%-         when TsUniffiTrait::Hash { method } %}
-    hashCode(): {% call cb::return_type(method) %} {
+    {% if method.renders_async() %}async {% endif %}hashCode(): {% call cb::return_type(method) %} {
         {% call cb::call_body_method(method, obj.obj_factory) %}
     }
     {%-         when TsUniffiTrait::Ord { cmp } %}
-    compareTo(other: {{ obj.impl_class_name }}): {% call cb::return_type(cmp) %} {
+    {% if cmp.renders_async() %}async {% endif %}compareTo(other: {{ obj.impl_class_name }}): {% call cb::return_type(cmp) %} {
         {% call cb::call_body_method(cmp, obj.obj_factory) %}
     }
     {%-    endmatch %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ObjectTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ObjectTemplate.ts
@@ -26,7 +26,7 @@ export class {{ obj.impl_class_name }} extends UniffiAbstractObject
 
     {%- match obj.primary_constructor %}
     {%- when Some with (cons) %}
-    {%- if !cons.is_async() %}
+    {%- if !cons.renders_async() %}
     {%-   call _object_ctor_decl(obj, cons) %}
     {%- else %}
     {%- call _object_private_ctor(obj) %}
@@ -206,7 +206,7 @@ const {{ obj.ffi_error_converter_name }} = new FfiConverterObjectAsError("{{ obj
 {#- Macro: method or static method declaration -#}
 {%- macro _object_method_decl(obj, func_decl, callable) %}
 {%- call cb::docstring(callable.docstring) %}
-    {% if !func_decl.is_empty() %}{{ func_decl }} {% endif %}{% if callable.is_async() %}async {% endif %}{{ callable.name }}(
+    {% if !func_decl.is_empty() %}{{ func_decl }} {% endif %}{% if callable.renders_async() %}async {% endif %}{{ callable.name }}(
     {%- call cb::arg_list_decl(callable) -%}): {# space #}
     {%- call cb::return_type(callable) %}
     {%- call cb::throws_kw(callable) %} {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
@@ -40,39 +40,39 @@ export const {{ rec.ts_name }} = (() => {
 {%- for ut in rec.uniffi_traits %}
 {%- match ut %}
 {%- when TsUniffiTrait::Display { method } %}
-        toString(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
+        {% if method.renders_async() %}async {% endif %}{% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
         },
 {%- when TsUniffiTrait::Debug { method } %}
-        toDebugString(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
+        {% if method.renders_async() %}async {% endif %}toDebugString(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
         },
 {%- if !rec.has_display_trait() %}
-        toString(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
+        {% if method.renders_async() %}async {% endif %}{% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
         },
 {%- endif %}
 {%- when TsUniffiTrait::Eq { eq, ne } %}
-        equals(self_: {{ rec.ts_name }}, {% call cb::arg_list_decl(eq) %}): {% call cb::return_type(eq) %} {
+        {% if eq.renders_async() %}async {% endif %}equals(self_: {{ rec.ts_name }}, {% call cb::arg_list_decl(eq) %}): {% call cb::return_type(eq) %} {
         {% call cb::call_body_value(eq) %}
         },
 {%- when TsUniffiTrait::Hash { method } %}
-        hashCode(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
+        {% if method.renders_async() %}async {% endif %}hashCode(self_: {{ rec.ts_name }}): {% call cb::return_type(method) %} {
         {% call cb::call_body_value(method) %}
         },
 {%- when TsUniffiTrait::Ord { cmp } %}
-        compareTo(self_: {{ rec.ts_name }}, {% call cb::arg_list_decl(cmp) %}): {% call cb::return_type(cmp) %} {
+        {% if cmp.renders_async() %}async {% endif %}compareTo(self_: {{ rec.ts_name }}, {% call cb::arg_list_decl(cmp) %}): {% call cb::return_type(cmp) %} {
         {% call cb::call_body_value(cmp) %}
         },
 {%- endmatch %}
 {%- endfor %}
 {%- for cons in rec.constructors %}
-        {{ cons.name }}({% call cb::arg_list_decl(cons) %}): {% call cb::return_type(cons) %} {
+        {% if cons.renders_async() %}async {% endif %}{{ cons.name }}({% call cb::arg_list_decl(cons) %}): {% call cb::return_type(cons) %} {
 {%- call cb::call_body_function(cons) %}
         },
 {%- endfor %}
 {%- for method in rec.methods %}
-        {{ method.name }}(self_: {{ rec.ts_name }}{% if !method.arguments.is_empty() %}, {% endif %}{% call cb::arg_list_decl(method) %}): {% call cb::return_type(method) %} {
+        {% if method.renders_async() %}async {% endif %}{{ method.name }}(self_: {{ rec.ts_name }}{% if !method.arguments.is_empty() %}, {% endif %}{% call cb::arg_list_decl(method) %}): {% call cb::return_type(method) %} {
 {%- call cb::call_body_value(method) %}
         },
 {%- endfor %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -83,28 +83,28 @@ export const {{ type_name }} = (() => {
         {%- for ut in e.uniffi_traits %}
         {%- match ut %}
         {%- when TsUniffiTrait::Display { method } %}
-        toString(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
+        {% if method.renders_async() %}async {% endif %}{% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
             {% call cb::call_body_value(method) %}
         }
         {%- when TsUniffiTrait::Debug { method } %}
-        toDebugString(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
+        {% if method.renders_async() %}async {% endif %}toDebugString(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
             {% call cb::call_body_value(method) %}
         }
         {%- if !e.has_display_trait() %}
-        toString(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
+        {% if method.renders_async() %}async {% endif %}{% if method.renders_async() %}asyncToString{% else %}toString{% endif %}(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
             {% call cb::call_body_value(method) %}
         }
         {%- endif %}
         {%- when TsUniffiTrait::Eq { eq, ne } %}
-        equals(other: {{ type_name }}): {% call cb::return_type(eq) %} { const self_ = this as unknown as {{ type_name }};
+        {% if eq.renders_async() %}async {% endif %}equals(other: {{ type_name }}): {% call cb::return_type(eq) %} { const self_ = this as unknown as {{ type_name }};
             {% call cb::call_body_value(eq) %}
         }
         {%- when TsUniffiTrait::Hash { method } %}
-        hashCode(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
+        {% if method.renders_async() %}async {% endif %}hashCode(): {% call cb::return_type(method) %} { const self_ = this as unknown as {{ type_name }};
             {% call cb::call_body_value(method) %}
         }
         {%- when TsUniffiTrait::Ord { cmp } %}
-        compareTo(other: {{ type_name }}): {% call cb::return_type(cmp) %} { const self_ = this as unknown as {{ type_name }};
+        {% if cmp.renders_async() %}async {% endif %}compareTo(other: {{ type_name }}): {% call cb::return_type(cmp) %} { const self_ = this as unknown as {{ type_name }};
             {% call cb::call_body_value(cmp) %}
         }
         {%- endmatch %}
@@ -137,13 +137,13 @@ export const {{ type_name }} = (() => {
         instanceOf,
         {%- for cons in e.constructors %}
 {% call cb::docstring(cons.docstring) %}
-        {{ cons.name }}({% call cb::arg_list_decl(cons) %}): {% call cb::return_type(cons) %} {
+        {% if cons.renders_async() %}async {% endif %}{{ cons.name }}({% call cb::arg_list_decl(cons) %}): {% call cb::return_type(cons) %} {
 {%- call cb::call_body_function(cons) %}
         },
         {%- endfor %}
         {%- for method in e.methods %}
 {% call cb::docstring(method.docstring) %}
-        {{ method.name }}(self_: {{ type_name }}{% if !method.arguments.is_empty() %}, {% endif %}{% call cb::arg_list_decl(method) %}): {% call cb::return_type(method) %} {
+        {% if method.renders_async() %}async {% endif %}{{ method.name }}(self_: {{ type_name }}{% if !method.arguments.is_empty() %}, {% endif %}{% call cb::arg_list_decl(method) %}): {% call cb::return_type(method) %} {
 {%- call cb::call_body_value(method) %}
         },
         {%- endfor %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TopLevelFunctionTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TopLevelFunctionTemplate.ts
@@ -1,7 +1,7 @@
 {%- import "CallBodyMacros.ts" as cb %}
 {%- macro function(func) %}
 {%- call cb::docstring(func.docstring) %}
-export {% if func.is_async() %}async {% endif %}function {{ func.name }}(
+export {% if func.renders_async() %}async {% endif %}function {{ func.name }}(
     {%- call cb::arg_list_decl(func) -%}): {# space #}
     {%- call cb::return_type(func) %}
     {%- call cb::throws_kw(func) %} {

--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -260,7 +260,7 @@ fn generate_api_from_pipeline(
             namespace,
             switches.flavor.clone(),
             ffi_exports,
-        );
+        )?;
         let code = gen_typescript::generate_api_code_from_ir(api_module)?;
         let path = ts_dir.join(module.ts_filename());
         ubrn_common::write_file(path, code)?;

--- a/docs/src/idioms/promises.md
+++ b/docs/src/idioms/promises.md
@@ -26,6 +26,10 @@ const message = await sayAfter(1000n, "World");
 
 You can see this in action in the [`futures-example` example](https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/examples/futures-example/src), and the more complete [`futures` fixture](https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/fixtures/futures).
 
+## Promises from synchronous Rust
+
+Rust that is not `async` can still be given a `Promise` surface in Typescript, with the [`forceAsync` option](../reference/uniffi-toml.md#forcing-an-async-surface) in `uniffi.toml`. The call itself stays synchronous; only the signature changes. It is a migration aid — a way to get call sites into the shape that calling Rust off the main thread requires, without changing what the code does today.
+
 ## Passing Promises across the FFI
 
 There is no support for passing a `Promise` or `Future` as an argument or error, in either direction.

--- a/docs/src/reference/uniffi-toml.md
+++ b/docs/src/reference/uniffi-toml.md
@@ -3,7 +3,7 @@ The `uniffi.toml` file is a toml file used to customize [the generation of C++ a
 To include the file when invoking `ubrn`, specify the path in the
 [corresponding key of the config](../reference/config-yaml.md#bindings).
 
-As of time of writing we support `typescript.customTypes`, `kotlin.cdylib_name` and `kotlin.package_name`.
+As of time of writing, `[bindings.typescript]` supports `logLevel`, `consoleImport`, `customTypes`, `strictObjectTypes`, `strictTypeChecking`, `strictByteArrays` and `forceAsync`; `[bindings.kotlin]` supports `cdylib_name` and `package_name`. Each is described below.
 
 ### Opting out of Interface generation
 
@@ -25,6 +25,77 @@ However, not all projects use or want that functionality. To globally translate 
 [bindings.typescript]
 strictByteArrays = true
 ```
+
+### Typescript strict type checking
+
+By default, generated Typescript files begin with `// @ts-nocheck`, so that `tsc` skips them and downstream projects are not troubled by type errors in code they did not write.
+
+To have `tsc` check the generated files, set `strictTypeChecking` to `true`. This is chiefly useful when working on the generated code itself.
+
+```toml
+[bindings.typescript]
+strictTypeChecking = true
+```
+
+### Forcing an async surface
+
+`forceAsync` gives chosen types and functions an `async`/`Promise` surface in Typescript, without making them async in Rust. The call into Rust still runs synchronously, on the thread that made it.
+
+```toml
+[bindings.typescript]
+forceAsync = true
+```
+
+The point is to let you migrate call sites ahead of time. Rust running off the main thread — whether as real Rust on a background thread, or as WASM on a worker — can only be called asynchronously, so every call site has to grow an `await`. `forceAsync` lets you make that change against a build whose behavior has not changed, and find out what it costs.
+
+```admonish warning
+**`forceAsync` moves no work off the main thread.** An awaited call blocks the Javascript thread for exactly as long as the synchronous one did. All that changes is the shape of the call site.
+```
+
+```admonish warning
+The `await` at each call site is the shape you are migrating towards, and it is what any off-main-thread scheme will need. The rest of the generated surface is less settled: `asyncToString` is named that way only because the call underneath is still synchronous, and forced calls take no `AbortSignal` only because there is no `Future` to cancel. Expect both to be spelled differently once there is.
+```
+
+Set it to `true` to force everything in the crate, or to a list of names to force only those:
+
+```toml
+[bindings.typescript]
+forceAsync = ["Widget", "makeFlatWidget"]
+```
+
+A name may be an object, a record, an enum, or a top-level function. Spelling doesn't matter: `make_flat_widget`, `makeFlatWidget` and `MakeFlatWidget` all name the same function.
+
+#### What changes in the generated Typescript
+
+Methods, constructors, top-level functions and trait methods of a forced type return a `Promise`. Errors arrive as a rejected promise, so `try`/`catch` needs an `await` to catch anything:
+
+```typescript
+// Without forceAsync.
+const w = new Widget("yo");
+const label = w.label();
+
+// With forceAsync. The primary constructor is no longer a `constructor`, so it
+// becomes a static factory — a Rust `new` is already named `create` in Typescript.
+const w = await Widget.create("yo");
+const label = await w.label();
+```
+
+The one method that cannot simply become async is `toString`: Javascript calls it to coerce an object into a string, and an async one hands back a `Promise`. So the `Display` trait is generated as `asyncToString` on a forced type, which no longer has a `toString` of its own. Coercing it — in a template literal, say — gets you the Javascript default of `[object Object]`.
+
+```typescript
+await w.asyncToString(); // "Widget(yo)", from the Display trait
+await w.toDebugString(); // Debug, Eq, Hash and Ord keep their names
+```
+
+Forced calls take no `{ signal: AbortSignal }` option bag. There is no `Future` on the Rust side to cancel — see [task cancellation](../idioms/promises.md#task-cancellation).
+
+#### Callback interfaces and trait interfaces
+
+A callback interface, or a `[Trait, WithForeign]` interface, is implemented in Typescript and called from Rust. `forceAsync` cannot change that direction of travel, so naming one has no effect on its surface. It is only checked: if any of its methods is **synchronous**, generation fails and names the offending methods.
+
+Rust calls into these types through a vtable, and each slot is sync or async according to the Rust method. On the way out, `forceAsync` only has to wrap a return value in a resolved promise; on the way in, it would have to hand a promise to a synchronous slot, which has no way to wait for it. Make the methods `async fn` in Rust, or leave the interface out of the list.
+
+The [`force-async`](https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/fixtures/force-async) and [`force-async-list`](https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/fixtures/force-async-list) fixtures exercise both forms.
 
 ### Logging the FFI
 

--- a/fixtures/force-async-list/Cargo.toml
+++ b/fixtures/force-async-list/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uniffi-fixture-force-async-list"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_force_async_list"
+
+[dependencies]
+uniffi = { workspace = true }
+
+[dev-dependencies]
+ubrn_macros = { workspace = true }
+ubrn_fixture_testing = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/force-async-list/src/lib.rs
+++ b/fixtures/force-async-list/src/lib.rs
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::sync::Arc;
+
+// Named in forceAsync -> async surface.
+#[derive(uniffi::Object)]
+#[uniffi::export(Display)]
+pub struct AsyncObj {
+    val: String,
+}
+
+#[uniffi::export]
+impl AsyncObj {
+    #[uniffi::constructor]
+    pub fn new(val: String) -> Arc<Self> {
+        Arc::new(Self { val })
+    }
+
+    pub fn label(&self) -> String {
+        self.val.clone()
+    }
+}
+
+impl std::fmt::Display for AsyncObj {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AsyncObj({})", self.val)
+    }
+}
+
+// NOT named in forceAsync -> synchronous surface.
+#[derive(uniffi::Object)]
+#[uniffi::export(Display)]
+pub struct SyncObj {
+    val: String,
+}
+
+#[uniffi::export]
+impl SyncObj {
+    #[uniffi::constructor]
+    pub fn new(val: String) -> Arc<Self> {
+        Arc::new(Self { val })
+    }
+
+    pub fn label(&self) -> String {
+        self.val.clone()
+    }
+}
+
+impl std::fmt::Display for SyncObj {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SyncObj({})", self.val)
+    }
+}
+
+// `asyncFn` (TS name) is named in forceAsync -> async; `syncFn` is not.
+#[uniffi::export]
+pub fn async_fn(x: u32) -> u32 {
+    x + 1
+}
+
+#[uniffi::export]
+pub fn sync_fn(x: u32) -> u32 {
+    x + 1
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/force-async-list/tests/bindings/test_force_async_list.ts
+++ b/fixtures/force-async-list/tests/bindings/test_force_async_list.ts
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// To run:
+//   cargo test -p uniffi-fixture-force-async-list -- jsi
+//   cargo test -p uniffi-fixture-force-async-list -- wasm
+
+import {
+  AsyncObj,
+  SyncObj,
+  asyncFn,
+  syncFn,
+} from "@/generated/uniffi_force_async_list";
+import { asyncTest, test } from "@/asserts";
+
+// Members left out of the forceAsync list keep their synchronous surface.
+test("un-named object and function are synchronous", (t) => {
+  const s = new SyncObj("hi");
+  t.assertFalse((s as unknown) instanceof Promise);
+
+  const label = s.label();
+  t.assertFalse((label as unknown) instanceof Promise);
+  t.assertEqual(label, "hi");
+
+  // Display keeps the name `toString`, so string coercion still works.
+  t.assertEqual(s.toString(), "SyncObj(hi)");
+  t.assertEqual(`${s}`, "SyncObj(hi)");
+
+  const r = syncFn(41);
+  t.assertFalse((r as unknown) instanceof Promise);
+  t.assertEqual(r, 42);
+});
+
+(async () => {
+  await asyncTest("named object and function are async", async (t) => {
+    // The primary constructor becomes `static async create()`.
+    const pending = AsyncObj.create("hi");
+    t.assertTrue((pending as unknown) instanceof Promise);
+    // `create` is typed `Promise<AsyncObjLike>`; cast to the class for the
+    // renamed trait method. See Risks: "Async constructor returns the interface type".
+    const a = (await pending) as AsyncObj;
+    t.assertEqual(await a.label(), "hi");
+    // Display renames to asyncToString on a forced type.
+    t.assertEqual(await a.asyncToString(), "AsyncObj(hi)");
+
+    const fnResult = asyncFn(41);
+    t.assertTrue((fnResult as unknown) instanceof Promise);
+    t.assertEqual(await fnResult, 42);
+    t.end();
+  });
+})();

--- a/fixtures/force-async-list/tests/bindings/test_force_async_list.ts
+++ b/fixtures/force-async-list/tests/bindings/test_force_async_list.ts
@@ -38,8 +38,8 @@ test("un-named object and function are synchronous", (t) => {
     // The primary constructor becomes `static async create()`.
     const pending = AsyncObj.create("hi");
     t.assertTrue((pending as unknown) instanceof Promise);
-    // `create` is typed `Promise<AsyncObjLike>`; cast to the class for the
-    // renamed trait method. See Risks: "Async constructor returns the interface type".
+    // `create` resolves to `AsyncObjLike`, the interface. Trait methods live on
+    // the class, so cast to `AsyncObj` to reach them.
     const a = (await pending) as AsyncObj;
     t.assertEqual(await a.label(), "hi");
     // Display renames to asyncToString on a forced type.

--- a/fixtures/force-async-list/tests/test_bindings.rs
+++ b/fixtures/force-async-list/tests/test_bindings.rs
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+ubrn_macros::build_foreign_language_testcases! {
+    "tests/bindings/test_force_async_list.ts" => [Jsi, Wasm, Napi],
+}

--- a/fixtures/force-async-list/uniffi.toml
+++ b/fixtures/force-async-list/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.typescript]
+forceAsync = ["AsyncObj", "asyncFn"]
+strictTypeChecking = true

--- a/fixtures/force-async/Cargo.toml
+++ b/fixtures/force-async/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uniffi-fixture-force-async"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_force_async"
+
+[dependencies]
+uniffi = { workspace = true }
+
+[dev-dependencies]
+ubrn_macros = { workspace = true }
+ubrn_fixture_testing = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/force-async/src/lib.rs
+++ b/fixtures/force-async/src/lib.rs
@@ -1,0 +1,128 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use std::sync::Arc;
+
+// Object with a primary constructor, a plain method, and all five traits.
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, uniffi::Object)]
+#[uniffi::export(Debug, Display, Eq, Hash, Ord)]
+pub struct Widget {
+    val: String,
+}
+
+#[uniffi::export]
+impl Widget {
+    #[uniffi::constructor]
+    pub fn new(val: String) -> Arc<Self> {
+        Arc::new(Self { val })
+    }
+
+    pub fn label(&self) -> String {
+        self.val.clone()
+    }
+}
+
+impl std::fmt::Display for Widget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Widget({})", self.val)
+    }
+}
+
+// Debug without Display: exercises the synthesized asyncToString delegator.
+#[derive(Debug, uniffi::Object)]
+#[uniffi::export(Debug)]
+pub struct DebugOnly {
+    n: i32,
+}
+
+#[uniffi::export]
+impl DebugOnly {
+    #[uniffi::constructor]
+    pub fn new(n: i32) -> Arc<Self> {
+        Arc::new(Self { n })
+    }
+}
+
+// Record with all five traits (namespace-function trait surface).
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, uniffi::Record)]
+#[uniffi::export(Debug, Display, Eq, Hash, Ord)]
+pub struct WidgetRecord {
+    pub name: String,
+    pub value: i32,
+}
+
+impl std::fmt::Display for WidgetRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WidgetRecord({}, {})", self.name, self.value)
+    }
+}
+
+// Tagged enum with traits + a value method.
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, uniffi::Enum)]
+#[uniffi::export(Debug, Display, Eq, Hash, Ord)]
+pub enum WidgetEnum {
+    Alpha,
+    Beta { val: String },
+}
+
+#[uniffi::export]
+impl WidgetEnum {
+    pub fn describe(&self) -> String {
+        match self {
+            WidgetEnum::Alpha => "alpha".to_string(),
+            WidgetEnum::Beta { val } => format!("beta:{val}"),
+        }
+    }
+}
+
+impl std::fmt::Display for WidgetEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WidgetEnum::Alpha => write!(f, "Alpha"),
+            WidgetEnum::Beta { val } => write!(f, "Beta({val})"),
+        }
+    }
+}
+
+// Flat enum with traits + a value method + a top-level factory function.
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, uniffi::Enum)]
+#[uniffi::export(Debug, Display, Eq, Hash, Ord)]
+pub enum FlatWidget {
+    One,
+    Two,
+    Three,
+}
+
+#[uniffi::export]
+impl FlatWidget {
+    pub fn ordinal(&self) -> u8 {
+        match self {
+            FlatWidget::One => 1,
+            FlatWidget::Two => 2,
+            FlatWidget::Three => 3,
+        }
+    }
+}
+
+impl std::fmt::Display for FlatWidget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FlatWidget::One => write!(f, "one"),
+            FlatWidget::Two => write!(f, "two"),
+            FlatWidget::Three => write!(f, "three"),
+        }
+    }
+}
+
+#[uniffi::export]
+pub fn make_flat_widget(v: u8) -> FlatWidget {
+    match v {
+        1 => FlatWidget::One,
+        2 => FlatWidget::Two,
+        _ => FlatWidget::Three,
+    }
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/force-async/src/lib.rs
+++ b/fixtures/force-async/src/lib.rs
@@ -34,6 +34,9 @@ impl std::fmt::Display for Widget {
 #[derive(Debug, uniffi::Object)]
 #[uniffi::export(Debug)]
 pub struct DebugOnly {
+    // Read only through the derived `Debug` impl, which the dead-code pass
+    // cannot see through.
+    #[allow(dead_code)]
     n: i32,
 }
 

--- a/fixtures/force-async/tests/bindings/test_force_async.ts
+++ b/fixtures/force-async/tests/bindings/test_force_async.ts
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// To run:
+//   cargo test -p uniffi-fixture-force-async -- jsi
+//   cargo test -p uniffi-fixture-force-async -- wasm
+
+import {
+  Widget,
+  DebugOnly,
+  WidgetRecord,
+  WidgetEnum,
+  FlatWidget,
+  makeFlatWidget,
+} from "@/generated/uniffi_force_async";
+import { asyncTest } from "@/asserts";
+
+(async () => {
+  await asyncTest("object surface is async and behavior-preserving", async (t) => {
+    // Primary constructor -> `static async create(...)`, which is typed
+    // `Promise<WidgetLike>` (the object *interface*). Trait methods
+    // (equals/hashCode/compareTo/asyncToString) are members of the *class*,
+    // not the interface, so cast to `Widget` to reach them. See Risks:
+    // "Async constructor returns the interface type".
+    const mk = async (s: string): Promise<Widget> => (await Widget.create(s)) as Widget;
+    const w = await mk("yo");
+    t.assertEqual(await w.label(), "yo");
+    t.assertEqual(await w.asyncToString(), "Widget(yo)");
+    t.assertEqual(await w.toDebugString(), 'Widget { val: "yo" }');
+    t.assertTrue(await w.equals(await mk("yo")));
+    t.assertFalse(await w.equals(await mk("no")));
+    t.assertEqual(typeof (await w.hashCode()), "bigint");
+    const a = await mk("alpha");
+    const b = await mk("beta");
+    t.assertTrue((await a.compareTo(b)) < 0);
+    t.assertEqual(await a.compareTo(await mk("alpha")), 0);
+    t.end();
+  });
+
+  await asyncTest("Debug-only object gets an async asyncToString delegator", async (t) => {
+    const d = (await DebugOnly.create(7)) as DebugOnly;
+    // asyncToString delegates to toDebugString; both are async now.
+    t.assertEqual(await d.asyncToString(), await d.toDebugString());
+    t.end();
+  });
+
+  await asyncTest("record namespace trait functions are async", async (t) => {
+    // Records stay plain objects; only their trait functions turn async.
+    const r: WidgetRecord = { name: "hello", value: 42 };
+    t.assertEqual(await WidgetRecord.asyncToString(r), "WidgetRecord(hello, 42)");
+    t.assertTrue(await WidgetRecord.equals(r, { name: "hello", value: 42 }));
+    t.assertFalse(await WidgetRecord.equals(r, { name: "hello", value: 43 }));
+    t.assertEqual(typeof (await WidgetRecord.hashCode(r)), "bigint");
+    t.end();
+  });
+
+  await asyncTest("tagged enum trait methods + value method are async", async (t) => {
+    // Variant construction stays synchronous (pure JS).
+    const alpha = new WidgetEnum.Alpha();
+    const beta = new WidgetEnum.Beta({ val: "x" });
+    t.assertEqual(await alpha.asyncToString(), "Alpha");
+    t.assertEqual(await beta.asyncToString(), "Beta(x)");
+    t.assertTrue(await alpha.equals(new WidgetEnum.Alpha()));
+    t.assertTrue((await alpha.compareTo(beta)) < 0);
+    // Namespace value method.
+    t.assertEqual(await WidgetEnum.describe(alpha), "alpha");
+    t.assertEqual(await WidgetEnum.describe(beta), "beta:x");
+    t.end();
+  });
+
+  await asyncTest("flat enum namespace functions + top-level fn are async", async (t) => {
+    // Variant values stay plain.
+    const one = FlatWidget.One;
+    t.assertEqual(await FlatWidget.asyncToString(FlatWidget.One), "one");
+    t.assertEqual(await FlatWidget.toDebugString(FlatWidget.Two), "Two");
+    t.assertTrue(await FlatWidget.equals(FlatWidget.One, one));
+    t.assertTrue((await FlatWidget.compareTo(FlatWidget.One, FlatWidget.Two)) < 0);
+    t.assertEqual(await FlatWidget.ordinal(FlatWidget.Three), 3);
+    // Top-level function is async and round-trips through the FFI.
+    const two = await makeFlatWidget(2);
+    t.assertEqual(two, FlatWidget.Two);
+    t.assertEqual(await FlatWidget.asyncToString(two), "two");
+    t.end();
+  });
+})();

--- a/fixtures/force-async/tests/bindings/test_force_async.ts
+++ b/fixtures/force-async/tests/bindings/test_force_async.ts
@@ -18,28 +18,30 @@ import {
 import { asyncTest } from "@/asserts";
 
 (async () => {
-  await asyncTest("object surface is async and behavior-preserving", async (t) => {
-    // Primary constructor -> `static async create(...)`, which is typed
-    // `Promise<WidgetLike>` (the object *interface*). Trait methods
-    // (equals/hashCode/compareTo/asyncToString) are members of the *class*,
-    // not the interface, so cast to `Widget` to reach them. See Risks:
-    // "Async constructor returns the interface type".
-    const mk = async (s: string): Promise<Widget> => (await Widget.create(s)) as Widget;
-    const w = await mk("yo");
-    t.assertEqual(await w.label(), "yo");
-    t.assertEqual(await w.asyncToString(), "Widget(yo)");
-    t.assertEqual(await w.toDebugString(), 'Widget { val: "yo" }');
-    t.assertTrue(await w.equals(await mk("yo")));
-    t.assertFalse(await w.equals(await mk("no")));
-    // Hash values are not stable across builds, so assert the invariant —
-    // equal instances hash equal — rather than a literal.
-    t.assertEqual(await w.hashCode(), await (await mk("yo")).hashCode());
-    const a = await mk("alpha");
-    const b = await mk("beta");
-    t.assertTrue((await a.compareTo(b)) < 0);
-    t.assertEqual(await a.compareTo(await mk("alpha")), 0);
-    t.end();
-  });
+  await asyncTest(
+    "object surface is async and behavior-preserving",
+    async (t) => {
+      // Forcing async turns the primary constructor into `static async create()`,
+      // typed `Promise<WidgetLike>`. Trait methods live on the class, not on the
+      // `WidgetLike` interface, so cast to `Widget` to reach them.
+      const mk = async (s: string): Promise<Widget> =>
+        (await Widget.create(s)) as Widget;
+      const w = await mk("yo");
+      t.assertEqual(await w.label(), "yo");
+      t.assertEqual(await w.asyncToString(), "Widget(yo)");
+      t.assertEqual(await w.toDebugString(), 'Widget { val: "yo" }');
+      t.assertTrue(await w.equals(await mk("yo")));
+      t.assertFalse(await w.equals(await mk("no")));
+      // Hash values are not stable across builds, so assert the invariant —
+      // equal instances hash equal — rather than a literal.
+      t.assertEqual(await w.hashCode(), await (await mk("yo")).hashCode());
+      const a = await mk("alpha");
+      const b = await mk("beta");
+      t.assertTrue((await a.compareTo(b)) < 0);
+      t.assertEqual(await a.compareTo(await mk("alpha")), 0);
+      t.end();
+    },
+  );
 
   await asyncTest(
     "Debug-only object gets an async asyncToString delegator",

--- a/fixtures/force-async/tests/bindings/test_force_async.ts
+++ b/fixtures/force-async/tests/bindings/test_force_async.ts
@@ -31,7 +31,9 @@ import { asyncTest } from "@/asserts";
     t.assertEqual(await w.toDebugString(), 'Widget { val: "yo" }');
     t.assertTrue(await w.equals(await mk("yo")));
     t.assertFalse(await w.equals(await mk("no")));
-    t.assertEqual(typeof (await w.hashCode()), "bigint");
+    // Hash values are not stable across builds, so assert the invariant —
+    // equal instances hash equal — rather than a literal.
+    t.assertEqual(await w.hashCode(), await (await mk("yo")).hashCode());
     const a = await mk("alpha");
     const b = await mk("beta");
     t.assertTrue((await a.compareTo(b)) < 0);
@@ -39,49 +41,93 @@ import { asyncTest } from "@/asserts";
     t.end();
   });
 
-  await asyncTest("Debug-only object gets an async asyncToString delegator", async (t) => {
-    const d = (await DebugOnly.create(7)) as DebugOnly;
-    // asyncToString delegates to toDebugString; both are async now.
-    t.assertEqual(await d.asyncToString(), await d.toDebugString());
-    t.end();
-  });
+  await asyncTest(
+    "Debug-only object gets an async asyncToString delegator",
+    async (t) => {
+      const d = (await DebugOnly.create(7)) as DebugOnly;
+      const debugStr = await d.toDebugString();
+      t.assertEqual(debugStr, "DebugOnly { n: 7 }");
+      // With Debug but no Display, asyncToString delegates to toDebugString.
+      t.assertEqual(await d.asyncToString(), debugStr);
+      t.end();
+    },
+  );
 
   await asyncTest("record namespace trait functions are async", async (t) => {
     // Records stay plain objects; only their trait functions turn async.
     const r: WidgetRecord = { name: "hello", value: 42 };
-    t.assertEqual(await WidgetRecord.asyncToString(r), "WidgetRecord(hello, 42)");
+    t.assertEqual(
+      await WidgetRecord.asyncToString(r),
+      "WidgetRecord(hello, 42)",
+    );
+    t.assertEqual(
+      await WidgetRecord.toDebugString(r),
+      'WidgetRecord { name: "hello", value: 42 }',
+    );
     t.assertTrue(await WidgetRecord.equals(r, { name: "hello", value: 42 }));
     t.assertFalse(await WidgetRecord.equals(r, { name: "hello", value: 43 }));
-    t.assertEqual(typeof (await WidgetRecord.hashCode(r)), "bigint");
+    t.assertEqual(
+      await WidgetRecord.hashCode(r),
+      await WidgetRecord.hashCode({ name: "hello", value: 42 }),
+    );
+    // Derived Ord compares fields in declaration order: name, then value.
+    t.assertEqual(
+      await WidgetRecord.compareTo(r, { name: "hello", value: 42 }),
+      0,
+    );
+    t.assertTrue(
+      (await WidgetRecord.compareTo(r, { name: "hello", value: 100 })) < 0,
+    );
+    t.assertTrue(
+      (await WidgetRecord.compareTo(r, { name: "zzz", value: 1 })) < 0,
+    );
     t.end();
   });
 
-  await asyncTest("tagged enum trait methods + value method are async", async (t) => {
-    // Variant construction stays synchronous (pure JS).
-    const alpha = new WidgetEnum.Alpha();
-    const beta = new WidgetEnum.Beta({ val: "x" });
-    t.assertEqual(await alpha.asyncToString(), "Alpha");
-    t.assertEqual(await beta.asyncToString(), "Beta(x)");
-    t.assertTrue(await alpha.equals(new WidgetEnum.Alpha()));
-    t.assertTrue((await alpha.compareTo(beta)) < 0);
-    // Namespace value method.
-    t.assertEqual(await WidgetEnum.describe(alpha), "alpha");
-    t.assertEqual(await WidgetEnum.describe(beta), "beta:x");
-    t.end();
-  });
+  await asyncTest(
+    "tagged enum trait methods + value method are async",
+    async (t) => {
+      // Variant construction stays synchronous (pure JS).
+      const alpha = new WidgetEnum.Alpha();
+      const beta = new WidgetEnum.Beta({ val: "x" });
+      t.assertEqual(await alpha.asyncToString(), "Alpha");
+      t.assertEqual(await beta.asyncToString(), "Beta(x)");
+      t.assertEqual(await alpha.toDebugString(), "Alpha");
+      t.assertEqual(await beta.toDebugString(), 'Beta { val: "x" }');
+      t.assertTrue(await alpha.equals(new WidgetEnum.Alpha()));
+      t.assertTrue((await alpha.compareTo(beta)) < 0);
+      t.assertEqual(
+        await alpha.hashCode(),
+        await new WidgetEnum.Alpha().hashCode(),
+      );
+      // Namespace value method.
+      t.assertEqual(await WidgetEnum.describe(alpha), "alpha");
+      t.assertEqual(await WidgetEnum.describe(beta), "beta:x");
+      t.end();
+    },
+  );
 
-  await asyncTest("flat enum namespace functions + top-level fn are async", async (t) => {
-    // Variant values stay plain.
-    const one = FlatWidget.One;
-    t.assertEqual(await FlatWidget.asyncToString(FlatWidget.One), "one");
-    t.assertEqual(await FlatWidget.toDebugString(FlatWidget.Two), "Two");
-    t.assertTrue(await FlatWidget.equals(FlatWidget.One, one));
-    t.assertTrue((await FlatWidget.compareTo(FlatWidget.One, FlatWidget.Two)) < 0);
-    t.assertEqual(await FlatWidget.ordinal(FlatWidget.Three), 3);
-    // Top-level function is async and round-trips through the FFI.
-    const two = await makeFlatWidget(2);
-    t.assertEqual(two, FlatWidget.Two);
-    t.assertEqual(await FlatWidget.asyncToString(two), "two");
-    t.end();
-  });
+  await asyncTest(
+    "flat enum namespace functions + top-level fn are async",
+    async (t) => {
+      // Variant values stay plain.
+      const one = FlatWidget.One;
+      t.assertEqual(await FlatWidget.asyncToString(FlatWidget.One), "one");
+      t.assertEqual(await FlatWidget.toDebugString(FlatWidget.Two), "Two");
+      t.assertTrue(await FlatWidget.equals(FlatWidget.One, one));
+      t.assertEqual(
+        await FlatWidget.hashCode(FlatWidget.One),
+        await FlatWidget.hashCode(one),
+      );
+      t.assertTrue(
+        (await FlatWidget.compareTo(FlatWidget.One, FlatWidget.Two)) < 0,
+      );
+      t.assertEqual(await FlatWidget.ordinal(FlatWidget.Three), 3);
+      // Top-level function is async and round-trips through the FFI.
+      const two = await makeFlatWidget(2);
+      t.assertEqual(two, FlatWidget.Two);
+      t.assertEqual(await FlatWidget.asyncToString(two), "two");
+      t.end();
+    },
+  );
 })();

--- a/fixtures/force-async/tests/test_bindings.rs
+++ b/fixtures/force-async/tests/test_bindings.rs
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+ubrn_macros::build_foreign_language_testcases! {
+    "tests/bindings/test_force_async.ts" => [Jsi, Wasm, Napi],
+}

--- a/fixtures/force-async/uniffi.toml
+++ b/fixtures/force-async/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.typescript]
+forceAsync = true
+strictTypeChecking = true


### PR DESCRIPTION
In preparation for the OtMT work, and to aid migration of a codebase to use OtMT, then add a `forceAsync` flag to `uniffi.toml`.

This is documented [here](https://github.com/jhugman/uniffi-bindgen-react-native/blob/8b294ca9a34e68477d1a7dc7eaaf629f39099b83/docs/src/reference/uniffi-toml.md#forcing-an-async-surface).
