### PR TITLE
fix(napi): support runtimes without external ArrayBuffers

### DIFF
--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -172,37 +172,37 @@ pub(crate) fn call_ffi_function(
     }
 
     match &call_ret {
-        CallReturn::RustBuffer(rb) => {
-            rust_buffer_to_js_uint8array_handoff(env, *rb, capacity_symbol)
-        }
+        CallReturn::RustBuffer(rb) => rust_buffer_to_js_uint8array_handoff(
+            env,
+            *rb,
+            module.rb_ops().free_ptr,
+            capacity_symbol,
+        ),
         _ => marshal::read_return_to_js(env, &call_ret),
     }
 }
 
-/// Hand a returned `RustBufferC` to JS as a `Uint8Array` view aliasing the
-/// Rust-owned bytes — no boundary copy. The codegen-emitted lift wrapper is
-/// expected to call `converter.lift(view)` inside a `try/finally` and invoke
-/// the runtime's `rustbuffer_free(view)` afterwards. The single mandatory copy
-/// now happens inside `lift()` itself (via `dest.set(view)` for byte arrays,
-/// `TextDecoder.decode` for strings, field-by-field reads for composites).
+/// Hand a returned `RustBufferC` to JS as a `Uint8Array`.
 ///
-/// The view's `byteLength` is `rb.len` (so string/raw-byte-array converters
-/// that decode the whole view see only the message bytes). Rust may have
-/// allocated `rb.capacity > rb.len` bytes, so we stash `capacity` on the view
-/// via the runtime's per-registration capacity Symbol; the runtime's
-/// `rustbuffer_free` reads it back when releasing the allocation.
+/// Node gets a zero-copy view over the Rust-owned bytes. Runtimes that reject
+/// external ArrayBuffers, including Electron with V8's memory cage, get a
+/// copied V8-owned view instead. The codegen-emitted lift wrapper calls
+/// `rustbuffer_free(view)` in both cases; copied views carry a zero-capacity
+/// marker that makes that call a no-op because Rust was already freed.
 ///
 /// On any error in the handoff, we free the buffer to avoid leaking the
 /// Rust-side allocation.
 fn rust_buffer_to_js_uint8array_handoff(
     env: &napi::Env,
     rb: RustBufferC,
+    rb_free_ptr: *const c_void,
     capacity_symbol: &CapacitySymbol,
 ) -> Result<JsUnknown> {
     let raw_env = env.raw();
     let len = match usize::try_from(rb.len) {
         Ok(n) => n,
         Err(_) => {
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
             return Err(napi::Error::from_reason(
                 "RustBuffer len exceeds addressable memory",
             ));
@@ -218,18 +218,43 @@ fn rust_buffer_to_js_uint8array_handoff(
     }
 
     // SAFETY: `rb.data` points to a Rust-owned allocation of at least `len`
-    // bytes. We expose it to JS without a finalizer; the codegen-emitted
-    // try/finally calls `rustbuffer_free(view)` which will hand the (ptr,
-    // capacity) tuple back to the library's `rustbuffer_free`.
-    let typedarray = unsafe { napi_utils::create_external_uint8array(raw_env, rb.data, len)? };
-
-    // If `capacity > len`, the view's `byteLength` (== len) under-reports the
-    // allocation size. Stash the true capacity so `rustbuffer_free(view)` can
-    // free against the original `Layout`. When `capacity == len`, the runtime
-    // can recover capacity from `byteLength`, so we skip the property write.
-    if rb.capacity != rb.len {
-        unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity)? };
-    }
+    // bytes. When the runtime supports external buffers, expose it to JS
+    // without a copy and let the generated finally block release it.
+    let typedarray = match unsafe {
+        napi_utils::try_create_external_uint8array(raw_env, rb.data, len)
+    } {
+        Ok(Some(typedarray)) => {
+            // If `capacity > len`, the view's `byteLength` under-reports the
+            // allocation size. Stash the true capacity for `rustbuffer_free`.
+            if rb.capacity != rb.len {
+                if let Err(error) = unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity) }
+                {
+                    unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+                    return Err(error);
+                }
+            }
+            typedarray
+        }
+        Ok(None) => {
+            // Electron's V8 memory cage forbids external ArrayBuffers. Copy
+            // into V8-owned memory, release the Rust allocation now, and mark
+            // the view so the generated `rustbuffer_free(view)` becomes a no-op.
+            let copied = match unsafe { napi_utils::create_uint8array(raw_env, rb.data, len) } {
+                Ok(copied) => copied,
+                Err(error) => {
+                    unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+                    return Err(error);
+                }
+            };
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+            unsafe { capacity_symbol.set(raw_env, copied, 0)? };
+            copied
+        }
+        Err(error) => {
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+            return Err(error);
+        }
+    };
 
     Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? })
 }

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -35,7 +35,8 @@ use uniffi_runtime_core::ffi_c_types::{
 /// underlying RustBuffer capacity on a lift-handoff `Uint8Array`. The view's
 /// `byteLength` is set to `len` so converters that decode the whole view
 /// (strings, raw byte arrays) see only the message bytes — but the global
-/// allocator needs `capacity` to free correctly when `capacity > len`. The
+/// allocator needs `capacity` to free correctly when `capacity > len`. A zero
+/// capacity marks a copied, V8-owned fallback that Rust already released. The
 /// symbol is created once when the module registers and lives as long as the
 /// JS-side module facade.
 pub struct CapacitySymbol {
@@ -366,23 +367,27 @@ pub unsafe fn rustbuffer_alloc(
     Ok(rb)
 }
 
-/// Wrap externally-managed memory as a JS `Uint8Array` (via napi external ArrayBuffer).
+/// Try to wrap externally-managed memory as a JS `Uint8Array`.
 ///
 /// Unlike [`create_uint8array`], this **does not copy**: the returned typed array is a
 /// view directly over `data`. The caller is responsible for keeping the memory alive
 /// for as long as JS holds the view—we pass a no-op finalizer because the codegen-emitted
 /// wrapper drops the JS reference before the corresponding `rustbuffer_free` runs.
 ///
+/// Returns `Ok(None)` when the runtime forbids external buffers, as Electron does when
+/// V8's memory cage is enabled. Callers must fall back to a copied, V8-owned buffer and
+/// release the Rust allocation themselves.
+///
 /// # Safety
 ///
 /// - `raw_env` must be a valid `napi_env` for the current callback scope.
 /// - `data` must point to at least `len` readable+writable bytes that remain alive
 ///   for the lifetime of the returned typed array (ignored when `len == 0`).
-pub unsafe fn create_external_uint8array(
+pub unsafe fn try_create_external_uint8array(
     raw_env: napi::sys::napi_env,
     data: *mut u8,
     len: usize,
-) -> napi::Result<napi::sys::napi_value> {
+) -> napi::Result<Option<napi::sys::napi_value>> {
     // No-op finalizer: ownership stays with the Rust library; codegen will call
     // `rustbuffer_free` explicitly. Using `napi_create_external_arraybuffer` with
     // a null finalizer is technically permitted, but napi engines (Node 18+) emit
@@ -401,8 +406,12 @@ pub unsafe fn create_external_uint8array(
         std::ptr::null_mut(),
         &mut arraybuffer,
     );
+    if status == napi::sys::Status::napi_no_external_buffers_allowed {
+        return Ok(None);
+    }
     if status != napi::sys::Status::napi_ok {
-        return Err(napi::Error::from_reason(
+        return Err(napi::Error::new(
+            napi::Status::from(status),
             "Failed to create external ArrayBuffer".to_string(),
         ));
     }
@@ -424,7 +433,7 @@ pub unsafe fn create_external_uint8array(
             "Failed to create Uint8Array view".to_string(),
         ));
     }
-    Ok(typedarray)
+    Ok(Some(typedarray))
 }
 
 /// Convert a JS `Uint8Array` to a [`RustBufferC`] by reading its data and calling

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -90,6 +90,7 @@ pub fn register(
     // library's `rustbuffer_free`. Together they let JS allocate buffers that the
     // codegen-emitted lowering path can fill in place and ship to Rust without copying.
     let alloc_module = Arc::clone(&module);
+    let cap_sym_for_alloc = Arc::clone(&capacity_symbol);
     let alloc_fn = env.create_function_from_closure("rustbuffer_alloc", move |ctx| {
         let size_arg: i32 = ctx.get(0)?;
         if size_arg < 0 {
@@ -107,11 +108,34 @@ pub fn register(
             napi::Error::from_reason("RustBuffer capacity exceeds addressable memory".to_string())
         })?;
         // SAFETY: rb.data points to a valid allocation of `len` bytes that the Rust
-        // library owns; codegen will hand the view back via `rustbuffer_free` before
-        // shipping the (ptr, len, cap) tuple to FFI, so no finalizer is required.
-        let typedarray =
-            unsafe { napi_utils::create_external_uint8array(ctx.env.raw(), rb.data, len)? };
-        unsafe { JsUnknown::from_raw(ctx.env.raw(), typedarray) }
+        // library owns. Node can write directly into that allocation. Electron's V8
+        // memory cage rejects external ArrayBuffers, so fall back to a V8-owned view;
+        // argument marshalling will copy it into Rust when the function is called.
+        let raw_env = ctx.env.raw();
+        let typedarray = match unsafe {
+            napi_utils::try_create_external_uint8array(raw_env, rb.data, len)
+        } {
+            Ok(Some(typedarray)) => typedarray,
+            Ok(None) => {
+                let copied = match unsafe {
+                    napi_utils::create_uint8array(raw_env, std::ptr::null(), len)
+                } {
+                    Ok(copied) => copied,
+                    Err(error) => {
+                        unsafe { napi_utils::free_rustbuffer(rb, alloc_module.rb_ops().free_ptr) };
+                        return Err(error);
+                    }
+                };
+                unsafe { napi_utils::free_rustbuffer(rb, alloc_module.rb_ops().free_ptr) };
+                unsafe { cap_sym_for_alloc.set(raw_env, copied, 0)? };
+                copied
+            }
+            Err(error) => {
+                unsafe { napi_utils::free_rustbuffer(rb, alloc_module.rb_ops().free_ptr) };
+                return Err(error);
+            }
+        };
+        unsafe { JsUnknown::from_raw(raw_env, typedarray) }
     })?;
     result.set_named_property("rustbuffer_alloc", alloc_fn)?;
 
@@ -137,7 +161,7 @@ pub fn register(
         if length == 0 {
             return ctx.env.get_undefined().map(|u| u.into_unknown());
         }
-        // Capacity recovery. Two view origins to handle:
+        // Capacity recovery. Three view origins to handle:
         //   (a) `rustbuffer_alloc(n)` views: capacity == byteLength == n, no
         //       hint set. Use byteLength.
         //   (b) Lift-handoff views: byteLength == rb.len, capacity may be
@@ -146,6 +170,9 @@ pub fn register(
         //       `capacity == len` at handoff time we skip the property write,
         //       so absence of a hint here is also a valid "use byteLength"
         //       signal.
+        //   (c) Copied fallbacks: capacity is explicitly zero because Rust
+        //       already released the source allocation. `free_rustbuffer`
+        //       treats this as a no-op.
         // SAFETY: raw_env / raw_val are valid for the current callback scope.
         let capacity = unsafe { cap_sym_for_free.get(raw_env, raw_val) }.unwrap_or(length as u64);
         let rb = RustBufferC {
@@ -153,10 +180,9 @@ pub fn register(
             len: 0,
             data: data_ptr as *mut u8,
         };
-        // SAFETY: free_ptr was resolved at registration time. rb mirrors the
-        // buffer produced by the matching `rustbuffer_alloc` call OR a
-        // lift-handoff view whose `(data_ptr, capacity)` match the original
-        // RustBuffer that Rust returned across the FFI.
+        // SAFETY: free_ptr was resolved at registration time. For Rust-owned
+        // views, rb mirrors the allocation from `rustbuffer_alloc` or the
+        // lift-handoff. Copied views carry capacity zero and are ignored.
         unsafe { napi_utils::free_rustbuffer(rb, free_module.rb_ops().free_ptr) };
         ctx.env.get_undefined().map(|u| u.into_unknown())
     })?;


### PR DESCRIPTION
## Summary

Electron rejects the NAPI runtime's zero-copy RustBuffer handoff because V8's memory cage disallows external ArrayBuffers, so UniFFI buffer-backed returns fail with `napi_no_external_buffers_allowed`.

- preserve the zero-copy RustBuffer path when the runtime supports external ArrayBuffers
- fall back to a copied, V8-owned `Uint8Array` when NAPI reports that external buffers are unavailable
- release the original Rust allocation immediately and mark copied views so generated `rustbuffer_free(view)` calls are safe no-ops
- apply the same fallback to `rustbuffer_alloc`, allowing generated lowering code to work in Electron
- retain non-Electron errors instead of masking them as the unsupported-runtime case

Node documents Electron as a runtime that can return `napi_no_external_buffers_allowed`: https://nodejs.org/api/n-api.html#napi_create_external_arraybuffer

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p uniffi-runtime-napi`
- `cargo clippy -p uniffi-runtime-napi --all-targets -- -D warnings`
- built the NAPI test libraries and ran all 89 runtime tests
- replaced `@ubjs/node-darwin-arm64` with the patched addon in an Electron 41 host and started a real Rust-backed `EmbeddedCuaDriverHost`
- verified the Electron host received the complete connection record, propagated its MCP configuration, directly owned the daemon child, and removed the child and private socket on shutdown

The Electron validation uses the runtime's real buffer-backed async record return, which failed before this change with `Failed to create external ArrayBuffer`.
