### PR TITLE
fix(napi): support runtimes without external ArrayBuffers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install Electron display dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xauth xvfb
+
       - name: Install npm dependencies
         run: cd runtimes/napi && npm ci
 
@@ -120,6 +125,9 @@ jobs:
 
       - name: Run runtime tests
         run: cd runtimes/napi && npm test
+
+      - name: Run Electron RustBuffer test
+        run: cd runtimes/napi && xvfb-run -a npm run test:electron
 
       - name: Run bootstrap for N-API bindings
         run: cargo xtask bootstrap yarn

--- a/runtimes/napi/fixtures/test_lib/src/lib.rs
+++ b/runtimes/napi/fixtures/test_lib/src/lib.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
 use std::sync::Mutex;
 
 #[repr(C)]
@@ -83,10 +83,13 @@ pub extern "C" fn uniffi_test_fn_i64_negate(x: i64, status: &mut RustCallStatus)
 
 // --- RustBuffer helpers ---
 
+static BUFFER_FREE_COUNT: AtomicU64 = AtomicU64::new(0);
+
 fn free_buffer(buf: RustBuffer) {
     if !buf.data.is_null() && buf.capacity > 0 {
         let layout = std::alloc::Layout::from_size_align(buf.capacity as usize, 1).unwrap();
         unsafe { std::alloc::dealloc(buf.data, layout) };
+        BUFFER_FREE_COUNT.fetch_add(1, Ordering::SeqCst);
     }
 }
 
@@ -217,6 +220,12 @@ pub extern "C" fn uniffi_test_fn_buffer_len(buf: RustBuffer, status: &mut RustCa
     let len = buf.len as u32;
     free_buffer(buf);
     len
+}
+
+#[no_mangle]
+pub extern "C" fn uniffi_test_fn_buffer_free_count(status: &mut RustCallStatus) -> u64 {
+    status.code = 0;
+    BUFFER_FREE_COUNT.load(Ordering::SeqCst)
 }
 
 #[no_mangle]

--- a/runtimes/napi/package-lock.json
+++ b/runtimes/napi/package-lock.json
@@ -1,18 +1,41 @@
 {
   "name": "@ubjs/node",
-  "version": "0.31.0-2",
+  "version": "0.31.0-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/node",
-      "version": "0.31.0-2",
+      "version": "0.31.0-3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
         "@types/node": "^20.0.0",
+        "electron": "39.8.5",
         "prettier": "^3.8.1",
         "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -32,6 +55,62 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -41,6 +120,606 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "39.8.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.5.tgz",
+      "integrity": "sha512-q6+LiQIcTadSyvtPgLDQkCtVA9jQJXQVMrQcctfOJILh6OFMN+UJJLRkuUTy8CZDYeCIBn1ZycqsL1dAXugxZA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.8.1",
@@ -56,6 +735,149 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -78,6 +900,34 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     }
   }
 }

--- a/runtimes/napi/package.json
+++ b/runtimes/napi/package.json
@@ -60,11 +60,13 @@
     "prepare": "npm run build",
     "fmt": "prettier --write . && cargo fmt",
     "test": "node --import ./tests/setup.mjs --test tests/*.test.mjs",
+    "test:electron": "electron tests/electron-rust-buffer.cjs",
     "test:ts": "node --test tests/resolve-lib.test.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",
     "@types/node": "^20.0.0",
+    "electron": "39.8.5",
     "prettier": "^3.8.1",
     "typescript": "^5.4.0"
   }

--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -172,64 +172,94 @@ pub(crate) fn call_ffi_function(
     }
 
     match &call_ret {
-        CallReturn::RustBuffer(rb) => {
-            rust_buffer_to_js_uint8array_handoff(env, *rb, capacity_symbol)
-        }
+        CallReturn::RustBuffer(rb) => rust_buffer_to_js_uint8array_handoff(
+            env,
+            *rb,
+            module.rb_ops().free_ptr,
+            capacity_symbol,
+        ),
         _ => marshal::read_return_to_js(env, &call_ret),
     }
 }
 
