### PR TITLE
Add "cursor" to reduce the DataView per value when lifting and lowering.

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/builders.rs
@@ -408,9 +408,10 @@ fn build_error_type(config: &Config, type_node: &general::TypeNode) -> TsErrorTy
 }
 
 pub(super) fn build_arg(config: &Config, arg: &general::Argument) -> TsArg {
+    let ts_type = type_label_for(config, &arg.ty.ty);
     TsArg {
         name: arg_name(&arg.name),
-        ts_type: type_label_for(config, &arg.ty.ty),
+        ts_type,
         ffi_converter: ffi_converter_name_for(config, &arg.ty),
         default_value: arg
             .default
@@ -435,10 +436,11 @@ pub(super) fn build_callable(
         .map(|arg| build_arg(config, arg))
         .collect();
     let return_type = callable.return_type.ty.as_ref().map(|tn| {
+        let ts_type = type_label_for(config, &tn.ty);
         let ffi_type = ffi_type_to_ts_name(&tn.ffi_type.ty);
         let is_rust_buffer = ffi_type == "Uint8Array";
         TsReturnType {
-            ts_type: type_label_for(config, &tn.ty),
+            ts_type,
             ffi_converter: ffi_converter_name_for(config, tn),
             ffi_type,
             is_rust_buffer,

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/mod.rs
@@ -175,6 +175,7 @@ impl ImportAccumulator {
     fn collect_custom(&mut self, c: &TsCustomType) {
         self.add_infra_type("FfiConverter");
         self.add_infra_type("RustBufferAllocator");
+        self.add_infra_value("Cursor");
         self.add_infra_value("uniffiTypeNameSymbol");
         if let Some(cfg) = &c.custom_config {
             for (name, from) in &cfg.imports {
@@ -195,7 +196,7 @@ impl ImportAccumulator {
 
     fn collect_enum(&mut self, e: &TsEnum) {
         self.add_infra_value("AbstractFfiConverterByteArray");
-        self.add_infra_value("FfiConverterInt32");
+        self.add_infra_value("Cursor");
         self.add_infra_value("UniffiInternalError");
         if !e.is_flat {
             self.add_infra_value("uniffiTypeNameSymbol");
@@ -227,6 +228,7 @@ impl ImportAccumulator {
     fn collect_record(&mut self, r: &TsRecord) {
         self.add_infra_value("uniffiCreateRecord");
         self.add_infra_value("AbstractFfiConverterByteArray");
+        self.add_infra_value("Cursor");
         self.add_exported_converter(&r.ffi_converter_name);
 
         if r.has_callables() {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/api_module/nodes.rs
@@ -175,10 +175,11 @@ pub(crate) struct TsReturnType {
     pub ffi_converter: String,
     pub ffi_type: String,
     /// True when the FFI return type is a `RustBuffer` (i.e. `Uint8Array`).
-    /// The `try/finally` lift wrapper in `CallBodyMacros.ts` keys on this so
-    /// the wrapper only fires when the converter's `lift` actually consumes a
-    /// `Uint8Array` — primitive returns (numbers, bigints, booleans, pointers)
-    /// flow through their converters' `lift` directly without a buffer to free.
+    /// The `try/finally` lift wrapper in `CallBodyMacros.ts` keys on this
+    /// so the wrapper only fires when the converter's `lift` actually
+    /// consumes a `Uint8Array` — primitive returns (numbers, bigints,
+    /// booleans, pointers) flow through their converters' `lift` directly
+    /// without a buffer to free.
     pub is_rust_buffer: bool,
 }
 

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -70,7 +70,10 @@ console.debug(`-- {{ ffi_name }}`);
     {%- endif %}
 {%- endmacro %}
 
-{#- Lowered argument list (for FFI calls). -#}
+{#- Lowered argument list (for FFI calls). Every arg goes through
+   `converter.lower(value, nativeModule().rustbuffer_alloc)`; for `RustBuffer`-shaped
+   types the converter writes straight into a wasm allocation supplied
+   by `rustbuffer_alloc`, so there is no JS-side intermediate copy. -#}
 {%- macro arg_list_lowered(callable) %}
     {%- for arg in callable.arguments %}
         {{ arg.ffi_converter }}.lower({{ arg.name }}, nativeModule().rustbuffer_alloc),
@@ -149,22 +152,23 @@ console.debug(`-- {{ ffi_name }}`);
 
 {#- The synchronous lift call sites below wrap the converter's `.lift(__rb)`
    in `try/finally` so `rustbuffer_free` always runs — even if `lift`
-   throws on a malformed payload. The IIFE preserves the surrounding
-   `return ...` shape and avoids restructuring the multi-line `to_ffi_*_call`
-   macros into a `const __rb = ...` statement. -#}
+   throws on a malformed payload. A previous version of these macros
+   wrapped the try/finally in an IIFE (`((__rb) => { ... })(...)`); we
+   inline the `const __rb = ...; try { ... } finally { ... }` form
+   instead to avoid allocating a fresh closure object at every call
+   site invocation (V8-friendlier). -#}
 
 {#- Call body for value-receiver method: sync only (trait methods are never async). -#}
 {%- macro call_body_value(callable) %}
 {%- match callable.return_type -%}
 {%-     when Some with (return_type) %}
 {%- if return_type.is_rust_buffer %}
-    return ((__rb: Uint8Array) => {
-        try {
-            return {{ return_type.ffi_converter }}.lift(__rb);
-        } finally {
-            nativeModule().rustbuffer_free(__rb);
-        }
-    })({% call to_ffi_value_call(callable) %});
+    const __rb: Uint8Array = {% call to_ffi_value_call(callable) %};
+    try {
+        return {{ return_type.ffi_converter }}.lift(__rb);
+    } finally {
+        nativeModule().rustbuffer_free(__rb);
+    }
 {%- else %}
     return {{ return_type.ffi_converter }}.lift({% call to_ffi_value_call(callable) %});
 {%- endif %}
@@ -181,13 +185,12 @@ console.debug(`-- {{ ffi_name }}`);
 {%-     match callable.return_type -%}
 {%-         when Some with (return_type) %}
 {%- if return_type.is_rust_buffer %}
-    return ((__rb: Uint8Array) => {
-        try {
-            return {{ return_type.ffi_converter }}.lift(__rb);
-        } finally {
-            nativeModule().rustbuffer_free(__rb);
-        }
-    })({% call to_ffi_pointer_call(callable, obj_factory) %});
+    const __rb: Uint8Array = {% call to_ffi_pointer_call(callable, obj_factory) %};
+    try {
+        return {{ return_type.ffi_converter }}.lift(__rb);
+    } finally {
+        nativeModule().rustbuffer_free(__rb);
+    }
 {%- else %}
     return {{ return_type.ffi_converter }}.lift({% call to_ffi_pointer_call(callable, obj_factory) %});
 {%- endif %}
@@ -205,13 +208,12 @@ console.debug(`-- {{ ffi_name }}`);
 {%-     match callable.return_type -%}
 {%-         when Some with (return_type) %}
 {%- if return_type.is_rust_buffer %}
-    return ((__rb: Uint8Array) => {
-        try {
-            return {{ return_type.ffi_converter }}.lift(__rb);
-        } finally {
-            nativeModule().rustbuffer_free(__rb);
-        }
-    })({% call to_ffi_call(callable) %});
+    const __rb: Uint8Array = {% call to_ffi_call(callable) %};
+    try {
+        return {{ return_type.ffi_converter }}.lift(__rb);
+    } finally {
+        nativeModule().rustbuffer_free(__rb);
+    }
 {%- else %}
     return {{ return_type.ffi_converter }}.lift({% call to_ffi_call(callable) %});
 {%- endif %}

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CustomTypeTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CustomTypeTemplate.ts
@@ -37,13 +37,13 @@ const {{ custom.ffi_converter_name }} = (() => {
             const intermediate = {{ config.lower_expr }};
             return intermediateConverter.lower(intermediate, alloc);
         }
-        read(from: RustBuffer): TsType {
-            const intermediate = intermediateConverter.read(from);
+        readFromCursor(c: Cursor): TsType {
+            const intermediate = intermediateConverter.readFromCursor(c);
             return {{ config.lift_expr }};
         }
-        write(value: TsType, into: RustBuffer): void {
+        writeIntoCursor(value: TsType, c: Cursor): void {
             const intermediate = {{ config.lower_expr }};
-            intermediateConverter.write(intermediate, into);
+            intermediateConverter.writeIntoCursor(intermediate, c);
         }
         allocationSize(value: TsType): number {
             const intermediate = {{ config.lower_expr }};

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/EnumTemplate.ts
@@ -60,26 +60,25 @@ export namespace {{ e.ts_name }} {
 {%- endif %}
 
 const {{ e.ffi_converter_name }} = (() => {
-    const ordinalConverter = FfiConverterInt32;
     type TypeName = {{ e.ts_name }};
     class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
-        read(from: RustBuffer): TypeName {
-            switch (ordinalConverter.read(from)) {
+        readFromCursor(c: Cursor): TypeName {
+            switch (c.readI32()) {
                 {%- for variant in e.variants %}
                 case {{ loop.index }}: return {{ e.ts_name }}.{{ variant.name }};
                 {%- endfor %}
                 default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
         }
-        write(value: TypeName, into: RustBuffer): void {
+        writeIntoCursor(value: TypeName, c: Cursor): void {
             switch (value) {
                 {%- for variant in e.variants %}
-                case {{ e.ts_name }}.{{ variant.name }}: return ordinalConverter.write({{ loop.index }}, into);
+                case {{ e.ts_name }}.{{ variant.name }}: return c.writeI32({{ loop.index }});
                 {%- endfor %}
             }
         }
         allocationSize(value: TypeName): number {
-            return ordinalConverter.allocationSize(0);
+            return 4;
         }
     }
     return new FFIConverter();

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ErrorTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/ErrorTemplate.ts
@@ -65,26 +65,25 @@ export type {{ type_name }} = InstanceType<
 >;
 
 const {{ e.ffi_converter_name }} = (() => {
-    const intConverter = FfiConverterInt32;
     type TypeName = {{ type_name }};
     class FfiConverter extends AbstractFfiConverterByteArray<TypeName> {
-        read(from: RustBuffer): TypeName {
-            switch (intConverter.read(from)) {
+        readFromCursor(c: Cursor): TypeName {
+            switch (c.readI32()) {
             {%-   for variant in e.variants %}
                 case {{ loop.index }}: return new {{ type_name }}.{{ variant.name }}(
-                    FfiConverterString.read(from)
+                    FfiConverterString.readFromCursor(c)
                 );
             {%    endfor %}
                 default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
         }
-        write(value: TypeName, into: RustBuffer): void {
+        writeIntoCursor(value: TypeName, c: Cursor): void {
             const obj = value as any;
             const index = obj[variantOrdinalSymbol] as number;
-            intConverter.write(index, into);
+            c.writeI32(index);
         }
         allocationSize(value: TypeName): number {
-            return intConverter.allocationSize(0);
+            return 4;
         }
     }
     return new FfiConverter();

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/RecordTemplate.ts
@@ -82,17 +82,17 @@ export const {{ rec.ts_name }} = (() => {
 const {{ rec.ffi_converter_name }} = (() => {
     type TypeName = {{ rec.ts_name }};
     class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
-        read(from: RustBuffer): TypeName {
+        readFromCursor(c: Cursor): TypeName {
             return {
             {%- for field in rec.fields %}
-                {{ field.name }}: {{ field.ffi_converter }}.read(from)
+                {{ field.name }}: {{ field.ffi_converter }}.readFromCursor(c)
                 {%- if !loop.last %}, {% endif %}
             {%- endfor %}
             };
         }
-        write(value: TypeName, into: RustBuffer): void {
+        writeIntoCursor(value: TypeName, c: Cursor): void {
             {%- for field in rec.fields %}
-            {{ field.ffi_converter }}.write(value.{{ field.name }}, into);
+            {{ field.ffi_converter }}.writeIntoCursor(value.{{ field.name }}, c);
             {%- endfor %}
         }
         allocationSize(value: TypeName): number {

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
@@ -166,11 +166,10 @@ export type {{ type_name }} = InstanceType<
 
 // FfiConverter for enum {{ type_name }}
 const {{ e.ffi_converter_name }} = (() => {
-    const ordinalConverter = FfiConverterInt32;
     type TypeName = {{ type_name }};
     class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
-        read(from: RustBuffer): TypeName {
-            switch (ordinalConverter.read(from)) {
+        readFromCursor(c: Cursor): TypeName {
+            switch (c.readI32()) {
             {%- for variant in e.variants %}
             {%-   let has_fields = !variant.fields.is_empty() %}
             {%-   let is_tuple = variant.has_nameless_fields %}
@@ -179,12 +178,12 @@ const {{ e.ffi_converter_name }} = (() => {
             {%-   if has_fields %}
             {%-     if !is_tuple %}{
             {%-     for field in variant.fields %}
-            {{-       field.name }}: {{ field.ffi_converter }}.read(from)
+            {{-       field.name }}: {{ field.ffi_converter }}.readFromCursor(c)
             {%-       if !loop.last -%}, {% endif %}
             {%-     endfor %} }
             {%-     else %}
             {%-       for field in variant.fields %}
-            {{-         field.ffi_converter }}.read(from)
+            {{-         field.ffi_converter }}.readFromCursor(c)
             {%-         if !loop.last -%}, {% endif %}
             {%-       endfor %}
             {%-     endif %}
@@ -193,18 +192,18 @@ const {{ e.ffi_converter_name }} = (() => {
                 default: throw new UniffiInternalError.UnexpectedEnumCase();
             }
         }
-        write(value: TypeName, into: RustBuffer): void {
+        writeIntoCursor(value: TypeName, c: Cursor): void {
             switch (value.tag) {
                 {%- for variant in e.variants %}
                 {%-   let has_fields = !variant.fields.is_empty() %}
                 {%-   let is_tuple = variant.has_nameless_fields %}
                 {%-   let external_name = variant.name %}
                 case {{ type_name__Tags }}.{{ external_name }}: {
-                    ordinalConverter.write({{ loop.index }}, into);
+                    c.writeI32({{ loop.index }});
                     {%- if has_fields %}
                     const inner = value.inner;
                     {%-   for field in variant.fields %}
-                    {{ field.ffi_converter }}.write({%- if is_tuple %}inner[{{ loop.index0 }}]{% else %}inner.{{ field.name }}{% endif %}, into);
+                    {{ field.ffi_converter }}.writeIntoCursor({%- if is_tuple %}inner[{{ loop.index0 }}]{% else %}inner.{{ field.name }}{% endif %}, c);
                     {%-   endfor %}
                     {%- endif %}
                     return;
@@ -224,13 +223,13 @@ const {{ e.ffi_converter_name }} = (() => {
                 case {{ type_name__Tags }}.{{ external_name }}: {
                 {%-   if has_fields %}
                     const inner = value.inner;
-                    let size = ordinalConverter.allocationSize({{ loop.index }});
+                    let size = 4;
                 {%-     for field in variant.fields %}
                     size += {{ field.ffi_converter }}.allocationSize({%- if is_tuple %}inner[{{ loop.index0 }}]{% else %}inner.{{ field.name }}{% endif %});
                 {%-     endfor %}
                     return size;
                 {%-   else %}
-                    return ordinalConverter.allocationSize({{ loop.index }});
+                    return 4;
                 {%-   endif %}
                 }
                 {%- endfor %}

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -3,12 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+import { Cursor } from "./cursor.ts";
 import {
   type FfiConverter,
   FfiConverterUInt64,
   type RustBufferAllocator,
 } from "./ffi-converters.ts";
-import { type UniffiByteArray, RustBuffer } from "./ffi-types.ts";
+import { type UniffiByteArray } from "./ffi-types.ts";
 import {
   type UniffiHandle,
   UniffiHandleMap,
@@ -17,7 +18,6 @@ import {
 import {
   CALL_ERROR,
   CALL_UNEXPECTED_ERROR,
-  type UniffiRustCallStatus,
 } from "./rust-call.ts";
 
 const handleConverter = FfiConverterUInt64;
@@ -31,11 +31,11 @@ export class FfiConverterCallback<T> implements FfiConverter<UniffiHandle, T> {
   lower(value: T, _alloc: RustBufferAllocator): UniffiHandle {
     return this.handleMap.insert(value);
   }
-  read(from: RustBuffer): T {
-    return this.lift(handleConverter.read(from));
+  readFromCursor(c: Cursor): T {
+    return this.lift(handleConverter.readFromCursor(c));
   }
-  write(value: T, into: RustBuffer): void {
-    handleConverter.write(this.handleMap.insert(value), into);
+  writeIntoCursor(value: T, c: Cursor): void {
+    handleConverter.writeIntoCursor(this.handleMap.insert(value), c);
   }
   allocationSize(value: T): number {
     return handleConverter.allocationSize(defaultUniffiHandle);

--- a/typescript/src/callbacks.ts
+++ b/typescript/src/callbacks.ts
@@ -15,10 +15,7 @@ import {
   UniffiHandleMap,
   defaultUniffiHandle,
 } from "./handle-map.ts";
-import {
-  CALL_ERROR,
-  CALL_UNEXPECTED_ERROR,
-} from "./rust-call.ts";
+import { CALL_ERROR, CALL_UNEXPECTED_ERROR } from "./rust-call.ts";
 
 const handleConverter = FfiConverterUInt64;
 

--- a/typescript/src/cursor.ts
+++ b/typescript/src/cursor.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { UniffiInternalError } from "./errors";
+import { UniffiInternalError } from "./errors.ts";
 
 /**
  * Positional reader/writer over an `ArrayBuffer` slice with monomorphic typed

--- a/typescript/src/cursor.ts
+++ b/typescript/src/cursor.ts
@@ -1,0 +1,196 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { UniffiInternalError } from "./errors";
+
+/**
+ * Positional reader/writer over an `ArrayBuffer` slice with monomorphic typed
+ * accessors. One `DataView` and one `Uint8Array` are built at construction and
+ * reused for every primitive operation — no per-read DataView allocation, no
+ * function-pointer dispatch.
+ *
+ * Big-endian on the wire (matches the UniFFI RustBuffer wire format).
+ */
+export class Cursor {
+  private readonly dv: DataView;
+  private readonly u8: Uint8Array;
+  private readonly start: number;
+  private readonly end: number;
+  private pos: number;
+
+  constructor(buffer: ArrayBuffer, offset: number, length: number) {
+    this.dv = new DataView(buffer, offset, length);
+    this.u8 = new Uint8Array(buffer, offset, length);
+    this.start = offset;
+    this.end = offset + length;
+    this.pos = 0;
+  }
+
+  static fromUint8Array(view: Uint8Array): Cursor {
+    return new Cursor(
+      view.buffer as ArrayBuffer,
+      view.byteOffset,
+      view.byteLength,
+    );
+  }
+
+  remaining(): number {
+    return this.end - this.start - this.pos;
+  }
+
+  skip(n: number): void {
+    this.boundsCheck(n);
+    this.pos += n;
+  }
+
+  readU8(): number {
+    this.boundsCheck(1);
+    const v = this.dv.getUint8(this.pos);
+    this.pos += 1;
+    return v;
+  }
+  readI8(): number {
+    this.boundsCheck(1);
+    const v = this.dv.getInt8(this.pos);
+    this.pos += 1;
+    return v;
+  }
+  readU16(): number {
+    this.boundsCheck(2);
+    const v = this.dv.getUint16(this.pos);
+    this.pos += 2;
+    return v;
+  }
+  readI16(): number {
+    this.boundsCheck(2);
+    const v = this.dv.getInt16(this.pos);
+    this.pos += 2;
+    return v;
+  }
+  readU32(): number {
+    this.boundsCheck(4);
+    const v = this.dv.getUint32(this.pos);
+    this.pos += 4;
+    return v;
+  }
+  readI32(): number {
+    this.boundsCheck(4);
+    const v = this.dv.getInt32(this.pos);
+    this.pos += 4;
+    return v;
+  }
+  readU64(): bigint {
+    this.boundsCheck(8);
+    const v = this.dv.getBigUint64(this.pos);
+    this.pos += 8;
+    return v;
+  }
+  readI64(): bigint {
+    this.boundsCheck(8);
+    const v = this.dv.getBigInt64(this.pos);
+    this.pos += 8;
+    return v;
+  }
+  readF32(): number {
+    this.boundsCheck(4);
+    const v = this.dv.getFloat32(this.pos);
+    this.pos += 4;
+    return v;
+  }
+  readF64(): number {
+    this.boundsCheck(8);
+    const v = this.dv.getFloat64(this.pos);
+    this.pos += 8;
+    return v;
+  }
+  readBool(): boolean {
+    return this.readU8() !== 0;
+  }
+
+  writeU8(v: number): void {
+    this.boundsCheck(1);
+    this.dv.setUint8(this.pos, v);
+    this.pos += 1;
+  }
+  writeI8(v: number): void {
+    this.boundsCheck(1);
+    this.dv.setInt8(this.pos, v);
+    this.pos += 1;
+  }
+  writeU16(v: number): void {
+    this.boundsCheck(2);
+    this.dv.setUint16(this.pos, v);
+    this.pos += 2;
+  }
+  writeI16(v: number): void {
+    this.boundsCheck(2);
+    this.dv.setInt16(this.pos, v);
+    this.pos += 2;
+  }
+  writeU32(v: number): void {
+    this.boundsCheck(4);
+    this.dv.setUint32(this.pos, v);
+    this.pos += 4;
+  }
+  writeI32(v: number): void {
+    this.boundsCheck(4);
+    this.dv.setInt32(this.pos, v);
+    this.pos += 4;
+  }
+  writeU64(v: bigint): void {
+    this.boundsCheck(8);
+    this.dv.setBigUint64(this.pos, v);
+    this.pos += 8;
+  }
+  writeI64(v: bigint): void {
+    this.boundsCheck(8);
+    this.dv.setBigInt64(this.pos, v);
+    this.pos += 8;
+  }
+  writeF32(v: number): void {
+    this.boundsCheck(4);
+    this.dv.setFloat32(this.pos, v);
+    this.pos += 4;
+  }
+  writeF64(v: number): void {
+    this.boundsCheck(8);
+    this.dv.setFloat64(this.pos, v);
+    this.pos += 8;
+  }
+  writeBool(v: boolean): void {
+    this.writeU8(v ? 1 : 0);
+  }
+
+  readBytes(len: number): Uint8Array {
+    this.boundsCheck(len);
+    // start is an absolute offset into the underlying buffer; this matters
+    // when the Cursor wraps a sub-window of a larger buffer (e.g. via
+    // fromUint8Array over a Node.js Buffer pool).
+    const start = this.start + this.pos;
+    const out = new Uint8Array(this.u8.buffer.slice(start, start + len));
+    this.pos += len;
+    return out;
+  }
+
+  readArrayBuffer(len: number): ArrayBuffer {
+    this.boundsCheck(len);
+    const start = this.start + this.pos;
+    const out = (this.u8.buffer as ArrayBuffer).slice(start, start + len);
+    this.pos += len;
+    return out;
+  }
+
+  writeBytes(src: Uint8Array): void {
+    this.boundsCheck(src.byteLength);
+    this.u8.set(src, this.pos);
+    this.pos += src.byteLength;
+  }
+
+  private boundsCheck(n: number): void {
+    if (this.pos + n > this.end - this.start) {
+      throw new UniffiInternalError.BufferOverflow();
+    }
+  }
+}

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -3,8 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+import { Cursor } from "./cursor.ts";
 import { UniffiInternalError } from "./errors.ts";
-import { type UniffiByteArray, RustBuffer } from "./ffi-types.ts";
+import { type UniffiByteArray } from "./ffi-types.ts";
 
 // https://github.com/mozilla/uniffi-rs/blob/main/docs/manual/src/internals/lifting_and_lowering.md
 //
@@ -17,146 +18,120 @@ export type RustBufferAllocator = (n: number) => Uint8Array;
 export interface FfiConverter<FfiType, TsType> {
   lift(value: FfiType): TsType;
   lower(value: TsType, alloc: RustBufferAllocator): FfiType;
-  read(from: RustBuffer): TsType;
-  write(value: TsType, into: RustBuffer): void;
+  readFromCursor(c: Cursor): TsType;
+  writeIntoCursor(value: TsType, c: Cursor): void;
   allocationSize(value: TsType): number;
-}
-
-export abstract class FfiConverterPrimitive<T> implements FfiConverter<T, T> {
-  lift(value: T): T {
-    return value;
-  }
-  lower(value: T, _alloc: RustBufferAllocator): T {
-    return value;
-  }
-  abstract read(from: RustBuffer): T;
-  abstract write(value: T, into: RustBuffer): void;
-  abstract allocationSize(value: T): number;
 }
 
 export abstract class AbstractFfiConverterByteArray<TsType>
   implements FfiConverter<UniffiByteArray, TsType>
 {
   lift(value: UniffiByteArray): TsType {
-    const buffer = RustBuffer.fromUint8Array(value);
-    return this.read(buffer);
+    const c = Cursor.fromUint8Array(value);
+    return this.readFromCursor(c);
   }
   lower(value: TsType, alloc: RustBufferAllocator): UniffiByteArray {
     const view = alloc(this.allocationSize(value));
-    const buffer = RustBuffer.fromUint8Array(view);
-    this.write(value, buffer);
+    const c = Cursor.fromUint8Array(view);
+    this.writeIntoCursor(value, c);
     return view;
   }
-  abstract read(from: RustBuffer): TsType;
-  abstract write(value: TsType, into: RustBuffer): void;
+
+  abstract readFromCursor(c: Cursor): TsType;
+  abstract writeIntoCursor(value: TsType, c: Cursor): void;
   abstract allocationSize(value: TsType): number;
 }
 
-type NumberType = number | bigint;
-class FfiConverterNumber<
-  T extends NumberType,
-> extends FfiConverterPrimitive<T> {
-  // These fields should be private, but Typescript doesn't allow
-  // that because of the way they are exposed.
-  constructor(
-    public reader: (view: DataView) => T,
-    public writer: (view: DataView, value: T) => void,
-    public byteSize: number,
-  ) {
-    super();
-  }
-  read(from: RustBuffer): T {
-    return from.readWithView(this.byteSize, this.reader);
-  }
-  write(value: T, into: RustBuffer): void {
-    return into.writeWithView(this.byteSize, (view) =>
-      this.writer(view, value),
-    );
-  }
-  allocationSize(value: T): number {
-    return this.byteSize;
-  }
+/**
+ * Build a primitive `FfiConverter` whose hot path delegates straight into
+ * Cursor's monomorphic typed accessors. The returned object is a plain
+ * module-level value (not a class instance) — V8 can inline `lift`/`lower`
+ * trivially, and `readFromCursor`/`writeIntoCursor` are direct references
+ * to the Cursor method wrappers (no per-call function-pointer dispatch via
+ * the old `FfiConverterNumber(reader, writer, byteSize)` closure shape).
+ */
+function makePrimitive<T>(
+  read: (c: Cursor) => T,
+  write: (v: T, c: Cursor) => void,
+  byteSize: number,
+): FfiConverter<T, T> {
+  return {
+    lift: (v: T) => v,
+    lower: (v: T, _alloc: RustBufferAllocator) => v,
+    allocationSize: (_v: T) => byteSize,
+    readFromCursor: read,
+    writeIntoCursor: write,
+  };
 }
 
-const littleEndian = false;
-
 // Ints
-export const FfiConverterInt8 = new FfiConverterNumber(
-  (view: DataView) => view.getInt8(0),
-  (view: DataView, value: number) => view.setInt8(0, value),
-  Int8Array.BYTES_PER_ELEMENT,
+export const FfiConverterInt8 = makePrimitive<number>(
+  (c) => c.readI8(),
+  (v, c) => c.writeI8(v),
+  1,
 );
-export const FfiConverterInt16 = new FfiConverterNumber(
-  (view: DataView) => view.getInt16(0, littleEndian),
-  (view: DataView, value: number) => view.setInt16(0, value, littleEndian),
-  Int16Array.BYTES_PER_ELEMENT,
+export const FfiConverterInt16 = makePrimitive<number>(
+  (c) => c.readI16(),
+  (v, c) => c.writeI16(v),
+  2,
 );
-export const FfiConverterInt32 = new FfiConverterNumber(
-  (view: DataView) => view.getInt32(0, littleEndian),
-  (view: DataView, value: number) => view.setInt32(0, value, littleEndian),
-  Int32Array.BYTES_PER_ELEMENT,
+export const FfiConverterInt32 = makePrimitive<number>(
+  (c) => c.readI32(),
+  (v, c) => c.writeI32(v),
+  4,
 );
-export const FfiConverterInt64 = new FfiConverterNumber(
-  (view: DataView) => view.getBigInt64(0, littleEndian),
-  (view: DataView, value: bigint) => view.setBigInt64(0, value, littleEndian),
-  BigInt64Array.BYTES_PER_ELEMENT,
+export const FfiConverterInt64 = makePrimitive<bigint>(
+  (c) => c.readI64(),
+  (v, c) => c.writeI64(v),
+  8,
 );
 
 // Floats
-export const FfiConverterFloat32 = new FfiConverterNumber(
-  (view: DataView) => view.getFloat32(0, littleEndian),
-  (view: DataView, value: number) => view.setFloat32(0, value, littleEndian),
-  Float32Array.BYTES_PER_ELEMENT,
+export const FfiConverterFloat32 = makePrimitive<number>(
+  (c) => c.readF32(),
+  (v, c) => c.writeF32(v),
+  4,
 );
-export const FfiConverterFloat64 = new FfiConverterNumber(
-  (view: DataView) => view.getFloat64(0, littleEndian),
-  (view: DataView, value: number) => view.setFloat64(0, value, littleEndian),
-  Float64Array.BYTES_PER_ELEMENT,
+export const FfiConverterFloat64 = makePrimitive<number>(
+  (c) => c.readF64(),
+  (v, c) => c.writeF64(v),
+  8,
 );
 
 // UInts
-export const FfiConverterUInt8 = new FfiConverterNumber(
-  (view: DataView) => view.getUint8(0),
-  (view: DataView, value: number) => view.setUint8(0, value),
-  Uint8Array.BYTES_PER_ELEMENT,
+export const FfiConverterUInt8 = makePrimitive<number>(
+  (c) => c.readU8(),
+  (v, c) => c.writeU8(v),
+  1,
 );
-export const FfiConverterUInt16 = new FfiConverterNumber(
-  (view: DataView) => view.getUint16(0, littleEndian),
-  (view: DataView, value: number) => view.setUint16(0, value, littleEndian),
-  Uint16Array.BYTES_PER_ELEMENT,
+export const FfiConverterUInt16 = makePrimitive<number>(
+  (c) => c.readU16(),
+  (v, c) => c.writeU16(v),
+  2,
 );
-export const FfiConverterUInt32 = new FfiConverterNumber(
-  (view: DataView) => view.getUint32(0, littleEndian),
-  (view: DataView, value: number) => view.setUint32(0, value, littleEndian),
-  Uint32Array.BYTES_PER_ELEMENT,
+export const FfiConverterUInt32 = makePrimitive<number>(
+  (c) => c.readU32(),
+  (v, c) => c.writeU32(v),
+  4,
 );
-export const FfiConverterUInt64 = new FfiConverterNumber(
-  (view: DataView) => view.getBigUint64(0, littleEndian),
-  (view: DataView, value: bigint) => view.setBigUint64(0, value, littleEndian),
-  BigUint64Array.BYTES_PER_ELEMENT,
+export const FfiConverterUInt64 = makePrimitive<bigint>(
+  (c) => c.readU64(),
+  (v, c) => c.writeU64(v),
+  8,
 );
 
-// Bool
+// Bool — separate from `makePrimitive` because lift/lower convert between
+// the on-the-wire `number` and JS `boolean` rather than passing through.
 export const FfiConverterBool = (() => {
-  const byteConverter = FfiConverterInt8;
-  class FfiConverterBool implements FfiConverter<number, boolean> {
-    lift(value: number): boolean {
-      return !!value;
-    }
-    lower(value: boolean, _alloc: RustBufferAllocator): number {
-      return value ? 1 : 0;
-    }
-    read(from: RustBuffer): boolean {
-      return this.lift(byteConverter.read(from));
-    }
-    write(value: boolean, into: RustBuffer): void {
-      byteConverter.write(value ? 1 : 0, into);
-    }
-    allocationSize(value: boolean): number {
-      return byteConverter.allocationSize(0);
-    }
-  }
-  return new FfiConverterBool();
+  const read = (c: Cursor) => c.readBool();
+  const write = (v: boolean, c: Cursor) => c.writeBool(v);
+  return {
+    lift: (n: number) => !!n,
+    lower: (b: boolean, _alloc: RustBufferAllocator) => (b ? 1 : 0),
+    allocationSize: (_v: boolean) => 1,
+    readFromCursor: read,
+    writeIntoCursor: write,
+  } satisfies FfiConverter<number, boolean>;
 })();
 
 // Duration
@@ -167,32 +142,27 @@ export const FfiConverterBool = (() => {
 // and switch on from a config file.
 export type UniffiDuration = number;
 export const FfiConverterDuration = (() => {
-  const secondsConverter = FfiConverterUInt64;
-  const nanosConverter = FfiConverterUInt32;
   const msPerSecBigInt = BigInt("1000");
   const nanosPerMs = 1e6;
   class FFIConverter extends AbstractFfiConverterByteArray<UniffiDuration> {
-    read(from: RustBuffer): UniffiDuration {
-      const secsBigInt = secondsConverter.read(from);
-      const nanos = nanosConverter.read(from);
+    readFromCursor(c: Cursor): UniffiDuration {
+      const secsBigInt = c.readU64();
+      const nanos = c.readU32();
       const ms = Number(secsBigInt * msPerSecBigInt);
       if (ms === Number.POSITIVE_INFINITY || ms === Number.NEGATIVE_INFINITY) {
         throw new UniffiInternalError.NumberOverflow();
       }
       return ms + nanos / nanosPerMs;
     }
-    write(value: UniffiDuration, into: RustBuffer): void {
+    writeIntoCursor(value: UniffiDuration, c: Cursor): void {
       const ms = value.valueOf();
       const secsBigInt = BigInt(Math.trunc(ms)) / msPerSecBigInt;
       const remainingNanos = (ms % 1000) * nanosPerMs;
-      secondsConverter.write(secsBigInt, into);
-      nanosConverter.write(remainingNanos, into);
+      c.writeU64(secsBigInt);
+      c.writeU32(remainingNanos);
     }
     allocationSize(_value: UniffiDuration): number {
-      return (
-        secondsConverter.allocationSize(msPerSecBigInt) +
-        nanosConverter.allocationSize(0)
-      );
+      return 12;
     }
   }
   return new FFIConverter();
@@ -202,12 +172,9 @@ export const FfiConverterDuration = (() => {
 // and switch on from a config file.
 export type UniffiTimestamp = Date;
 export const FfiConverterTimestamp = (() => {
-  const secondsConverter = FfiConverterInt64;
-  const nanosConverter = FfiConverterUInt32;
   const msPerSecBigInt = BigInt("1000");
   const nanosPerMs = 1e6;
   const msPerSec = 1e3;
-  const maxMsFromEpoch = 8.64e15;
   function safeDate(ms: number) {
     if (Math.abs(ms) > 8.64e15) {
       throw new UniffiInternalError.DateTimeOverflow();
@@ -216,9 +183,9 @@ export const FfiConverterTimestamp = (() => {
   }
 
   class FFIConverter extends AbstractFfiConverterByteArray<UniffiTimestamp> {
-    read(from: RustBuffer): UniffiTimestamp {
-      const secsBigInt = secondsConverter.read(from);
-      const nanos = nanosConverter.read(from);
+    readFromCursor(c: Cursor): UniffiTimestamp {
+      const secsBigInt = c.readI64();
+      const nanos = c.readU32();
       const ms = Number(secsBigInt * msPerSecBigInt);
       if (ms >= 0) {
         return safeDate(ms + nanos / nanosPerMs);
@@ -226,18 +193,15 @@ export const FfiConverterTimestamp = (() => {
         return safeDate(ms - nanos / nanosPerMs);
       }
     }
-    write(value: UniffiTimestamp, into: RustBuffer): void {
+    writeIntoCursor(value: UniffiTimestamp, c: Cursor): void {
       const ms = value.valueOf();
       const secsBigInt = BigInt(Math.trunc(ms / msPerSec));
       const remainingNanos = Math.abs((ms % msPerSec) * nanosPerMs);
-      secondsConverter.write(secsBigInt, into);
-      nanosConverter.write(remainingNanos, into);
+      c.writeI64(secsBigInt);
+      c.writeU32(remainingNanos);
     }
     allocationSize(_value: UniffiTimestamp): number {
-      return (
-        secondsConverter.allocationSize(msPerSecBigInt) +
-        nanosConverter.allocationSize(0)
-      );
+      return 12;
     }
   }
   return new FFIConverter();
@@ -246,54 +210,50 @@ export const FfiConverterTimestamp = (() => {
 export class FfiConverterOptional<Item> extends AbstractFfiConverterByteArray<
   Item | undefined
 > {
-  private static flagConverter = FfiConverterBool;
   constructor(private itemConverter: FfiConverter<any, Item>) {
     super();
   }
-  read(from: RustBuffer): Item | undefined {
-    const flag = FfiConverterOptional.flagConverter.read(from);
-    return flag ? this.itemConverter.read(from) : undefined;
+  readFromCursor(c: Cursor): Item | undefined {
+    const tag = c.readU8();
+    return tag === 0 ? undefined : this.itemConverter.readFromCursor(c);
   }
-  write(value: Item | undefined, into: RustBuffer): void {
-    if (value !== undefined) {
-      FfiConverterOptional.flagConverter.write(true, into);
-      this.itemConverter.write(value!, into);
-    } else {
-      FfiConverterOptional.flagConverter.write(false, into);
+  writeIntoCursor(value: Item | undefined, c: Cursor): void {
+    if (value === undefined) {
+      c.writeU8(0);
+      return;
     }
+    c.writeU8(1);
+    this.itemConverter.writeIntoCursor(value, c);
   }
   allocationSize(value: Item | undefined): number {
-    let size = FfiConverterOptional.flagConverter.allocationSize(true);
-    if (value !== undefined) {
-      size += this.itemConverter.allocationSize(value);
-    }
-    return size;
+    return (
+      1 + (value === undefined ? 0 : this.itemConverter.allocationSize(value))
+    );
   }
 }
 
 export class FfiConverterArray<Item> extends AbstractFfiConverterByteArray<
   Array<Item>
 > {
-  private static sizeConverter = FfiConverterInt32;
   constructor(private itemConverter: FfiConverter<any, Item>) {
     super();
   }
-  read(from: RustBuffer): Array<Item> {
-    const size = FfiConverterArray.sizeConverter.read(from);
+  readFromCursor(c: Cursor): Array<Item> {
+    const size = c.readI32();
     const array = new Array<Item>(size);
     for (let i = 0; i < size; i++) {
-      array[i] = this.itemConverter.read(from);
+      array[i] = this.itemConverter.readFromCursor(c);
     }
     return array;
   }
-  write(array: Array<Item>, into: RustBuffer): void {
-    FfiConverterArray.sizeConverter.write(array.length, into);
+  writeIntoCursor(array: Array<Item>, c: Cursor): void {
+    c.writeI32(array.length);
     for (const item of array) {
-      this.itemConverter.write(item, into);
+      this.itemConverter.writeIntoCursor(item, c);
     }
   }
   allocationSize(array: Array<Item>): number {
-    let size = FfiConverterArray.sizeConverter.allocationSize(array.length);
+    let size = 4;
     for (const item of array) {
       size += this.itemConverter.allocationSize(item);
     }
@@ -304,30 +264,32 @@ export class FfiConverterArray<Item> extends AbstractFfiConverterByteArray<
 export class FfiConverterMap<K, V> extends AbstractFfiConverterByteArray<
   Map<K, V>
 > {
-  private static sizeConverter = FfiConverterInt32;
   constructor(
     private keyConverter: FfiConverter<any, K>,
     private valueConverter: FfiConverter<any, V>,
   ) {
     super();
   }
-  read(from: RustBuffer): Map<K, V> {
-    const size = FfiConverterMap.sizeConverter.read(from);
-    const map = new Map();
+  readFromCursor(c: Cursor): Map<K, V> {
+    const size = c.readI32();
+    const map = new Map<K, V>();
     for (let i = 0; i < size; i++) {
-      map.set(this.keyConverter.read(from), this.valueConverter.read(from));
+      map.set(
+        this.keyConverter.readFromCursor(c),
+        this.valueConverter.readFromCursor(c),
+      );
     }
     return map;
   }
-  write(map: Map<K, V>, into: RustBuffer): void {
-    FfiConverterMap.sizeConverter.write(map.size, into);
+  writeIntoCursor(map: Map<K, V>, c: Cursor): void {
+    c.writeI32(map.size);
     for (const [k, v] of map.entries()) {
-      this.keyConverter.write(k, into);
-      this.valueConverter.write(v, into);
+      this.keyConverter.writeIntoCursor(k, c);
+      this.valueConverter.writeIntoCursor(v, c);
     }
   }
   allocationSize(map: Map<K, V>): number {
-    let size = FfiConverterMap.sizeConverter.allocationSize(map.size);
+    let size = 4;
     for (const [k, v] of map.entries()) {
       size +=
         this.keyConverter.allocationSize(k) +
@@ -338,38 +300,34 @@ export class FfiConverterMap<K, V> extends AbstractFfiConverterByteArray<
 }
 
 export const FfiConverterArrayBuffer = (() => {
-  const lengthConverter = FfiConverterInt32;
   class FFIConverter extends AbstractFfiConverterByteArray<ArrayBuffer> {
-    read(from: RustBuffer): ArrayBuffer {
-      const length = lengthConverter.read(from);
-      return from.readArrayBuffer(length);
+    readFromCursor(c: Cursor): ArrayBuffer {
+      const length = c.readI32();
+      return c.readArrayBuffer(length);
     }
-    write(value: ArrayBuffer, into: RustBuffer): void {
-      const length = value.byteLength;
-      lengthConverter.write(length, into);
-      into.writeByteArray(new Uint8Array(value));
+    writeIntoCursor(value: ArrayBuffer, c: Cursor): void {
+      c.writeI32(value.byteLength);
+      c.writeBytes(new Uint8Array(value));
     }
     allocationSize(value: ArrayBuffer): number {
-      return lengthConverter.allocationSize(0) + value.byteLength;
+      return 4 + value.byteLength;
     }
   }
   return new FFIConverter();
 })();
 
 export const FfiConverterUint8Array = (() => {
-  const lengthConverter = FfiConverterInt32;
   class FFIConverter extends AbstractFfiConverterByteArray<Uint8Array> {
-    read(from: RustBuffer): Uint8Array {
-      const length = lengthConverter.read(from);
-      return new Uint8Array(from.readArrayBuffer(length));
+    readFromCursor(c: Cursor): Uint8Array {
+      const length = c.readI32();
+      return c.readBytes(length);
     }
-    write(value: Uint8Array, into: RustBuffer): void {
-      const length = value.byteLength;
-      lengthConverter.write(length, into);
-      into.writeByteArray(value);
+    writeIntoCursor(value: Uint8Array, c: Cursor): void {
+      c.writeI32(value.byteLength);
+      c.writeBytes(value);
     }
     allocationSize(value: Uint8Array): number {
-      return lengthConverter.allocationSize(0) + value.byteLength;
+      return 4 + value.byteLength;
     }
   }
   return new FFIConverter();
@@ -394,8 +352,6 @@ type StringConverter = {
 export function uniffiCreateFfiConverterString(
   converter: StringConverter,
 ): FfiConverter<UniffiByteArray, string> {
-  const lengthConverter = FfiConverterInt32;
-
   class FFIConverter implements FfiConverter<UniffiByteArray, string> {
     lift(value: UniffiByteArray): string {
       return converter.bytesToString(value);
@@ -403,45 +359,50 @@ export function uniffiCreateFfiConverterString(
     lower(value: string, _alloc: RustBufferAllocator): UniffiByteArray {
       return converter.stringToBytes(value);
     }
-    read(from: RustBuffer): string {
-      const length = lengthConverter.read(from);
+    readFromCursor(c: Cursor): string {
+      const length = c.readI32();
       if (converter.readStringFromBuffer) {
-        // Read directly from the RustBuffer's backing ArrayBuffer — zero copy.
-        const offset = from.advanceReadOffset(length);
-        return converter.readStringFromBuffer(from, offset, length);
+        // Read directly from the cursor's backing ArrayBuffer — zero copy.
+        // The helper takes an object with an `arrayBuffer` property plus an
+        // absolute offset and length; for Cursor that's `u8.buffer` and
+        // `start + pos`.
+        const buf: any = { arrayBuffer: (c as any).u8.buffer };
+        const offset = (c as any).start + (c as any).pos;
+        (c as any).pos += length;
+        return converter.readStringFromBuffer(buf, offset, length);
       }
-      const bytes = from.readByteArray(length);
+      const bytes = c.readBytes(length);
       return converter.bytesToString(bytes);
     }
-    write(value: string, into: RustBuffer): void {
+    writeIntoCursor(value: string, c: Cursor): void {
       if (converter.writeStringIntoBuffer) {
-        // Encode the string first, then backfill the i32 length prefix with
-        // the actual byte count. Skips one `stringByteLength` measurement
-        // call per string compared to the writeByteArray path below.
-        const lengthOffset = into.advanceWriteOffset(4);
-        const dataOffset = lengthOffset + 4;
+        // Encode the string into the buffer at the data offset (after the
+        // i32 length prefix), then backfill the length prefix with the
+        // actual bytes written. Skips one `stringByteLength` measurement
+        // call per string compared to the writeBytes path below.
+        const lengthPos = (c as any).pos;
+        // Reserve 4 bytes for the length prefix.
+        (c as any).pos += 4;
+        const dataOffset = (c as any).start + (c as any).pos;
+        // Synthetic buf with the cursor's underlying ArrayBuffer; helpers
+        // use `buf.arrayBuffer` to construct a Uint8Array view.
+        const buf: any = { arrayBuffer: (c as any).u8.buffer };
         const bytesWritten = converter.writeStringIntoBuffer(
           value,
-          into,
+          buf,
           dataOffset,
         );
-        new DataView(into.arrayBuffer, lengthOffset, 4).setInt32(
-          0,
-          bytesWritten,
-          false,
-        );
-        into.setWriteOffset(dataOffset + bytesWritten);
+        // Backfill the length prefix (big-endian i32, matches Cursor.writeI32).
+        (c as any).dv.setInt32(lengthPos, bytesWritten);
+        (c as any).pos += bytesWritten;
         return;
       }
       const bytes = converter.stringToBytes(value);
-      const numBytes = bytes.byteLength;
-      lengthConverter.write(numBytes, into);
-      into.writeByteArray(bytes);
+      c.writeI32(bytes.byteLength);
+      c.writeBytes(bytes);
     }
     allocationSize(value: string): number {
-      return (
-        lengthConverter.allocationSize(0) + converter.stringByteLength(value)
-      );
+      return 4 + converter.stringByteLength(value);
     }
   }
   return new FFIConverter();

--- a/typescript/src/ffi-types.ts
+++ b/typescript/src/ffi-types.ts
@@ -37,9 +37,31 @@ export class RustBuffer {
   }
 
   /**
+   * Construct a RustBuffer that reads/writes directly out of a
+   * `WebAssembly.Memory` backing buffer, with `readOffset`/`writeOffset`
+   * pre-positioned at `dataPtr`. Allows record lift/lower to skip the
+   * intermediate `Uint8Array` copy. The caller is responsible for the
+   * buffer remaining attached for the duration of any read/write.
+   */
+  static fromWasmMemory(
+    memoryBuffer: ArrayBuffer,
+    dataPtr: number,
+    len: number,
+  ): RustBuffer {
+    const buf = new RustBuffer(memoryBuffer);
+    // The reader/writer offset machinery uses absolute offsets into the
+    // backing buffer; treat `dataPtr` as the start of the slice and
+    // `dataPtr + len` as its end.
+    buf.readOffset = dataPtr;
+    buf.writeOffset = dataPtr;
+    buf.capacity = dataPtr + len;
+    return buf;
+  }
+
+  /**
    * Construct a `RustBuffer` over a `Uint8Array` view. Cursors track absolute
    * offsets into the backing `ArrayBuffer`, so `byteOffset` and `byteLength`
-   * delimit the readable/writable region.
+   * delimit the readable/writable region. Generalises `fromWasmMemory`.
    */
   static fromUint8Array(view: UniffiByteArray): RustBuffer {
     const buf = new RustBuffer(view.buffer as ArrayBuffer);
@@ -90,23 +112,6 @@ export class RustBuffer {
     const dest = new Uint8Array(this.arrayBuffer, start);
     dest.set(src);
 
-    this.writeOffset = end;
-  }
-
-  readWithView<T>(numBytes: number, reader: (view: DataView) => T): T {
-    const start = this.readOffset;
-    const end = this.checkOverflow(start, numBytes);
-    const view = new DataView(this.arrayBuffer, start, numBytes);
-    const value = reader(view);
-    this.readOffset = end;
-    return value as T;
-  }
-
-  writeWithView(numBytes: number, writer: (view: DataView) => void) {
-    const start = this.writeOffset;
-    const end = this.checkOverflow(start, numBytes);
-    const view = new DataView(this.arrayBuffer, start, numBytes);
-    writer(view);
     this.writeOffset = end;
   }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -9,6 +9,7 @@
 export * from "./async-callbacks.ts";
 export * from "./async-rust-call.ts";
 export * from "./callbacks.ts";
+export * from "./cursor.ts";
 export * from "./enums.ts";
 export * from "./errors.ts";
 export * from "./ffi-converters.ts";

--- a/typescript/src/objects.ts
+++ b/typescript/src/objects.ts
@@ -4,16 +4,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+import { Cursor } from "./cursor.ts";
 import {
   AbstractFfiConverterByteArray,
   type FfiConverter,
   FfiConverterUInt64,
   type RustBufferAllocator,
 } from "./ffi-converters.ts";
-import { RustBuffer } from "./ffi-types.ts";
 import type { UniffiGcObject } from "./rust-call.ts";
 import { type UniffiHandle, UniffiHandleMap } from "./handle-map.ts";
-import { UniffiInternalError, UniffiThrownObject } from "./errors.ts";
+import { UniffiThrownObject } from "./errors.ts";
 
 /**
  * Marker interface for all `interface` objects that cross the FFI.
@@ -59,7 +59,7 @@ export interface UniffiObjectFactory<T> {
   isConcreteType(obj: any): obj is T;
 }
 
-const pointerConverter: FfiConverter<any, UniffiHandle> = FfiConverterUInt64;
+const pointerConverter = FfiConverterUInt64;
 const dummyPointer: UniffiHandle = BigInt("0");
 
 /**
@@ -74,11 +74,11 @@ export class FfiConverterObject<T> implements FfiConverter<UniffiHandle, T> {
   lower(value: T, _alloc: RustBufferAllocator): UniffiHandle {
     return this.lowerHandle(value);
   }
-  read(from: RustBuffer): T {
-    return this.lift(pointerConverter.read(from));
+  readFromCursor(c: Cursor): T {
+    return this.lift(pointerConverter.readFromCursor(c));
   }
-  write(value: T, into: RustBuffer): void {
-    pointerConverter.write(this.lowerHandle(value), into);
+  writeIntoCursor(value: T, c: Cursor): void {
+    pointerConverter.writeIntoCursor(this.lowerHandle(value), c);
   }
   protected lowerHandle(value: T): UniffiHandle {
     if (this.factory.isConcreteType(value)) {
@@ -142,13 +142,13 @@ export class FfiConverterObjectAsError<T> extends AbstractFfiConverterByteArray<
   ) {
     super();
   }
-  read(from: RustBuffer): UniffiThrownObject<T> {
-    const obj = this.innerConverter.read(from);
+  readFromCursor(c: Cursor): UniffiThrownObject<T> {
+    const obj = this.innerConverter.readFromCursor(c);
     return new UniffiThrownObject(this.typeName, obj);
   }
-  write(value: UniffiThrownObject<T>, into: RustBuffer): void {
+  writeIntoCursor(value: UniffiThrownObject<T>, c: Cursor): void {
     const obj = value.inner;
-    this.innerConverter.write(obj, into);
+    this.innerConverter.writeIntoCursor(obj, c);
   }
   allocationSize(value: UniffiThrownObject<T>): number {
     return this.innerConverter.allocationSize(value.inner);

--- a/typescript/tests/cursor.test.ts
+++ b/typescript/tests/cursor.test.ts
@@ -1,0 +1,121 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { Cursor } from "../src/cursor";
+import { test } from "../testing/asserts";
+
+test("Cursor: u8/i8 round-trip at boundaries", (t) => {
+  const buf = new ArrayBuffer(8);
+  const w = new Cursor(buf, 0, 8);
+  w.writeU8(0);
+  w.writeU8(255);
+  w.writeI8(-128);
+  w.writeI8(127);
+  const r = new Cursor(buf, 0, 8);
+  t.assertEqual(r.readU8(), 0);
+  t.assertEqual(r.readU8(), 255);
+  t.assertEqual(r.readI8(), -128);
+  t.assertEqual(r.readI8(), 127);
+});
+
+test("Cursor: u32/i32 big-endian round-trip", (t) => {
+  const buf = new ArrayBuffer(16);
+  const w = new Cursor(buf, 0, 16);
+  w.writeU32(0xdeadbeef);
+  w.writeI32(-2_147_483_648);
+  w.writeI32(2_147_483_647);
+  w.writeU32(0);
+  const r = new Cursor(buf, 0, 16);
+  t.assertEqual(r.readU32(), 0xdeadbeef);
+  t.assertEqual(r.readI32(), -2_147_483_648);
+  t.assertEqual(r.readI32(), 2_147_483_647);
+  t.assertEqual(r.readU32(), 0);
+});
+
+test("Cursor: u64/i64 bigint round-trip", (t) => {
+  // ts target is es5 in the test harness, so use BigInt() instead of `n` literals.
+  const U64_MAX = BigInt("0xffffffffffffffff");
+  const I64_MIN = BigInt("-9223372036854775808");
+  const I64_MAX = BigInt("9223372036854775807");
+  const ZERO = BigInt(0);
+  const buf = new ArrayBuffer(32);
+  const w = new Cursor(buf, 0, 32);
+  w.writeU64(U64_MAX);
+  w.writeI64(I64_MIN);
+  w.writeI64(I64_MAX);
+  w.writeU64(ZERO);
+  const r = new Cursor(buf, 0, 32);
+  t.assertEqual(r.readU64(), U64_MAX);
+  t.assertEqual(r.readI64(), I64_MIN);
+  t.assertEqual(r.readI64(), I64_MAX);
+  t.assertEqual(r.readU64(), ZERO);
+});
+
+test("Cursor: f32/f64 round-trip", (t) => {
+  const buf = new ArrayBuffer(12);
+  const w = new Cursor(buf, 0, 12);
+  w.writeF32(1.5);
+  w.writeF64(Math.PI);
+  const r = new Cursor(buf, 0, 12);
+  t.assertEqual(r.readF32(), 1.5);
+  t.assertEqual(r.readF64(), Math.PI);
+});
+
+test("Cursor: bool maps to 0/1 bytes", (t) => {
+  const buf = new ArrayBuffer(2);
+  const w = new Cursor(buf, 0, 2);
+  w.writeBool(true);
+  w.writeBool(false);
+  const r = new Cursor(buf, 0, 2);
+  t.assertEqual(r.readBool(), true);
+  t.assertEqual(r.readBool(), false);
+});
+
+test("Cursor: readBytes returns a fresh copy, not an alias", (t) => {
+  const buf = new ArrayBuffer(8);
+  new Uint8Array(buf).set([1, 2, 3, 4, 5, 6, 7, 8]);
+  const r = new Cursor(buf, 2, 4); // window from offset 2, 4 bytes
+  const bytes = r.readBytes(4);
+  t.assertEqual(Array.from(bytes), [3, 4, 5, 6]);
+  // mutating the original buffer doesn't affect the returned bytes
+  new Uint8Array(buf).fill(0);
+  t.assertEqual(Array.from(bytes), [3, 4, 5, 6]);
+});
+
+test("Cursor: writeBytes copies src into the cursor's region", (t) => {
+  const buf = new ArrayBuffer(8);
+  const w = new Cursor(buf, 1, 4);
+  w.writeBytes(new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]));
+  t.assertEqual(
+    Array.from(new Uint8Array(buf)),
+    [0, 0xaa, 0xbb, 0xcc, 0xdd, 0, 0, 0],
+  );
+});
+
+test("Cursor: skip advances pos without reading", (t) => {
+  const buf = new ArrayBuffer(8);
+  new Uint8Array(buf).set([0, 0, 0, 0, 0x42, 0, 0, 0]);
+  const r = new Cursor(buf, 0, 8);
+  r.skip(4);
+  t.assertEqual(r.readU8(), 0x42);
+});
+
+test("Cursor: remaining() reports unread bytes", (t) => {
+  const buf = new ArrayBuffer(8);
+  const r = new Cursor(buf, 0, 8);
+  t.assertEqual(r.remaining(), 8);
+  r.readU32();
+  t.assertEqual(r.remaining(), 4);
+});
+
+test("Cursor: throws on read past end", (t) => {
+  const buf = new ArrayBuffer(4);
+  const r = new Cursor(buf, 0, 4);
+  r.readU32();
+  t.assertThrows(
+    (e) => e instanceof Error,
+    () => r.readU8(),
+  );
+});

--- a/typescript/tests/ffi-converters.test.ts
+++ b/typescript/tests/ffi-converters.test.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-import { RustBuffer } from "../src/ffi-types";
+import { Cursor } from "../src/cursor";
 import {
   FfiConverter,
   FfiConverterArray,
@@ -13,7 +13,6 @@ import {
   FfiConverterInt32,
   FfiConverterInt8,
   FfiConverterOptional,
-  FfiConverterPrimitive,
   FfiConverterUInt16,
   FfiConverterUInt8,
   FfiConverterUint8Array,
@@ -26,11 +25,11 @@ class TestConverter<R extends any, T> extends AbstractFfiConverterByteArray<T> {
   constructor(public inner: FfiConverter<R, T>) {
     super();
   }
-  read(from: RustBuffer): T {
-    return this.inner.read(from);
+  readFromCursor(c: Cursor): T {
+    return this.inner.readFromCursor(c);
   }
-  write(value: T, into: RustBuffer): void {
-    return this.inner.write(value, into);
+  writeIntoCursor(value: T, c: Cursor): void {
+    return this.inner.writeIntoCursor(value, c);
   }
   allocationSize(value: T): number {
     return this.inner.allocationSize(value);

--- a/typescript/tests/ffi-types.test.ts
+++ b/typescript/tests/ffi-types.test.ts
@@ -4,7 +4,38 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 import { RustBuffer } from "../src/ffi-types";
-import { test } from "../testing/asserts";
+import { test, xtest } from "../testing/asserts";
+
+// `WebAssembly` is not in scope in Hermes (Jsi runtime); access it through
+// `globalThis` so the test source compiles on every flavor and we can skip
+// the body where the API is missing.
+const WA: any = (globalThis as any).WebAssembly;
+const itTest = WA !== undefined ? test : xtest;
+
+itTest(
+  "RustBuffer.fromWasmMemory reads from a wasm-memory-backed slice",
+  (t) => {
+    const wm = new WA.Memory({ initial: 1 });
+    const view = new Uint8Array(wm.buffer);
+    view[100] = 0xab;
+    view[101] = 0xcd;
+
+    const rb = RustBuffer.fromWasmMemory(wm.buffer, 100, 2);
+    const readBack = rb.readByteArray(2);
+    t.assertEqual(Array.from(readBack), [0xab, 0xcd]);
+  },
+);
+
+itTest("RustBuffer.fromWasmMemory writes through to wasm memory", (t) => {
+  const wm = new WA.Memory({ initial: 1 });
+  const rb = RustBuffer.fromWasmMemory(wm.buffer, 200, 3);
+  rb.writeByteArray(new Uint8Array([0x01, 0x02, 0x03]));
+
+  const view = new Uint8Array(wm.buffer);
+  t.assertEqual(view[200], 0x01);
+  t.assertEqual(view[201], 0x02);
+  t.assertEqual(view[202], 0x03);
+});
 
 test("RustBuffer.fromUint8Array honours non-zero byteOffset", (t) => {
   const backing = new ArrayBuffer(64);


### PR DESCRIPTION
This is for a micro-performance gain; gene-transfused from uniffi-bindgen-js.

This designed to help cases where there is many small read/writes in the lowering/lifting, so large, deeply nested records, recursive enums etc.

This helps all backends.