-/// Hand a returned `RustBufferC` to JS as a `Uint8Array` view aliasing the
-/// Rust-owned bytes — no boundary copy. The codegen-emitted lift wrapper is
-/// expected to call `converter.lift(view)` inside a `try/finally` and invoke
-/// the runtime's `rustbuffer_free(view)` afterwards. The single mandatory copy
-/// now happens inside `lift()` itself (via `dest.set(view)` for byte arrays,
-/// `TextDecoder.decode` for strings, field-by-field reads for composites).
+/// Hand a returned `RustBufferC` to JS as a `Uint8Array`.
 ///
-/// The view's `byteLength` is `rb.len` (so string/raw-byte-array converters
-/// that decode the whole view see only the message bytes). Rust may have
-/// allocated `rb.capacity > rb.len` bytes, so we stash `capacity` on the view
-/// via the runtime's per-registration capacity Symbol; the runtime's
-/// `rustbuffer_free` reads it back when releasing the allocation.
+/// Node gets a zero-copy view over the Rust-owned bytes. Runtimes that reject
+/// external ArrayBuffers, including Electron with V8's memory cage, get a
+/// copied V8-owned view instead. The codegen-emitted lift wrapper calls
+/// `rustbuffer_free(view)` in both cases; copied views carry a zero-capacity
+/// marker that makes that call a no-op because Rust was already freed.
 ///
 /// On any error in the handoff, we free the buffer to avoid leaking the
 /// Rust-side allocation.
 fn rust_buffer_to_js_uint8array_handoff(
     env: &napi::Env,
     rb: RustBufferC,
+    rb_free_ptr: *const c_void,
     capacity_symbol: &CapacitySymbol,
 ) -> Result<JsUnknown> {
     let raw_env = env.raw();
     let len = match usize::try_from(rb.len) {
         Ok(n) => n,
         Err(_) => {
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
             return Err(napi::Error::from_reason(
                 "RustBuffer len exceeds addressable memory",
             ));
         }
     };
 
-    // Empty RustBuffer (capacity == 0 or null data): no allocation to alias,
-    // and no capacity hint needed — the runtime's `rustbuffer_free` short-
-    // circuits on empty views without a hint.
-    if rb.capacity == 0 || rb.data.is_null() {
-        let typedarray = unsafe { napi_utils::create_uint8array(raw_env, std::ptr::null(), 0)? };
+    // Empty buffers have no bytes to alias. Release any spare Rust capacity
+    // immediately because a zero-length typed array cannot retain its data pointer.
+    if rb.len == 0 || rb.capacity == 0 || rb.data.is_null() {
+        let typedarray =
+            match unsafe { napi_utils::create_uint8array(raw_env, std::ptr::null(), 0) } {
+                Ok(typedarray) => typedarray,
+                Err(error) => {
+                    unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+                    return Err(error);
+                }
+            };
+        unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+        unsafe { capacity_symbol.set(raw_env, typedarray, 0)? };
         return Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? });
     }
 
     // SAFETY: `rb.data` points to a Rust-owned allocation of at least `len`
-    // bytes. We expose it to JS without a finalizer; the codegen-emitted
-    // try/finally calls `rustbuffer_free(view)` which will hand the (ptr,
-    // capacity) tuple back to the library's `rustbuffer_free`.
-    let typedarray = unsafe { napi_utils::create_external_uint8array(raw_env, rb.data, len)? };
-
-    // If `capacity > len`, the view's `byteLength` (== len) under-reports the
-    // allocation size. Stash the true capacity so `rustbuffer_free(view)` can
-    // free against the original `Layout`. When `capacity == len`, the runtime
-    // can recover capacity from `byteLength`, so we skip the property write.
-    if rb.capacity != rb.len {
-        unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity)? };
-    }
+    // bytes. When the runtime supports external buffers, expose it to JS
+    // without a copy and let the generated finally block release it.
+    let typedarray = match unsafe {
+        napi_utils::try_create_external_uint8array(raw_env, rb.data, len)
+    } {
+        Ok(Some(typedarray)) => {
+            // Record ownership even when capacity equals byteLength. Freeing an
+            // unmarked JS-owned view must never reach Rust's allocator.
+            if let Err(error) = unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity) } {
+                unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+                return Err(error);
+            }
+            typedarray
+        }
+        Ok(None) => {
+            // Electron's V8 memory cage forbids external ArrayBuffers. Copy
+            // into V8-owned memory, release the Rust allocation now, and mark
+            // the view so the generated `rustbuffer_free(view)` becomes a no-op.
+            let copied = match unsafe { napi_utils::create_uint8array(raw_env, rb.data, len) } {
+                Ok(copied) => copied,
+                Err(error) => {
+                    unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+                    return Err(error);
+                }
+            };
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+            unsafe { capacity_symbol.set(raw_env, copied, 0)? };
+            copied
+        }
+        Err(error) => {
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+            return Err(error);
+        }
+    };
 
     Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? })
 }

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -27,17 +27,14 @@ use std::ffi::c_void;
 use napi::{JsUnknown, NapiRaw};
 
 use uniffi_runtime_core::ffi_c_types::{
-    ForeignBytesC, RustBufferAllocFn, RustBufferC, RustBufferFreeFn, RustBufferFromBytesFn,
-    RustCallStatusC,
+    ForeignBytesC, RustBufferC, RustBufferFreeFn, RustBufferFromBytesFn, RustCallStatusC,
 };
 
 /// A per-registration JS Symbol used as a hidden property key for stashing the
-/// underlying RustBuffer capacity on a lift-handoff `Uint8Array`. The view's
-/// `byteLength` is set to `len` so converters that decode the whole view
-/// (strings, raw byte arrays) see only the message bytes — but the global
-/// allocator needs `capacity` to free correctly when `capacity > len`. The
-/// symbol is created once when the module registers and lives as long as the
-/// JS-side module facade.
+/// RustBuffer ownership on a `Uint8Array`. Rust-owned views carry their
+/// allocation capacity, which may exceed `byteLength`; JS-owned views carry
+/// zero. The symbol is created once when the module registers and lives as long
+/// as the JS-side module facade.
 pub struct CapacitySymbol {
     /// `napi_ref` keeping the Symbol alive across JS callbacks. Symbols are GC-
     /// managed; we hold a strong reference (initial refcount 1) so the symbol
@@ -141,17 +138,40 @@ impl CapacitySymbol {
                 "Failed to create BigInt for capacity hint".to_string(),
             ));
         }
-        let status = napi::sys::napi_set_property(raw_env, obj, sym_val, cap_val);
+        let mut has = false;
+        let status = napi::sys::napi_has_property(raw_env, obj, sym_val, &mut has);
         if status != napi::sys::Status::napi_ok {
             return Err(napi::Error::from_reason(
-                "Failed to set capacity-hint property".to_string(),
+                "Failed to inspect RustBuffer ownership metadata",
+            ));
+        }
+
+        let status = if has {
+            napi::sys::napi_set_property(raw_env, obj, sym_val, cap_val)
+        } else {
+            let descriptor = napi::sys::napi_property_descriptor {
+                utf8name: std::ptr::null(),
+                name: sym_val,
+                method: None,
+                getter: None,
+                setter: None,
+                value: cap_val,
+                attributes: napi::sys::PropertyAttributes::writable,
+                data: std::ptr::null_mut(),
+            };
+            napi::sys::napi_define_properties(raw_env, obj, 1, &descriptor)
+        };
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to set RustBuffer ownership metadata",
             ));
         }
         Ok(())
     }
 
-    /// Read the capacity hint from `obj`. Returns `None` if no hint is set
-    /// (e.g., views from `rustbuffer_alloc(n)` where `byteLength == capacity`).
+    /// Read the capacity metadata from `obj`. Returns `Ok(None)` only when the
+    /// property is absent; N-API failures remain errors so callers never mistake
+    /// an ownership lookup failure for a Rust-owned buffer.
     ///
     /// # Safety
     ///
@@ -160,26 +180,37 @@ impl CapacitySymbol {
         &self,
         raw_env: napi::sys::napi_env,
         obj: napi::sys::napi_value,
-    ) -> Option<u64> {
-        let sym_val = self.value(raw_env).ok()?;
+    ) -> napi::Result<Option<u64>> {
+        let sym_val = self.value(raw_env)?;
         let mut has = false;
         let status = napi::sys::napi_has_property(raw_env, obj, sym_val, &mut has);
-        if status != napi::sys::Status::napi_ok || !has {
-            return None;
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to inspect RustBuffer ownership metadata",
+            ));
         }
+        if !has {
+            return Ok(None);
+        }
+
         let mut cap_val: napi::sys::napi_value = std::ptr::null_mut();
         let status = napi::sys::napi_get_property(raw_env, obj, sym_val, &mut cap_val);
         if status != napi::sys::Status::napi_ok || cap_val.is_null() {
-            return None;
+            return Err(napi::Error::from_reason(
+                "Failed to read RustBuffer ownership metadata",
+            ));
         }
+
         let mut value: u64 = 0;
         let mut lossless = false;
         let status =
             napi::sys::napi_get_value_bigint_uint64(raw_env, cap_val, &mut value, &mut lossless);
-        if status != napi::sys::Status::napi_ok {
-            return None;
+        if status != napi::sys::Status::napi_ok || !lossless {
+            return Err(napi::Error::from_reason(
+                "Invalid RustBuffer ownership metadata",
+            ));
         }
-        Some(value)
+        Ok(Some(value))
     }
 }
 
@@ -201,14 +232,14 @@ impl Drop for CapacitySymbol {
 /// The two-step construction—first an `ArrayBuffer`, then a `TypedArray` view
 /// over it—is the only way to create a `Uint8Array` via the napi C API.
 /// The `ArrayBuffer` owns the backing memory; the `TypedArray` is a lightweight
-/// view with zero additional allocation. We copy `len` bytes from `data` into
-/// the newly allocated `ArrayBuffer` and return the `Uint8Array` view as a raw
-/// `napi_value`.
+/// view with zero additional allocation. When `data` is non-null, we copy `len`
+/// bytes into the newly allocated `ArrayBuffer`; a null pointer leaves the new
+/// buffer for the caller to initialize through the returned view.
 ///
 /// # Safety
 ///
 /// - `raw_env` must be a valid `napi_env` for the current callback scope.
-/// - `data` must point to at least `len` readable bytes (ignored when `len == 0`).
+/// - When non-null, `data` must point to at least `len` readable bytes.
 pub unsafe fn create_uint8array(
     raw_env: napi::sys::napi_env,
     data: *const u8,
@@ -334,55 +365,27 @@ pub unsafe fn rustbuffer_from_raw_bytes(
     Ok(rb)
 }
 
-/// Allocate a [`RustBufferC`] of the requested capacity via `rustbuffer_alloc`.
-///
-/// Returned buffer has `capacity == size`, `len == 0`, and a heap-allocated `data`
-/// pointer owned by the Rust library. Callers must hand the buffer back through the
-/// matching `rustbuffer_free` (or pass it across the FFI to a function that consumes it).
-///
-/// # Safety
-///
-/// - `rb_alloc_ptr` must point to a valid `rustbuffer_alloc` function.
-pub unsafe fn rustbuffer_alloc(
-    size: i32,
-    rb_alloc_ptr: *const c_void,
-) -> napi::Result<RustBufferC> {
-    if rb_alloc_ptr.is_null() {
-        return Err(napi::Error::from_reason(
-            "rustbuffer_alloc symbol is unresolved".to_string(),
-        ));
-    }
-    // SAFETY: `rb_alloc_ptr` was obtained via `dlsym` for the symbol whose name was
-    // provided under `symbols.rustbuffer_alloc` in the JS definitions. We transmute
-    // it to `RustBufferAllocFn`—the correct signature for UniFFI's `rustbuffer_alloc`.
-    let alloc: RustBufferAllocFn = std::mem::transmute(rb_alloc_ptr);
-    let mut call_status = RustCallStatusC::default();
-    let rb = alloc(size, &mut call_status as *mut RustCallStatusC);
-    if call_status.code != 0 {
-        return Err(napi::Error::from_reason(
-            "rustbuffer_alloc failed".to_string(),
-        ));
-    }
-    Ok(rb)
-}
-
-/// Wrap externally-managed memory as a JS `Uint8Array` (via napi external ArrayBuffer).
+/// Try to wrap externally-managed memory as a JS `Uint8Array`.
 ///
 /// Unlike [`create_uint8array`], this **does not copy**: the returned typed array is a
 /// view directly over `data`. The caller is responsible for keeping the memory alive
 /// for as long as JS holds the view—we pass a no-op finalizer because the codegen-emitted
 /// wrapper drops the JS reference before the corresponding `rustbuffer_free` runs.
 ///
+/// Returns `Ok(None)` when the runtime forbids external buffers, as Electron does when
+/// V8's memory cage is enabled. Callers must fall back to a copied, V8-owned buffer and
+/// release the Rust allocation themselves.
+///
 /// # Safety
 ///
 /// - `raw_env` must be a valid `napi_env` for the current callback scope.
 /// - `data` must point to at least `len` readable+writable bytes that remain alive
 ///   for the lifetime of the returned typed array (ignored when `len == 0`).
-pub unsafe fn create_external_uint8array(
+pub unsafe fn try_create_external_uint8array(
     raw_env: napi::sys::napi_env,
     data: *mut u8,
     len: usize,
-) -> napi::Result<napi::sys::napi_value> {
+) -> napi::Result<Option<napi::sys::napi_value>> {
     // No-op finalizer: ownership stays with the Rust library; codegen will call
     // `rustbuffer_free` explicitly. Using `napi_create_external_arraybuffer` with
     // a null finalizer is technically permitted, but napi engines (Node 18+) emit
@@ -401,8 +404,12 @@ pub unsafe fn create_external_uint8array(
         std::ptr::null_mut(),
         &mut arraybuffer,
     );
+    if status == napi::sys::Status::napi_no_external_buffers_allowed {
+        return Ok(None);
+    }
     if status != napi::sys::Status::napi_ok {
-        return Err(napi::Error::from_reason(
+        return Err(napi::Error::new(
+            napi::Status::from(status),
             "Failed to create external ArrayBuffer".to_string(),
         ));
     }
@@ -424,7 +431,7 @@ pub unsafe fn create_external_uint8array(
             "Failed to create Uint8Array view".to_string(),
         ));
     }
-    Ok(typedarray)
+    Ok(Some(typedarray))
 }
 
 /// Convert a JS `Uint8Array` to a [`RustBufferC`] by reading its data and calling

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -38,12 +38,9 @@ pub fn register(
     let functions: JsObject = definitions.get_named_property("functions")?;
     let mut result = env.create_object()?;
 
-    // Per-registration Symbol used as a hidden capacity-hint key on lift-
-    // handoff `Uint8Array` views. The view-handoff path returns a view whose
-    // `byteLength` is `rb.len`, but Rust may have allocated
-    // `rb.capacity > rb.len`. We stash `capacity` on the view via this
-    // symbol; `rustbuffer_free(view)` reads it back when releasing the
-    // allocation.
+    // Per-registration Symbol used as hidden ownership metadata on RustBuffer
+    // views. Rust-owned lift views carry their allocation capacity; JS-owned
+    // views carry zero so free is a no-op.
     //
     // SAFETY: env is the active napi env supplied by node for this register
     // call. The `Arc<CapacitySymbol>` keeps the Symbol alive across the
@@ -85,11 +82,10 @@ pub fn register(
         result.set_named_property(&name, js_func)?;
     }
 
-    // `rustbuffer_alloc(n)` -> Uint8Array view over Rust-owned memory of capacity `n`.
-    // `rustbuffer_free(view)` -> hands the underlying (ptr, capacity) back to the
-    // library's `rustbuffer_free`. Together they let JS allocate buffers that the
-    // codegen-emitted lowering path can fill in place and ship to Rust without copying.
-    let alloc_module = Arc::clone(&module);
+    // Lowering serializes into a JS-owned buffer. Call dispatch then copies those bytes
+    // into the Rust-owned buffer that the FFI function consumes. Mark the view as
+    // JS-owned so an explicit `rustbuffer_free(view)` is also a safe no-op.
+    let cap_sym_for_alloc = Arc::clone(&capacity_symbol);
     let alloc_fn = env.create_function_from_closure("rustbuffer_alloc", move |ctx| {
         let size_arg: i32 = ctx.get(0)?;
         if size_arg < 0 {
@@ -97,21 +93,11 @@ pub fn register(
                 "rustbuffer_alloc size must be non-negative".to_string(),
             ));
         }
-        // SAFETY: `alloc_ptr` was resolved at registration time via dlsym; module
-        // (and thus the loaded library) outlives this closure thanks to the captured Arc.
-        let rb =
-            unsafe { napi_utils::rustbuffer_alloc(size_arg, alloc_module.rb_ops().alloc_ptr)? };
-        let len = usize::try_from(rb.capacity).map_err(|_| {
-            // Free what we just allocated to avoid leaking on the error path.
-            unsafe { napi_utils::free_rustbuffer(rb, alloc_module.rb_ops().free_ptr) };
-            napi::Error::from_reason("RustBuffer capacity exceeds addressable memory".to_string())
-        })?;
-        // SAFETY: rb.data points to a valid allocation of `len` bytes that the Rust
-        // library owns; codegen will hand the view back via `rustbuffer_free` before
-        // shipping the (ptr, len, cap) tuple to FFI, so no finalizer is required.
+        let raw_env = ctx.env.raw();
         let typedarray =
-            unsafe { napi_utils::create_external_uint8array(ctx.env.raw(), rb.data, len)? };
-        unsafe { JsUnknown::from_raw(ctx.env.raw(), typedarray) }
+            unsafe { napi_utils::create_uint8array(raw_env, std::ptr::null(), size_arg as usize)? };
+        unsafe { cap_sym_for_alloc.set(raw_env, typedarray, 0)? };
+        unsafe { JsUnknown::from_raw(raw_env, typedarray) }
     })?;
     result.set_named_property("rustbuffer_alloc", alloc_fn)?;
 
@@ -125,38 +111,33 @@ pub fn register(
         let raw_val = unsafe { js_val.raw() };
         // SAFETY: js_val came from JS; if it is not a typed array,
         // `read_typedarray_data` returns None and we surface a clean error.
-        let (data_ptr, length) = unsafe { napi_utils::read_typedarray_data(raw_env, raw_val) }
+        let (data_ptr, _) = unsafe { napi_utils::read_typedarray_data(raw_env, raw_val) }
             .ok_or_else(|| {
                 napi::Error::from_reason(
                     "rustbuffer_free expected a Uint8Array argument".to_string(),
                 )
             })?;
-        // Empty views never carry a capacity hint (view-handoff short-
-        // circuits empty buffers, and `rustbuffer_alloc(0)` is itself a
-        // no-op). Bail out before the napi_ref + napi_has_property dance.
-        if length == 0 {
+        // Rust-owned lift views carry their allocation capacity. JS-owned
+        // lowering buffers and copied lift fallbacks carry zero. An unmarked
+        // view did not come from this runtime and must never reach Rust's allocator.
+        // SAFETY: raw_env / raw_val are valid for the current callback scope.
+        let capacity = unsafe { cap_sym_for_free.get(raw_env, raw_val)? }.ok_or_else(|| {
+            napi::Error::from_reason("rustbuffer_free received an unowned Uint8Array")
+        })?;
+        if capacity == 0 {
             return ctx.env.get_undefined().map(|u| u.into_unknown());
         }
-        // Capacity recovery. Two view origins to handle:
-        //   (a) `rustbuffer_alloc(n)` views: capacity == byteLength == n, no
-        //       hint set. Use byteLength.
-        //   (b) Lift-handoff views: byteLength == rb.len, capacity may be
-        //       larger and was stashed on the view at handoff time. Read
-        //       the stashed value via `CapacitySymbol::get`. When
-        //       `capacity == len` at handoff time we skip the property write,
-        //       so absence of a hint here is also a valid "use byteLength"
-        //       signal.
-        // SAFETY: raw_env / raw_val are valid for the current callback scope.
-        let capacity = unsafe { cap_sym_for_free.get(raw_env, raw_val) }.unwrap_or(length as u64);
+
+        // Mark the view released before handing its original allocation back to
+        // Rust. Repeated cleanup is then a no-op instead of a double free.
+        unsafe { cap_sym_for_free.set(raw_env, raw_val, 0)? };
         let rb = RustBufferC {
             capacity,
             len: 0,
             data: data_ptr as *mut u8,
         };
-        // SAFETY: free_ptr was resolved at registration time. rb mirrors the
-        // buffer produced by the matching `rustbuffer_alloc` call OR a
-        // lift-handoff view whose `(data_ptr, capacity)` match the original
-        // RustBuffer that Rust returned across the FFI.
+        // SAFETY: free_ptr was resolved at registration time, and the ownership
+        // metadata ties this exact pointer and capacity to a Rust lift handoff.
         unsafe { napi_utils::free_rustbuffer(rb, free_module.rb_ops().free_ptr) };
         ctx.env.get_undefined().map(|u| u.into_unknown())
     })?;

--- a/runtimes/napi/tests/electron-rust-buffer.cjs
+++ b/runtimes/napi/tests/electron-rust-buffer.cjs
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+const assert = require("node:assert/strict");
+const { app } = require("electron");
+const lib = require("../lib.js");
+
+const { FfiType, UniffiNativeModule } = lib;
+
+void (async () => {
+  try {
+    const { libPath } = await import("./helpers/lib-path.mjs");
+    await app.whenReady();
+
+    const module = UniffiNativeModule.open(libPath("uniffi_napi_test_lib"));
+    const native = module.register({
+      symbols: {
+        rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+        rustbuffer_free: "uniffi_test_rustbuffer_free",
+        rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+      },
+      structs: {},
+      callbacks: {},
+      functions: {
+        uniffi_test_fn_echo_buffer: {
+          args: [FfiType.RustBuffer],
+          ret: FfiType.RustBuffer,
+          hasRustCallStatus: true,
+        },
+      },
+    });
+
+    const input = native.rustbuffer_alloc(4);
+    input.set([1, 2, 3, 4]);
+
+    const status = { code: 0 };
+    const result = native.uniffi_test_fn_echo_buffer(input, status);
+    assert.equal(status.code, 0);
+    assert.deepEqual(result, new Uint8Array([1, 2, 3, 4]));
+    native.rustbuffer_free(input);
+    native.rustbuffer_free(result);
+    native.rustbuffer_free(result);
+    module.unload({ force: true });
+
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/runtimes/napi/tests/rust_buffer.test.mjs
+++ b/runtimes/napi/tests/rust_buffer.test.mjs
@@ -43,6 +43,8 @@ test("RustBuffer echo: pass Uint8Array, get same bytes back", () => {
   assert.strictEqual(status.code, 0);
   assert.ok(result instanceof Uint8Array);
   assert.deepStrictEqual(result, input);
+  nm.rustbuffer_free(result);
+  nm.rustbuffer_free(result);
 });
 
 test("RustBuffer echo: empty buffer", () => {
@@ -67,6 +69,45 @@ test("RustBuffer echo: empty buffer", () => {
   assert.strictEqual(status.code, 0);
   assert.ok(result instanceof Uint8Array);
   assert.strictEqual(result.length, 0);
+});
+
+test("empty RustBuffer handoffs release spare Rust capacity", () => {
+  const lib = openLib();
+  const nm = lib.register({
+    symbols: SYMBOLS,
+    structs: {},
+    callbacks: {},
+    functions: {
+      uniffi_test_rustbuffer_alloc: {
+        args: [FfiType.UInt64],
+        ret: FfiType.RustBuffer,
+        hasRustCallStatus: true,
+      },
+      uniffi_test_fn_buffer_free_count: {
+        args: [],
+        ret: FfiType.UInt64,
+        hasRustCallStatus: true,
+      },
+    },
+  });
+
+  const countStatus = { code: 0 };
+  const before = nm.uniffi_test_fn_buffer_free_count(countStatus);
+  assert.strictEqual(countStatus.code, 0);
+
+  const allocStatus = { code: 0 };
+  const result = nm.uniffi_test_rustbuffer_alloc(8n, allocStatus);
+  assert.strictEqual(allocStatus.code, 0);
+  assert.strictEqual(result.byteLength, 0);
+
+  const after = nm.uniffi_test_fn_buffer_free_count({ code: 0 });
+  assert.strictEqual(after, before + 1n);
+  nm.rustbuffer_free(result);
+  nm.rustbuffer_free(result);
+  assert.strictEqual(
+    nm.uniffi_test_fn_buffer_free_count({ code: 0 }),
+    after,
+  );
 });
 
 test("RustBuffer: large buffer round-trip (1MB)", () => {
@@ -141,7 +182,7 @@ test("RustBuffer: buffer_len returns correct length", () => {
   assert.strictEqual(result, 4);
 });
 
-test("rustbuffer_alloc returns a Uint8Array view of the requested length", () => {
+test("rustbuffer_alloc returns a JS-owned view with scoped cleanup", () => {
   const lib = openLib();
   const nm = lib.register({
     symbols: SYMBOLS,
@@ -155,8 +196,12 @@ test("rustbuffer_alloc returns a Uint8Array view of the requested length", () =>
   assert.strictEqual(view.byteLength, 16);
   view[0] = 0xab;
   view[15] = 0xcd;
-  // Hand the buffer back to Rust to free it (otherwise it leaks).
   nm.rustbuffer_free(view);
+  nm.rustbuffer_free(view);
+  assert.throws(
+    () => nm.rustbuffer_free(new Uint8Array(16)),
+    /unowned Uint8Array/,
+  );
 });
 
 test("RustBuffer return is a view-handoff (alias safety)", () => {


### PR DESCRIPTION
## Summary

Electron's V8 memory cage rejects external ArrayBuffers, so RustBuffer returns fail with `napi_no_external_buffers_allowed`.

- keep the zero-copy return path where external buffers are supported; otherwise copy into V8 memory and release the Rust allocation immediately
- keep lowering buffers JS-owned because call dispatch already copies them into the RustBuffer consumed by FFI
- track ownership with non-enumerable metadata so cleanup is idempotent, unowned V8 pointers never reach Rust's allocator, and empty returns release spare Rust capacity
- add focused ownership tests and an Electron regression to N-API CI

This is the fallback recommended by the [N-API documentation](https://nodejs.org/api/n-api.html#napi_create_external_arraybuffer) for runtimes that disallow external buffers.

## Validation

- rustfmt and clippy with warnings denied
- all 90 N-API runtime tests
- Electron 39 regression test
- Electron 41 `EmbeddedCuaDriverHost` lifecycle, including connection decoding, direct child ownership, and process/socket cleanup
