### PR TITLE
feat(wasm2): add the player runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ docs/superpowers/
 # OS core dump files (negation ensures runtimes/core/ crate is not excluded)
 core
 !runtimes/core/
+!runtimes/wasm/core/
 
 runtimes/napi/artifacts/
 runtimes/napi/npm/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-runtime-wasm"
+version = "0.31.0-3"
+
+[[package]]
 name = "uniffi_bindgen"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ members = [
     "fixtures/*",
     "runtimes/*",
     "runtimes/napi/fixtures/*",
+    "runtimes/wasm/helper-crate",
     "xtask",
 ]
+exclude = ["runtimes/wasm"]
 
 resolver = "2"
 
@@ -28,3 +30,6 @@ uniffi_core = { version = "=0.31.0", default-features = false }
 uniffi_meta = "=0.31.0"
 ubrn_fixture_testing = { path = "crates/ubrn_fixture_testing" }
 ubrn_macros = { path = "crates/ubrn_macros" }
+uniffi-runtime-wasm = { path = "runtimes/wasm/helper-crate" }
+walrus = "0.23"
+wasm-bindgen-cli-support = "=0.2.100"

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -38,6 +38,8 @@ use uniffi_runtime_core::ffi_c_types::{
 /// allocator needs `capacity` to free correctly when `capacity > len`. The
 /// symbol is created once when the module registers and lives as long as the
 /// JS-side module facade.
+///
+/// Mirrors wasm2's `CAPACITY_HINT` symbol in `runtimes/wasm/core/src/call.ts`.
 pub struct CapacitySymbol {
     /// `napi_ref` keeping the Symbol alive across JS callbacks. Symbols are GC-
     /// managed; we hold a strong reference (initial refcount 1) so the symbol

--- a/runtimes/wasm/README.md
+++ b/runtimes/wasm/README.md
@@ -1,0 +1,60 @@
+# @ubjs/wasm
+
+The WebAssembly player runtime for [`uniffi-bindgen-react-native`][bindgen]
+generated bindings. Imported by generated TypeScript code; not intended for
+direct use.
+
+[bindgen]: https://github.com/jhugman/uniffi-bindgen-react-native
+
+## What it does
+
+The player reads a table of FFI signatures the bindgen emits alongside your
+bindings, and calls the `.wasm` through it. Nothing per-crate is generated in
+C++ or JavaScript — one runtime drives every module.
+
+## Compatibility
+
+Runs anywhere `WebAssembly` does: modern browsers, Node ≥18, Bun, and web
+bundlers. The `exports` map picks the browser or node build through the
+`browser` and `node` conditions.
+
+Hermes has no `WebAssembly`, so this does not run in a standard React Native
+app. Use the JSI flavor there. Metro is still supported as a *web* bundler
+(Expo Web, React Native Web).
+
+## Install
+
+You should not install this directly. Generated bindings import it, and list
+`@ubjs/core` as a peer requirement.
+
+```bash
+npm install @ubjs/wasm @ubjs/core
+```
+
+## Loading a module
+
+Generated bindings export `uniffiInitAsync`, which takes the `.wasm` however
+your environment names it — a URL, a path, a `Response`, or bytes. Naming the
+asset is the one thing only the host knows, so there is no default.
+
+```ts
+import { uniffiInitAsync } from './generated';
+
+import wasm from './generated/my_crate.wasm';                    // bundler
+const wasm = new URL('./generated/my_crate.wasm', import.meta.url); // node
+
+await uniffiInitAsync(wasm);
+```
+
+Under Metro, `.wasm` goes through the asset registry rather than becoming a
+URL; resolve it with `Asset.fromModule(...).uri`, or serve the file and pass
+its URL.
+
+## Rust side
+
+Your crate builds a `cdylib` and depends on the [`uniffi-runtime-wasm`][crate]
+crate, which supplies the allocator and panic hook the player calls into.
+`ubrn build wasm2` checks both, and `uniffi_core` needs its
+`wasm-unstable-single-threaded` feature.
+
+[crate]: https://crates.io/crates/uniffi-runtime-wasm

--- a/runtimes/wasm/browser/src/index.ts
+++ b/runtimes/wasm/browser/src/index.ts
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import {
+  UniffiNativeModule,
+  type ImportResolver,
+  type WasmSource,
+} from "../../core/src/module.js";
+export { FfiType } from "../../core/src/ffi-type.js";
+export { UniffiNativeModule };
+export type { WasmSource };
+
+/**
+ * `options.resolveModule` supplies the wasm's own module imports. A cdylib
+ * that reached wasm-bindgen through its dependencies imports `./<lib>_bg.js`,
+ * and the caller must hand that glue over — generated bindings import it
+ * statically, which keeps it in the bundler's graph. Nothing here loads a
+ * module at runtime, so a bundler sees no dynamic import to warn about.
+ */
+export async function openWasm(
+  source: WasmSource | Promise<Response>,
+  options?: { resolveModule?: ImportResolver },
+): Promise<UniffiNativeModule> {
+  if (typeof source === "string" || source instanceof URL) {
+    const response = await fetch(source.toString());
+    return UniffiNativeModule.open(response, options);
+  }
+  // `fetch(...)` handed straight in, without an intervening `await`.
+  if (typeof (source as Promise<Response>)?.then === "function") {
+    return UniffiNativeModule.open(
+      await (source as Promise<Response>),
+      options,
+    );
+  }
+  return UniffiNativeModule.open(source as WasmSource, options);
+}

--- a/runtimes/wasm/core/src/call.ts
+++ b/runtimes/wasm/core/src/call.ts
@@ -1,0 +1,640 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import type { Memory } from "./memory.js";
+import type { Scratch } from "./scratch.js";
+import {
+  RUST_CALL_STATUS_SIZE,
+  RUST_BUFFER_SIZE,
+  RCS_ERROR_BUF_OFF,
+  readRustBuffer,
+  writeRustBufferPayload,
+  writeRustCallStatusZero,
+  type RustBufferLike,
+  type StructLayout,
+} from "./marshal.js";
+import type { FfiTypeDesc } from "./ffi-type.js";
+import type { CallbackDef } from "./callback.js";
+
+export interface FunctionDef {
+  args: FfiTypeDesc[];
+  ret: FfiTypeDesc;
+  hasRustCallStatus: boolean;
+}
+
+export interface DispatchContext {
+  memory: Memory;
+  scratch: Scratch;
+  structs: Map<string, StructLayout>;
+  // Per-shape definitions, keyed by the same name codegen passes in
+  // `FfiType.Callback("...")`. Used by `planArg` to recover the trampoline
+  // signature when lowering JS functions.
+  callbackDefs: Map<string, CallbackDef>;
+  // Wasm-side allocator for byte buffers: RustBuffer args and returns, plus
+  // errorBuf inside RustCallStatus. The helper crate's
+  // `__ubrn_alloc`/`__ubrn_free` reach the same global allocator Rust uses
+  // for `Vec<u8>`, so a buffer allocated here with `(size, align=1)` can be
+  // dropped on the Rust side via `Vec::from_raw_parts`, and vice versa.
+  alloc: (size: number, align: number) => number;
+  free: (ptr: number, size: number, align: number) => void;
+  // Install a JS function as a wasm callback (per-closure trampoline + table
+  // slot). Returns the table index that Rust's `call_indirect` will land on.
+  installCallback: (fn: (...args: any[]) => any, def: CallbackDef) => number;
+  // Whether the dispatcher may JIT-compile per-export bodies via
+  // `new Function`. `module.ts` decides once at register time; when false,
+  // `specializeFunction` always takes the interpreted path.
+  useJit: boolean;
+}
+
+// How much of the reserved scratch region a value needs. This is all
+// `computeAndReserveLayout` looks at, so the JIT path can lay a call out
+// without building the `prepare`/`finish` closures it never calls.
+interface ScratchSlot {
+  scratchSize: number; // 0 for pass-by-value scalars
+  scratchAlign: number;
+}
+
+interface ArgPlan extends ScratchSlot {
+  // What the dispatcher does at call-time per arg. Returns the wasm-arg int
+  // (pointer or scalar).
+  prepare: (ctx: DispatchContext, base: number, jsArg: any) => number;
+}
+
+interface RetSlot extends ScratchSlot {
+  hasSret: boolean;
+}
+
+interface RetPlan extends RetSlot {
+  finish: (ctx: DispatchContext, sretBase: number, scalarRet: any) => any;
+}
+
+const SCALAR_SLOT: ScratchSlot = { scratchSize: 0, scratchAlign: 1 };
+const RUST_BUFFER_SLOT: ScratchSlot = {
+  scratchSize: RUST_BUFFER_SIZE,
+  scratchAlign: 8,
+};
+
+/** Scratch a lowered arg needs. Only `RustBuffer` takes a slot; everything
+ * else — scalars, callback table indices, and the persistently-allocated
+ * `Reference(Struct)` — passes by value. */
+function argSlot(t: FfiTypeDesc): ScratchSlot {
+  return t.tag === "RustBuffer" ? RUST_BUFFER_SLOT : SCALAR_SLOT;
+}
+
+/** Scratch a return value needs. `RustBuffer` returns come back through an
+ * sret pointer; scalars and `Void` come back in the wasm return slot. */
+function retSlot(t: FfiTypeDesc): RetSlot {
+  return t.tag === "RustBuffer"
+    ? { hasSret: true, ...RUST_BUFFER_SLOT }
+    : { hasSret: false, ...SCALAR_SLOT };
+}
+
+const align = (off: number, a: number) => (off + (a - 1)) & ~(a - 1);
+
+/**
+ * Probe for `new Function` availability. Returns true if we can JIT-compile
+ * dispatchers; false under strict CSP. The probe is cheap (one Function
+ * construction) and the result is captured at register() time for the
+ * lifetime of the module.
+ */
+export function canUseFunctionConstructor(): boolean {
+  try {
+    // eslint-disable-next-line no-new-func
+    return new Function("return 42")() === 42;
+  } catch {
+    return false;
+  }
+}
+
+function planArg(t: FfiTypeDesc): ArgPlan {
+  switch (t.tag) {
+    case "UInt8":
+    case "Int8":
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "VoidPointer":
+    case "MutReference":
+      return { ...argSlot(t), prepare: (_c, _b, v) => v | 0 };
+    case "UInt64":
+    case "Int64":
+    case "Handle":
+      return { ...argSlot(t), prepare: (_c, _b, v) => v }; // bigint passes through
+    case "Float32":
+    case "Float64":
+      return { ...argSlot(t), prepare: (_c, _b, v) => v };
+    case "RustBuffer":
+      return {
+        ...argSlot(t),
+        // Codegen lowers every `RustBuffer`-shaped arg via
+        // `converter.lower(value, rustbuffer_alloc)`, so the view arriving
+        // here already aliases wasm memory: its `byteOffset` is the
+        // `dataPtr`. All that remains is the (capacity, len, dataPtr) struct
+        // Rust reads as a `RustBuffer`. Rust drops it via
+        // `Vec::from_raw_parts`, so don't free `dataPtr` here.
+        prepare: (ctx, base, v: Uint8Array) => {
+          writeRustBufferPayload(ctx.memory, ctx.alloc, base, v);
+          return base;
+        },
+      };
+    case "Callback": {
+      const name = t.name;
+      return {
+        ...argSlot(t),
+        prepare: (ctx, _base, fn: (...args: any[]) => any) => {
+          const def = ctx.callbackDefs.get(name);
+          if (!def) {
+            throw new Error(`planArg: callback shape "${name}" not registered`);
+          }
+          return ctx.installCallback(fn, def);
+        },
+      };
+    }
+    case "Reference": {
+      // The only `Reference(...)` arg in the codegen today is
+      // `Reference(Struct(name))` — used for `init_callback_vtable_*` to pass
+      // a vtable struct in linear memory. The allocation is persistent: Rust
+      // retains the pointer for the cdylib lifetime, so it is deliberately
+      // not freed from the scratch path.
+      if (t.inner.tag !== "Struct") {
+        throw new Error(
+          `planArg: Reference inner type ${t.inner.tag} not yet supported`,
+        );
+      }
+      const structName = t.inner.name;
+      return {
+        ...argSlot(t),
+        prepare: (ctx, _base, value: Record<string, unknown>) => {
+          const layout = ctx.structs.get(structName);
+          if (!layout) {
+            throw new Error(`planArg: struct "${structName}" not registered`);
+          }
+          const ptr = ctx.alloc(layout.size, 8);
+          for (const f of layout.fields) {
+            const fieldVal = value[f.name];
+            if (f.type.tag === "Callback") {
+              const def = ctx.callbackDefs.get(f.type.name);
+              if (!def) {
+                throw new Error(
+                  `planArg: callback shape "${f.type.name}" (in struct "${structName}") not registered`,
+                );
+              }
+              const slot = ctx.installCallback(
+                fieldVal as (...args: any[]) => any,
+                def,
+              );
+              ctx.memory.writeU32(ptr + f.offset, slot);
+            } else {
+              f.shape.write(ctx.memory, ptr + f.offset, fieldVal);
+            }
+          }
+          return ptr;
+        },
+      };
+    }
+    default:
+      throw new Error(`planArg: type ${t.tag} not yet supported`);
+  }
+}
+
+// Copy a wasm-side RustBuffer's payload into a fresh `Uint8Array` and free
+// the wasm allocation. Used for RustCallStatus's errorBuf, whose bytes reach
+// `liftString` / errorHandler after the allocation is gone and so must be
+// JS-owned.
+function copyAndFreeRustBuffer(
+  ctx: DispatchContext,
+  rb: RustBufferLike,
+): Uint8Array {
+  const len = Number(rb.len);
+  const cap = Number(rb.capacity);
+  const bytes =
+    len > 0 ? ctx.memory.readBytes(rb.dataPtr, len) : new Uint8Array(0);
+  if (cap > 0 && rb.dataPtr !== 0) {
+    ctx.free(rb.dataPtr, cap, 1);
+  }
+  return bytes;
+}
+
+// Records a view's Rust-side `capacity`, which `rustbuffer_free` must pass
+// back to satisfy the allocator's `Layout` contract.
+//
+// A handed-off view has `byteLength === len`, so converters see only the
+// message bytes — but Rust may have allocated more. Views from elsewhere
+// (`rustbuffer_alloc(n)`) carry no hint, and the runtime falls back to
+// `byteLength`, which equals capacity for those.
+const CAPACITY_HINT = Symbol("uniffi.rustbuffer.capacity");
+function setCapacityHint(view: Uint8Array, capacity: number): void {
+  (view as any)[CAPACITY_HINT] = capacity;
+}
+export function getCapacityHint(view: Uint8Array): number | undefined {
+  return (view as any)[CAPACITY_HINT];
+}
+
+// Alias the RustBuffer's payload in wasm memory — no copy, no free. The one
+// mandatory copy happens inside `lift()` instead.
+//
+// Two invariants the caller owns:
+//
+//   * Ownership. The codegen call site wraps `lift(view)` in `try/finally`
+//     so `rustbuffer_free(view)` runs even when `lift` throws.
+//   * Detachment. Growing wasm memory invalidates the view, so `lift` must
+//     not trigger a grow before it finishes reading. Converter `read` only
+//     allocates on the JS heap, so this holds today.
+function viewRustBufferHandoff(
+  ctx: DispatchContext,
+  rb: RustBufferLike,
+): Uint8Array {
+  const cap = Number(rb.capacity);
+  const len = Number(rb.len);
+  if (cap === 0 || rb.dataPtr === 0) return new Uint8Array(0);
+  const view = new Uint8Array(ctx.memory.buffer(), rb.dataPtr, len);
+  if (cap !== len) setCapacityHint(view, cap);
+  return view;
+}
+
+function planRet(t: FfiTypeDesc): RetPlan {
+  switch (t.tag) {
+    case "Void":
+      return { ...retSlot(t), finish: () => undefined };
+    case "UInt8":
+    case "Int8":
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "Handle":
+    case "UInt64":
+    case "Int64":
+    case "Float32":
+    case "Float64":
+      return { ...retSlot(t), finish: (_c, _b, r) => r };
+    case "RustBuffer":
+      // Hand back a `Uint8Array` view aliasing wasm memory. Codegen wraps the
+      // converter's `lift(view)` in try/finally so `rustbuffer_free(view)`
+      // releases the allocation even when `lift` throws.
+      return {
+        ...retSlot(t),
+        finish: (ctx, sretBase) =>
+          viewRustBufferHandoff(ctx, readRustBuffer(ctx.memory, sretBase)),
+      };
+    default:
+      throw new Error(`planRet: type ${(t as any).tag} not yet supported`);
+  }
+}
+
+interface CallLayout {
+  layoutSize: number;
+  statusOff: number; // -1 if !hasRustCallStatus
+  sretOff: number; // -1 if the return needs no sret slot
+  argOffsets: number[]; // -1 entries for scalar args (no scratch slot)
+  base: number; // wasm-memory offset of the reserved region
+}
+
+/**
+ * Lay out one call's scratch — status, sret, then each arg needing a slot —
+ * and reserve the region. Takes `ScratchSlot`s rather than plans so both
+ * dispatchers can call it: the JIT path knows the sizes without building the
+ * `prepare`/`finish` closures it would never call.
+ */
+function computeAndReserveLayout(
+  ctx: DispatchContext,
+  def: FunctionDef,
+  argSlots: ScratchSlot[],
+  ret: RetSlot,
+): CallLayout {
+  let layoutSize = 0;
+  const statusOff = def.hasRustCallStatus
+    ? ((layoutSize = align(layoutSize, 8)), layoutSize)
+    : -1;
+  if (def.hasRustCallStatus) layoutSize += RUST_CALL_STATUS_SIZE;
+  const sretOff = ret.hasSret
+    ? ((layoutSize = align(layoutSize, ret.scratchAlign)), layoutSize)
+    : -1;
+  if (ret.hasSret) layoutSize += ret.scratchSize;
+  const argOffsets: number[] = argSlots.map((s) => {
+    if (s.scratchSize === 0) return -1;
+    layoutSize = align(layoutSize, s.scratchAlign);
+    const off = layoutSize;
+    layoutSize += s.scratchSize;
+    return off;
+  });
+  const base = ctx.scratch.reserve(layoutSize);
+  return { layoutSize, statusOff, sretOff, argOffsets, base };
+}
+
+/**
+ * Interpreted dispatcher: reserve scratch once, then per call write each arg
+ * via its `prepare` closure, call `exportFn`, check the status inline, and
+ * return `retPlan.finish`.
+ *
+ * Every call shares the one register-time scratch reservation, so an export
+ * that re-enters itself synchronously corrupts the outer call. See
+ * `Scratch.reserve`.
+ */
+function buildInterpretedDispatcher(
+  ctx: DispatchContext,
+  exportFn: Function,
+  def: FunctionDef,
+): (...jsArgs: any[]) => any {
+  const argPlans = def.args.map((t) => planArg(t));
+  const retPlan = planRet(def.ret);
+  const { statusOff, sretOff, argOffsets, base } = computeAndReserveLayout(
+    ctx,
+    def,
+    argPlans,
+    retPlan,
+  );
+
+  return function dispatch(...jsArgs: any[]) {
+    // Last JS arg is the status object iff hasRustCallStatus.
+    const userArgs = def.hasRustCallStatus ? jsArgs.slice(0, -1) : jsArgs;
+    const statusObj = def.hasRustCallStatus ? jsArgs[jsArgs.length - 1] : null;
+
+    if (def.hasRustCallStatus)
+      writeRustCallStatusZero(ctx.memory, base + statusOff);
+
+    const wasmArgs: any[] = [];
+    if (retPlan.hasSret) wasmArgs.push(base + sretOff);
+    for (let i = 0; i < argPlans.length; i++) {
+      const p = argPlans[i];
+      const argBase = argOffsets[i] >= 0 ? base + argOffsets[i] : 0;
+      wasmArgs.push(p.prepare(ctx, argBase, userArgs[i]));
+    }
+    if (def.hasRustCallStatus) wasmArgs.push(base + statusOff);
+
+    const scalarRet = (exportFn as any)(...wasmArgs);
+
+    // Inline status check on the success path — no RustCallStatus object built.
+    if (def.hasRustCallStatus) {
+      const code = ctx.memory.readU8(base + statusOff);
+      statusObj.code = code;
+      if (code !== 0) {
+        // Lift errorBuf into a Uint8Array and free the wasm allocation, to
+        // match the `UniffiByteArray` contract `rust-call.ts` assumes when
+        // it forwards the buffer to liftString / errorHandler.
+        const errBufRb = readRustBuffer(
+          ctx.memory,
+          base + statusOff + RCS_ERROR_BUF_OFF,
+        );
+        (statusObj as any).errorBuf = copyAndFreeRustBuffer(ctx, errBufRb);
+        // On the error path Rust hasn't written a valid value into the sret
+        // slot — `rustCallWithError` will throw via `uniffiCheckCallStatus`
+        // before anything looks at the return, so skip `retPlan.finish`.
+        return undefined;
+      }
+    }
+    return retPlan.finish(ctx, base + sretOff, scalarRet);
+  };
+}
+
+/**
+ * Tags that the JIT dispatcher knows how to emit inline as return types.
+ * Includes `Void` (return-only), scalars, and `RustBuffer`.
+ */
+function isSimpleRetType(t: FfiTypeDesc): boolean {
+  switch (t.tag) {
+    case "Void":
+    case "UInt8":
+    case "Int8":
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "UInt64":
+    case "Int64":
+    case "Float32":
+    case "Float64":
+    case "Handle":
+    case "RustBuffer":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Tags that the JIT dispatcher knows how to emit inline as arg types.
+ * Restricted to scalars and `RustBuffer` — excludes `Void` (return-only).
+ * Anything outside this set returns `undefined` from `buildJitDispatcher`,
+ * causing `specializeFunction` to fall back to the interpreted path.
+ */
+function isSimpleArgType(t: FfiTypeDesc): boolean {
+  switch (t.tag) {
+    case "UInt8":
+    case "Int8":
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "UInt64":
+    case "Int64":
+    case "Float32":
+    case "Float64":
+    case "Handle":
+    case "RustBuffer":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isI32Tag(tag: string): boolean {
+  return (
+    tag === "UInt8" ||
+    tag === "Int8" ||
+    tag === "UInt16" ||
+    tag === "Int16" ||
+    tag === "UInt32" ||
+    tag === "Int32"
+  );
+}
+
+function isBigIntTag(tag: string): boolean {
+  return tag === "UInt64" || tag === "Int64" || tag === "Handle";
+}
+
+function isFloatTag(tag: string): boolean {
+  return tag === "Float32" || tag === "Float64";
+}
+
+function isPassByValueArg(tag: string): boolean {
+  return isI32Tag(tag) || isBigIntTag(tag) || isFloatTag(tag);
+}
+
+function safeName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_]/g, "_") || "dispatch";
+}
+
+function buildReturnReader(retTag: string, sretBase: number): string {
+  switch (retTag) {
+    case "Void":
+      return "return undefined;";
+    case "UInt8":
+    case "Int8":
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "UInt64":
+    case "Int64":
+    case "Handle":
+    case "Float32":
+    case "Float64":
+      return "return scalarRet;";
+    case "RustBuffer":
+      // As in `planRet`: the caller's try/finally frees the returned view.
+      return `return viewRustBufferHandoff(ctx, readRustBuffer(mem, ${sretBase}));`;
+    default:
+      // Unreachable: `isSimpleRetType` filters before this is called.
+      return "throw new Error('JIT: unsupported return type');";
+  }
+}
+
+/**
+ * Build a JIT-compiled dispatcher for a function whose arg/return types are
+ * all in the "simple" set (scalars + `RustBuffer` + `Void` return). Returns
+ * `undefined` for unsupported shapes (callback args, struct-by-value args,
+ * etc.) so the caller falls back to the interpreted dispatcher.
+ *
+ * Offsets, scalar/RustBuffer call shape, and the inline status check are
+ * baked into the body. The body refers to `mem`, `fn`, `alloc`, `ctx` and
+ * a handful of helpers as free variables; they are passed in as
+ * `new Function` constructor args so V8 can monomorphise the closure
+ * identically to hand-written source.
+ *
+ * The body bakes in one register-time scratch base, so it carries the same
+ * re-entrancy hazard as `buildInterpretedDispatcher`. See `Scratch.reserve`.
+ */
+export function buildJitDispatcher(
+  ctx: DispatchContext,
+  exportFn: Function,
+  def: FunctionDef,
+  fnName: string,
+): ((...args: any[]) => unknown) | undefined {
+  // Bail out for unsupported shapes — fall back to interpreted.
+  for (const a of def.args) {
+    if (!isSimpleArgType(a)) return undefined;
+  }
+  if (!isSimpleRetType(def.ret)) return undefined;
+
+  const { statusOff, sretOff, argOffsets, base } = computeAndReserveLayout(
+    ctx,
+    def,
+    def.args.map(argSlot),
+    retSlot(def.ret),
+  );
+
+  // String-build the dispatcher body.
+  const hasStatus = def.hasRustCallStatus;
+  const userArgNames = def.args.map((_, i) => `a${i}`);
+  const paramNames = hasStatus
+    ? [...userArgNames, "statusObj"]
+    : [...userArgNames];
+
+  // Per-arg: scalars pass straight through; RustBuffer writes a 24-byte
+  // struct into the reserved scratch slot.
+  const writes: string[] = [];
+  for (let i = 0; i < def.args.length; i++) {
+    const tag = def.args[i].tag;
+    if (isPassByValueArg(tag)) {
+      // Nothing to write — value goes straight into the wasm call below.
+    } else if (tag === "RustBuffer") {
+      const off = base + argOffsets[i];
+      writes.push(`writeRustBufferPayload(mem, alloc, ${off}, a${i});`);
+    } else {
+      // isSimpleArgType filtered above; this is unreachable.
+      throw new Error(`unreachable: arg tag ${tag} passed isSimpleArgType`);
+    }
+  }
+
+  // Wasm-side arg order: [sret?, ...userArgs, status?].
+  const callArgs: string[] = [];
+  if (sretOff >= 0) callArgs.push(`${base + sretOff}`);
+  for (let i = 0; i < def.args.length; i++) {
+    const tag = def.args[i].tag;
+    if (isI32Tag(tag)) {
+      // Match the interpreted path's `v | 0` coercion.
+      callArgs.push(`(a${i} | 0)`);
+    } else if (isPassByValueArg(tag)) {
+      // bigint / float pass straight through.
+      callArgs.push(`a${i}`);
+    } else {
+      // RustBuffer: the wasm fn receives the scratch pointer.
+      callArgs.push(`${base + argOffsets[i]}`);
+    }
+  }
+  if (hasStatus) callArgs.push(`${base + statusOff}`);
+
+  const statusBase = base + statusOff;
+  const errBufBase = statusBase + RCS_ERROR_BUF_OFF;
+  const writeStatusZero = hasStatus
+    ? `writeRustCallStatusZero(mem, ${statusBase});`
+    : "";
+  // Mirrors `buildInterpretedDispatcher`: assign `statusObj.code` on both
+  // paths, and on error copy out errorBuf then return undefined — Rust
+  // leaves the sret slot invalid when the call fails.
+  const statusCheck = hasStatus
+    ? `
+      var code = mem.readU8(${statusBase});
+      statusObj.code = code;
+      if (code !== 0) {
+        statusObj.errorBuf = copyAndFreeRustBuffer(ctx, readRustBuffer(mem, ${errBufBase}));
+        return undefined;
+      }
+    `
+    : "";
+  const callExpr = `fn(${callArgs.join(", ")})`;
+  const readRet = buildReturnReader(def.ret.tag, base + sretOff);
+
+  const body = `
+    "use strict";
+    return function ${safeName(fnName)}(${paramNames.join(", ")}) {
+      ${writeStatusZero}
+      ${writes.join("\n      ")}
+      var scalarRet = ${callExpr};
+      ${statusCheck}
+      ${readRet}
+    };
+  `;
+
+  // eslint-disable-next-line no-new-func
+  const factory = new Function(
+    "ctx",
+    "mem",
+    "fn",
+    "alloc",
+    "readRustBuffer",
+    "viewRustBufferHandoff",
+    "copyAndFreeRustBuffer",
+    "writeRustBufferPayload",
+    "writeRustCallStatusZero",
+    body,
+  );
+  return factory(
+    ctx,
+    ctx.memory,
+    exportFn,
+    ctx.alloc,
+    readRustBuffer,
+    viewRustBufferHandoff,
+    copyAndFreeRustBuffer,
+    writeRustBufferPayload,
+    writeRustCallStatusZero,
+  ) as (...args: any[]) => unknown;
+}
+
+export function specializeFunction(
+  ctx: DispatchContext,
+  exportFn: Function,
+  def: FunctionDef,
+  fnName: string = "dispatch",
+): (...jsArgs: any[]) => any {
+  if (ctx.useJit) {
+    const jit = buildJitDispatcher(ctx, exportFn, def, fnName);
+    if (jit) return jit as (...jsArgs: any[]) => any;
+  }
+  return buildInterpretedDispatcher(ctx, exportFn, def);
+}

--- a/runtimes/wasm/core/src/callback.ts
+++ b/runtimes/wasm/core/src/callback.ts
@@ -1,0 +1,725 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// JS-side dispatch table and per-shape trampoline cache for the Wasm2 player.
+//
+// Rust can only call back into JS through `call_indirect`, so every callback
+// needs a wasm function in the host's `__indirect_function_table`. Three
+// pieces make that work:
+//
+//   * A *shape* is one signature, say "(i32, i32) -> i32". Each gets one
+//     trampoline, emitted by `trampoline.ts` and instantiated as its own
+//     module: it imports `env.__ubrn_dispatch` and exports "trampoline".
+//   * Many closures share their shape's trampoline. `register` hands each a
+//     *handle*, unique within the shape, which the host passes as the first
+//     argument.
+//   * `dispatch(shapeId, handle, ...args)` recovers the closure and calls it.
+
+import type { FfiTypeDesc } from "./ffi-type.js";
+import type { Memory } from "./memory.js";
+import {
+  RUST_BUFFER_SIZE,
+  readRustBuffer,
+  writeRustBufferPayload,
+  writeRustCallStatusZero,
+  type StructLayout,
+} from "./marshal.js";
+import { emitTrampoline as emitTrampolineModule } from "./trampoline.js";
+
+const RCS_CODE_OFF = 0;
+const RCS_ERROR_BUF_OFF = 8;
+
+/** Lift one callback arg into the form the codegen closure expects: the
+ * receive-side mirror of `planArg` in `call.ts`.
+ *
+ * Scalars pass through. A `RustBuffer` becomes a `Uint8Array` and its wasm
+ * allocation is freed, Rust having handed ownership over. A `Callback` is a
+ * table index, wrapped into a JS callable. */
+function liftCallbackArg(ctx: LiftContext, t: FfiTypeDesc, raw: any): any {
+  if (t.tag === "RustBuffer") {
+    const ptr = raw as number;
+    const rb = readRustBuffer(ctx.memory, ptr);
+    const len = Number(rb.len);
+    const cap = Number(rb.capacity);
+    const bytes =
+      len > 0 ? ctx.memory.readBytes(rb.dataPtr, len) : new Uint8Array(0);
+    if (cap > 0 && rb.dataPtr !== 0) {
+      ctx.free(rb.dataPtr, cap, 1);
+    }
+    return bytes;
+  }
+  if (t.tag === "Callback") {
+    return wrapWasmCallback(ctx, t.name, raw as number);
+  }
+  return raw;
+}
+
+interface LiftContext {
+  memory: Memory;
+  alloc: (size: number, align: number) => number;
+  free: (ptr: number, size: number, align: number) => void;
+  table?: WebAssembly.Table;
+  callbackDefs?: Map<string, CallbackDef>;
+  structs?: Map<string, StructLayout>;
+}
+
+/** Wrap a function-table index into a JS callable that lowers its arguments
+ * per `def.args` and dispatches through `__indirect_function_table`, the way
+ * `call_indirect` would. */
+function wrapWasmCallback(
+  ctx: LiftContext,
+  name: string,
+  slotIdx: number,
+): (...args: any[]) => any {
+  const callbackDefs = ctx.callbackDefs;
+  const structs = ctx.structs;
+  const table = ctx.table;
+  if (!callbackDefs || !structs || !table) {
+    throw new Error(
+      "wrapWasmCallback: registration context not installed; call setRegistrationContext()",
+    );
+  }
+  const def = callbackDefs.get(name);
+  if (!def) {
+    throw new Error(
+      `wrapWasmCallback: callback shape "${name}" not registered`,
+    );
+  }
+  const target = table.get(slotIdx);
+  if (typeof target !== "function") {
+    throw new Error(
+      `wrapWasmCallback: __indirect_function_table[${slotIdx}] is not a function`,
+    );
+  }
+  // No completion callback lifted this way sets either flag. Bail rather
+  // than silently produce wrong wasm args if one ever does.
+  if (def.outReturn || def.hasRustCallStatus) {
+    throw new Error(
+      `wrapWasmCallback: callback shape "${name}" with outReturn/hasRustCallStatus not yet supported`,
+    );
+  }
+  const argTypes = def.args;
+  const memory = ctx.memory;
+  const alloc = ctx.alloc;
+  const free = ctx.free;
+  return (...userArgs: any[]) => {
+    // Freed after the call. Inner allocations, such as RustBuffer payloads,
+    // pass to Rust and are not.
+    const outerAllocs: { ptr: number; size: number; align: number }[] = [];
+    const wasmArgs: any[] = [];
+    try {
+      for (let i = 0; i < argTypes.length; i++) {
+        const t = argTypes[i];
+        const v = userArgs[i];
+        wasmArgs.push(
+          lowerCallbackArg(memory, alloc, structs, t, v, outerAllocs),
+        );
+      }
+      return (target as (...a: any[]) => any)(...wasmArgs);
+    } finally {
+      for (const a of outerAllocs) free(a.ptr, a.size, a.align);
+    }
+  };
+}
+
+function lowerCallbackArg(
+  memory: Memory,
+  alloc: (size: number, align: number) => number,
+  structs: Map<string, StructLayout>,
+  t: FfiTypeDesc,
+  v: any,
+  outerAllocs: { ptr: number; size: number; align: number }[],
+): any {
+  switch (t.tag) {
+    case "UInt8":
+    case "Int8":
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "VoidPointer":
+    case "Callback":
+    case "Reference":
+    case "MutReference":
+      return v | 0;
+    case "UInt64":
+    case "Int64":
+    case "Handle":
+      return typeof v === "bigint" ? v : BigInt(v);
+    case "Float32":
+    case "Float64":
+      return v;
+    case "RustBuffer": {
+      // Bytes are handed to Rust, so don't free them here.
+      const rbPtr = alloc(RUST_BUFFER_SIZE, 8);
+      outerAllocs.push({ ptr: rbPtr, size: RUST_BUFFER_SIZE, align: 8 });
+      writeRustBufferPayload(memory, alloc, rbPtr, v as Uint8Array);
+      return rbPtr;
+    }
+    case "Struct": {
+      const layout = structs.get(t.name);
+      if (!layout) {
+        throw new Error(`lowerCallbackArg: struct "${t.name}" not registered`);
+      }
+      const ptr = alloc(layout.size, 8);
+      outerAllocs.push({ ptr, size: layout.size, align: 8 });
+      for (const f of layout.fields) {
+        const fieldVal = (v as any)[f.name];
+        switch (f.type.tag) {
+          case "RustCallStatus":
+            writeStatusFromResult(memory, alloc, ptr + f.offset, fieldVal);
+            break;
+          case "RustBuffer":
+            writeRustBufferPayload(
+              memory,
+              alloc,
+              ptr + f.offset,
+              fieldVal as Uint8Array,
+            );
+            break;
+          default:
+            f.shape.write(memory, ptr + f.offset, fieldVal);
+        }
+      }
+      return ptr;
+    }
+    default:
+      throw new Error(`lowerCallbackArg: type ${t.tag} not yet supported`);
+  }
+}
+
+/** Write a lowered return value to the pointer Rust handed us: `planRet` in
+ * `call.ts`, in the lowering direction. */
+function writeReturnValue(
+  memory: Memory,
+  alloc: (size: number, align: number) => number,
+  ptr: number,
+  ret: FfiTypeDesc,
+  value: any,
+  /** Optional registration context, required when `ret.tag === "Struct"`
+   * (or when a struct field is `Callback`-typed). The dispatcher passes
+   * this through from `makeDispatchRoute`. */
+  ctx?: {
+    structs: Map<string, StructLayout>;
+    callbackDefs: Map<string, CallbackDef>;
+    installCallback: (fn: (...args: any[]) => any, def: CallbackDef) => number;
+  },
+): void {
+  switch (ret.tag) {
+    case "Void":
+      return;
+    case "UInt8":
+    case "Int8":
+      memory.writeU8(ptr, value | 0);
+      return;
+    case "UInt16":
+    case "Int16":
+    case "UInt32":
+    case "Int32":
+    case "VoidPointer":
+    case "Callback":
+    case "Reference":
+    case "MutReference":
+      memory.writeU32(ptr, value | 0);
+      return;
+    case "UInt64":
+    case "Int64":
+    case "Handle":
+      memory.writeU64(ptr, typeof value === "bigint" ? value : BigInt(value));
+      return;
+    case "Float32":
+      memory.writeF32(ptr, value);
+      return;
+    case "Float64":
+      memory.writeF64(ptr, value);
+      return;
+    case "RustBuffer":
+      // `value` is a `Uint8Array` (UniffiByteArray) — round-trip through
+      // wasm memory the same way `planArg.RustBuffer` does on the lower
+      // path, so Rust can reclaim it via `Vec::from_raw_parts`.
+      writeRustBufferPayload(memory, alloc, ptr, value as Uint8Array);
+      return;
+    case "Struct": {
+      if (!ctx) {
+        throw new Error(
+          `writeReturnValue: Struct return ("${ret.name}") requires a registration context`,
+        );
+      }
+      const layout = ctx.structs.get(ret.name);
+      if (!layout) {
+        throw new Error(
+          `writeReturnValue: struct "${ret.name}" not registered`,
+        );
+      }
+      // Walk the struct fields in declaration order, writing each at its
+      // computed offset. `Callback`-typed fields need the JS function
+      // installed as a wasm callback (so Rust receives a function-table
+      // index it can `call_indirect` on). `RustBuffer` fields ship their
+      // payload bytes through wasm memory and transfer ownership to Rust.
+      // Other field types are handled by the precomputed `f.shape.write`.
+      for (const f of layout.fields) {
+        const fieldVal = (value as any)[f.name];
+        switch (f.type.tag) {
+          case "Callback": {
+            const def = ctx.callbackDefs.get(f.type.name);
+            if (!def) {
+              throw new Error(
+                `writeReturnValue: callback shape "${f.type.name}" not registered (in struct "${ret.name}")`,
+              );
+            }
+            const slot = ctx.installCallback(
+              fieldVal as (...args: any[]) => any,
+              def,
+            );
+            memory.writeU32(ptr + f.offset, slot);
+            break;
+          }
+          case "RustBuffer":
+            writeRustBufferPayload(
+              memory,
+              alloc,
+              ptr + f.offset,
+              fieldVal as Uint8Array,
+            );
+            break;
+          default:
+            f.shape.write(memory, ptr + f.offset, fieldVal);
+        }
+      }
+      return;
+    }
+    default:
+      throw new Error(`writeReturnValue: ret type ${ret.tag} not supported`);
+  }
+}
+
+/** Write a `UniffiRustCallStatus` (32 bytes: i8 code + RustBuffer) to wasm
+ * memory. Empty error → success path. */
+function writeStatusFromResult(
+  memory: Memory,
+  alloc: (size: number, align: number) => number,
+  ptr: number,
+  result: any,
+): void {
+  const code = (result?.code ?? 0) | 0;
+  if (code === 0) {
+    writeRustCallStatusZero(memory, ptr);
+    return;
+  }
+  memory.writeU8(ptr + RCS_CODE_OFF, code);
+  const errorBuf = (result?.errorBuf as Uint8Array | undefined) ?? EMPTY_BYTES;
+  writeRustBufferPayload(memory, alloc, ptr + RCS_ERROR_BUF_OFF, errorBuf);
+}
+
+const EMPTY_BYTES = new Uint8Array(0);
+
+const TAG_I32 = 0;
+const TAG_I64 = 1;
+const TAG_F32 = 2;
+const TAG_F64 = 3;
+
+function tagFor(t: FfiTypeDesc): number {
+  switch (t.tag) {
+    case "UInt64":
+    case "Int64":
+    // UniFFI handles are u64 on every platform, including wasm32. Lowering
+    // them as i32 here would emit a trampoline whose `call_indirect`
+    // signature didn't match Rust's `extern "C" fn(handle: u64, ...)` —
+    // the wasm runtime then throws "null function or function signature
+    // mismatch" at the first poll.
+    case "Handle":
+      return TAG_I64;
+    case "Float32":
+      return TAG_F32;
+    case "Float64":
+      return TAG_F64;
+    default:
+      // All pointer-sized and small-integer FFI types lower to i32 in the
+      // wasm ABI. (Void is invalid here — only used as a return type and
+      // handled separately by `signatureKey`/`buildDescriptor`.)
+      return TAG_I32;
+  }
+}
+
+export interface CallbackDef {
+  args: FfiTypeDesc[];
+  ret: FfiTypeDesc;
+  hasRustCallStatus: boolean;
+  outReturn?: boolean;
+}
+
+interface ShapeCache {
+  signature: string;
+  shapeId: number;
+  trampoline: WebAssembly.ExportValue;
+  registry: Map<number, (...args: any[]) => any>;
+  nextHandle: number;
+}
+
+/**
+ * Per-instance dispatch table. `module.ts` owns one of these and routes the
+ * `__ubrn_dispatch` import through `dispatch`.
+ */
+export class CallbackTable {
+  private shapes = new Map<string, ShapeCache>();
+  private shapesByShapeId: ShapeCache[] = [];
+  /**
+   * Shapes that bypass the registry-by-handle path. The `RustFutureContinu-
+   * ationCallback` shape lives here: its first argument is a u64 cookie, not
+   * a UniFFI registry handle, so the per-shape callback owns its own routing
+   * (e.g. the FutureRegistry's cookie -> resolver map).
+   */
+  private continuationShapes = new Map<number, (...args: any[]) => any>();
+
+  /** Optional registration context: callback shape defs + compiled struct
+   * layouts. Set by `module.ts` after `registerSync()` so `makeDispatchRoute`
+   * can resolve `Callback`-typed args (function-table indices) into JS
+   * callables that re-lower their args and dispatch through the indirect
+   * function table. */
+  private registrationContext?: {
+    callbackDefs: Map<string, CallbackDef>;
+    structs: Map<string, StructLayout>;
+  };
+
+  constructor(
+    private memory: Memory,
+    private hostExports: WebAssembly.Exports,
+    /** Async compilation is not implemented; `false` is reserved for it. */
+    private compileSync: boolean = true,
+  ) {}
+
+  setRegistrationContext(ctx: {
+    callbackDefs: Map<string, CallbackDef>;
+    structs: Map<string, StructLayout>;
+  }): void {
+    this.registrationContext = ctx;
+  }
+
+  /**
+   * Implements `env.__ubrn_dispatch`. Trampolines prepend their shape id and
+   * forward everything else verbatim.
+   *
+   * On the registry path the host's first argument is the handle, per the
+   * UniFFI vtable convention; it is stripped before calling the closure.
+   *
+   * For shapes registered via `registerContinuationShape` (e.g. the future
+   * continuation callback) we forward all args verbatim — `args[0]` is a
+   * cookie, not a handle, and the caller owns the lookup.
+   */
+  dispatch = (shapeId: number, ...args: any[]): any => {
+    const continuationFn = this.continuationShapes.get(shapeId);
+    if (continuationFn) {
+      return continuationFn(...args);
+    }
+    const cache = this.shapesByShapeId[shapeId];
+    if (!cache) {
+      throw new Error(`__ubrn_dispatch: unknown shape ${shapeId}`);
+    }
+    // The trampoline forwards the handle in whatever wasm type the shape
+    // declares — a `Handle`/u64 arrives as a bigint, everything else as a
+    // number. `registry` is keyed by the number `register()` handed out, so
+    // normalise before looking up.
+    const handle = Number(args[0]);
+    const cb = cache.registry.get(handle);
+    if (!cb) {
+      throw new Error(
+        `__ubrn_dispatch: unknown handle ${handle} for shape ${shapeId}`,
+      );
+    }
+    return cb(...args.slice(1));
+  };
+
+  /**
+   * Mark `shapeId` as a "continuation" shape — when the trampoline fires for
+   * that shape we route directly to `fn(...args)` rather than going through
+   * the registry-by-handle lookup. Used by `FutureRegistry`.
+   */
+  registerContinuationShape(
+    shapeId: number,
+    fn: (...args: any[]) => any,
+  ): void {
+    this.continuationShapes.set(shapeId, fn);
+  }
+
+  // Slots for closures installed directly rather than registered against a
+  // shape: `planArg`'s `Callback(name)` args and `Callback`-typed vtable
+  // fields. Each distinct (closure, signature) pair takes its own shape and
+  // table slot. That stays bounded because codegen builds each callback
+  // interface's vtable once at module scope and carries instance identity in
+  // the handle argument, so an interface costs N + 2 (clone, free) shapes
+  // however many instances exist.
+  //
+  // Keyed by signature as well as identity: one function installed for two
+  // signatures needs two slots, or Rust's `call_indirect` traps.
+  private fnSlotCache = new WeakMap<Function, Map<string, number>>();
+
+  installCallbackFunction(
+    fn: (...args: any[]) => any,
+    def: CallbackDef,
+  ): number {
+    const sigKey = this.signatureKey(def);
+    let bySig = this.fnSlotCache.get(fn);
+    const cached = bySig?.get(sigKey);
+    if (cached !== undefined) return cached;
+
+    const shapeId = this.shapesByShapeId.length;
+    const wasmBytes = this.compileTrampoline(shapeId, def);
+    const trampolineModule = new WebAssembly.Module(wasmBytes as BufferSource);
+    const instance = new WebAssembly.Instance(trampolineModule, {
+      env: { __ubrn_dispatch: this.dispatch },
+    });
+    const trampoline = instance.exports.trampoline;
+    if (typeof trampoline !== "function") {
+      throw new Error(
+        "emitted trampoline module did not export a 'trampoline' function",
+      );
+    }
+    const cache: ShapeCache = {
+      signature: sigKey,
+      shapeId,
+      trampoline,
+      registry: new Map(),
+      nextHandle: 1,
+    };
+    this.shapesByShapeId.push(cache);
+
+    // Vtable methods on the codegen side return a `UniffiResult`; their
+    // wasm-level signature however returns void and takes trailing
+    // `out_ret` / `out_status` pointer args. Wrap the user closure so the
+    // dispatcher unwraps the result and writes it back through those
+    // pointers. Free/clone (no `outReturn`/`hasRustCallStatus`) and the
+    // future continuation route through unchanged.
+    const route = this.makeDispatchRoute(fn, def);
+    // Routed through the continuation path so all wasm args (including the
+    // u64 instance handle in vtable methods) are forwarded verbatim — the JS
+    // closure does its own handle-to-instance lift.
+    this.continuationShapes.set(shapeId, route);
+
+    const table = this.hostExports.__indirect_function_table as
+      | WebAssembly.Table
+      | undefined;
+    if (!table) {
+      throw new Error(
+        "installCallbackFunction: host wasm does not export __indirect_function_table",
+      );
+    }
+    const slot = table.length;
+    table.grow(1);
+    table.set(slot, trampoline as any);
+
+    if (!bySig) {
+      bySig = new Map();
+      this.fnSlotCache.set(fn, bySig);
+    }
+    bySig.set(sigKey, slot);
+    return slot;
+  }
+
+  private makeDispatchRoute(
+    fn: (...args: any[]) => any,
+    def: CallbackDef,
+  ): (...args: any[]) => any {
+    const userArgCount = def.args.length;
+    const memory = this.memory;
+    const alloc = this.hostExports.__ubrn_alloc as (
+      size: number,
+      align: number,
+    ) => number;
+    const free = this.hostExports.__ubrn_free as (
+      ptr: number,
+      size: number,
+      align: number,
+    ) => void;
+    const argTypes = def.args;
+    // Aggregate-typed args (RustBuffer) and function-pointer args
+    // (`Callback`) need a wasm-side lift before being handed to the user
+    // closure: the wasm ABI passes those as i32 pointers / table indices,
+    // but the codegen closure expects the lifted JS representation
+    // (`Uint8Array` / a callable wrapper).
+    const needsArgLift = argTypes.some(
+      (t) => t.tag === "RustBuffer" || t.tag === "Callback",
+    );
+    const ret = def.ret;
+    const outReturn = def.outReturn;
+    const hasStatus = def.hasRustCallStatus;
+    if (!outReturn && !hasStatus && !needsArgLift) {
+      // Direct passthrough — free/clone, the future continuation, etc.
+      return fn;
+    }
+    const installCallback = (
+      cbFn: (...args: any[]) => any,
+      cbDef: CallbackDef,
+    ) => this.installCallbackFunction(cbFn, cbDef);
+    const writeRetCtx = this.registrationContext
+      ? {
+          structs: this.registrationContext.structs,
+          callbackDefs: this.registrationContext.callbackDefs,
+          installCallback,
+        }
+      : undefined;
+    const liftCtx: LiftContext = {
+      memory,
+      alloc,
+      free,
+      table: this.hostExports.__indirect_function_table as
+        | WebAssembly.Table
+        | undefined,
+      callbackDefs: this.registrationContext?.callbackDefs,
+      structs: this.registrationContext?.structs,
+    };
+    // `hasStatus` also decides where the FFI return value lives: sync vtable
+    // methods wrap it in a `UniffiResult` (`result.pointee`), async ones
+    // return it directly.
+    return (...wasmArgs: any[]) => {
+      let idx = userArgCount;
+      const outRetPtr = outReturn ? wasmArgs[idx++] : -1;
+      const outStatusPtr = hasStatus ? wasmArgs[idx++] : -1;
+      const userArgs = needsArgLift
+        ? argTypes.map((t, i) => liftCallbackArg(liftCtx, t, wasmArgs[i]))
+        : wasmArgs.slice(0, userArgCount);
+      const result = fn(...userArgs);
+      const code = hasStatus ? (result?.code ?? 0) | 0 : 0;
+      if (outRetPtr >= 0 && code === 0) {
+        const retValue = hasStatus ? result?.pointee : result;
+        writeReturnValue(memory, alloc, outRetPtr, ret, retValue, writeRetCtx);
+      }
+      if (outStatusPtr >= 0) {
+        writeStatusFromResult(memory, alloc, outStatusPtr, result);
+      }
+    };
+  }
+
+  /**
+   * Define (or look up, if already defined) the trampoline for a callback
+   * shape. Returns the shape id, which is the index callers should pass to
+   * `register`/`installAt`.
+   */
+  defineShape(_name: string, def: CallbackDef): number {
+    const key = this.signatureKey(def);
+    const existing = this.shapes.get(key);
+    if (existing) {
+      return existing.shapeId;
+    }
+    const shapeId = this.shapesByShapeId.length;
+
+    const wasmBytes = this.compileTrampoline(shapeId, def);
+
+    if (!this.compileSync) {
+      throw new Error(
+        "Async trampoline compilation not yet supported; pass compileSync=true",
+      );
+    }
+    const trampolineModule = new WebAssembly.Module(wasmBytes as BufferSource);
+    const instance = new WebAssembly.Instance(trampolineModule, {
+      env: { __ubrn_dispatch: this.dispatch },
+    });
+    const trampoline = instance.exports.trampoline;
+    if (typeof trampoline !== "function") {
+      throw new Error(
+        "emitted trampoline module did not export a 'trampoline' function",
+      );
+    }
+
+    const cache: ShapeCache = {
+      signature: key,
+      shapeId,
+      trampoline,
+      registry: new Map(),
+      // Handles start at 1 so a caller can reliably distinguish "no callback"
+      // (0) from "registered". The host's `call_indirect` will use whatever
+      // handle the dispatcher gives it.
+      nextHandle: 1,
+    };
+    this.shapes.set(key, cache);
+    this.shapesByShapeId.push(cache);
+    return shapeId;
+  }
+
+  /** Register a JS closure for `def`'s shape. Returns the handle. */
+  register(
+    name: string,
+    fn: (...args: any[]) => any,
+    def: CallbackDef,
+  ): number {
+    const shapeId = this.defineShape(name, def);
+    const cache = this.shapesByShapeId[shapeId];
+    const handle = cache.nextHandle++;
+    cache.registry.set(handle, fn);
+    return handle;
+  }
+
+  /** Drop a previously registered callback. */
+  unregister(handle: number, def: CallbackDef): void {
+    const shapeId = this.shapeIdFor(def);
+    const cache = this.shapesByShapeId[shapeId];
+    cache.registry.delete(handle);
+  }
+
+  /** Number of live registrations for `def`'s shape. Used by tests and by
+   * the generated `free` vtable hook to verify callbacks are released. */
+  size(def: CallbackDef): number {
+    const shapeId = this.shapeIdFor(def);
+    return this.shapesByShapeId[shapeId].registry.size;
+  }
+
+  /**
+   * Install a shape's trampoline into the host's indirect function table at
+   * `tableIndex`. The host wasm calls into the trampoline via
+   * `call_indirect`, so this is how a JS callback becomes reachable from
+   * Rust.
+   *
+   * Note: many callbacks of the same *shape* share one trampoline, but each
+   * needs its own table slot because the host passes a fixed table index per
+   * Rust-side callback object.
+   */
+  installAt(tableIndex: number, shapeId: number): void {
+    const cache = this.shapesByShapeId[shapeId];
+    if (!cache) {
+      throw new Error(`installAt: shape ${shapeId} not defined`);
+    }
+    const table = this.hostExports.__indirect_function_table as
+      | WebAssembly.Table
+      | undefined;
+    if (!table) {
+      throw new Error(
+        "installAt: host wasm does not export __indirect_function_table",
+      );
+    }
+    if (tableIndex >= table.length) {
+      table.grow(tableIndex - table.length + 1);
+    }
+    table.set(tableIndex, cache.trampoline as any);
+  }
+
+  private shapeIdFor(def: CallbackDef): number {
+    const key = this.signatureKey(def);
+    const cache = this.shapes.get(key);
+    if (!cache) {
+      throw new Error("shape not defined; call defineShape first");
+    }
+    return cache.shapeId;
+  }
+
+  private signatureKey(def: CallbackDef): string {
+    const tags = def.args.map((a) => tagFor(a));
+    const ret = def.ret.tag === "Void" ? "" : `:${tagFor(def.ret)}`;
+    return `${tags.join(",")}${ret}`;
+  }
+
+  /** Encode the trampoline's wasm-level signature and emit the wasm bytes
+   * for it via the JS-side encoder in `trampoline.ts`. The wasm-level
+   * params are `def.args` plus implicit i32 pointer args UniFFI tacks on
+   * when `outReturn` / `hasRustCallStatus` are set; for `outReturn` the
+   * return travels via the pointer, so the trampoline's wasm return is
+   * void regardless of `def.ret`. */
+  private compileTrampoline(shapeId: number, def: CallbackDef): Uint8Array {
+    const paramTags = def.args.map((a) => tagFor(a));
+    if (def.outReturn) paramTags.push(TAG_I32); // out_ret pointer
+    if (def.hasRustCallStatus) paramTags.push(TAG_I32); // out_status pointer
+    const returnTag =
+      !def.outReturn && def.ret.tag !== "Void" ? tagFor(def.ret) : undefined;
+    return emitTrampolineModule(shapeId, paramTags, returnTag);
+  }
+}

--- a/runtimes/wasm/core/src/ffi-type.ts
+++ b/runtimes/wasm/core/src/ffi-type.ts
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+export type FfiTypeDesc =
+  | { tag: "UInt8" }
+  | { tag: "Int8" }
+  | { tag: "UInt16" }
+  | { tag: "Int16" }
+  | { tag: "UInt32" }
+  | { tag: "Int32" }
+  | { tag: "UInt64" }
+  | { tag: "Int64" }
+  | { tag: "Float32" }
+  | { tag: "Float64" }
+  | { tag: "Handle" }
+  | { tag: "RustBuffer" }
+  | { tag: "ForeignBytes" }
+  | { tag: "RustCallStatus" }
+  | { tag: "VoidPointer" }
+  | { tag: "Void" }
+  | { tag: "Callback"; name: string }
+  | { tag: "Struct"; name: string }
+  | { tag: "Reference"; inner: FfiTypeDesc }
+  | { tag: "MutReference"; inner: FfiTypeDesc };
+
+export const FfiType = {
+  UInt8: { tag: "UInt8" } as const,
+  Int8: { tag: "Int8" } as const,
+  UInt16: { tag: "UInt16" } as const,
+  Int16: { tag: "Int16" } as const,
+  UInt32: { tag: "UInt32" } as const,
+  Int32: { tag: "Int32" } as const,
+  UInt64: { tag: "UInt64" } as const,
+  Int64: { tag: "Int64" } as const,
+  Float32: { tag: "Float32" } as const,
+  Float64: { tag: "Float64" } as const,
+  Handle: { tag: "Handle" } as const,
+  RustBuffer: { tag: "RustBuffer" } as const,
+  ForeignBytes: { tag: "ForeignBytes" } as const,
+  RustCallStatus: { tag: "RustCallStatus" } as const,
+  VoidPointer: { tag: "VoidPointer" } as const,
+  Void: { tag: "Void" } as const,
+  Callback: (name: string) => ({ tag: "Callback", name }) as const,
+  Struct: (name: string) => ({ tag: "Struct", name }) as const,
+  Reference: (inner: FfiTypeDesc) => ({ tag: "Reference", inner }) as const,
+  MutReference: (inner: FfiTypeDesc) =>
+    ({ tag: "MutReference", inner }) as const,
+};

--- a/runtimes/wasm/core/src/future.ts
+++ b/runtimes/wasm/core/src/future.ts
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// JS-side registry for `RustFutureContinuationCallback`, UniFFI's poll-style
+// async ABI.
+//
+//   * The continuation has a *fixed* `(data: u64, code: i8)` signature, so one
+//     trampoline serves every future in the cdylib.
+//   * `data` is **not** a UniFFI handle. It is an opaque u64 cookie the player
+//     allocates per await and the host wasm passes back unchanged when the
+//     future settles.
+//   * Each await allocates a cookie and records `cookie -> resolver`. When the
+//     trampoline fires, the continuation route in `CallbackTable.dispatch`
+//     looks the resolver up by cookie rather than by the usual handle, and
+//     calls it with `code`.
+
+import type { CallbackTable } from "./callback.js";
+import { FfiType } from "./ffi-type.js";
+
+/** The single shape used by every `RustFutureContinuationCallback`. */
+const CONT_DEF = {
+  args: [FfiType.UInt64, FfiType.Int8],
+  ret: FfiType.Void,
+  hasRustCallStatus: false,
+};
+
+export class FutureRegistry {
+  private nextData: bigint = 1n;
+  private resolvers = new Map<bigint, (code: number) => void>();
+  private contShapeId = -1;
+
+  constructor(private callbacks: CallbackTable) {}
+
+  /**
+   * Compile (once) the continuation trampoline and install it at
+   * `tableIndex` in the host's indirect function table. Subsequent calls
+   * reuse the cached shape but re-install at whichever table index the
+   * caller asks for. Returns `tableIndex` for convenience.
+   */
+  installContinuation(tableIndex: number): number {
+    if (this.contShapeId < 0) {
+      this.contShapeId = this.callbacks.defineShape(
+        "__rust_future_continuation",
+        CONT_DEF as any,
+      );
+      this.callbacks.registerContinuationShape(
+        this.contShapeId,
+        (data: bigint, code: number) => {
+          const resolver = this.resolvers.get(data);
+          if (!resolver) return;
+          this.resolvers.delete(data);
+          resolver(code);
+        },
+      );
+    }
+    this.callbacks.installAt(tableIndex, this.contShapeId);
+    return tableIndex;
+  }
+
+  /**
+   * Allocate a fresh continuation cookie and record the resolver to be
+   * invoked when the host wasm calls the continuation trampoline with that
+   * cookie. The returned `bigint` is the `data` argument the caller should
+   * thread through to the Rust-side `rust_future_poll(...)`-style export.
+   */
+  allocateContinuation(resolver: (code: number) => void): bigint {
+    const data = this.nextData++;
+    this.resolvers.set(data, resolver);
+    return data;
+  }
+}

--- a/runtimes/wasm/core/src/index.ts
+++ b/runtimes/wasm/core/src/index.ts
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+export { FfiType, type FfiTypeDesc } from "./ffi-type.js";
+export {
+  UniffiNativeModule,
+  type WasmSource,
+  type ModuleDefinitions,
+  type NativeModuleInterface,
+} from "./module.js";

--- a/runtimes/wasm/core/src/marshal.ts
+++ b/runtimes/wasm/core/src/marshal.ts
@@ -1,0 +1,291 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { Memory } from "./memory.js";
+import type { FfiTypeDesc } from "./ffi-type.js";
+import { RustBuffer } from "@ubjs/core";
+
+export const RUST_BUFFER_SIZE = 24; // capacity:u64, len:u64, dataPtr:u32 (+pad)
+export const RUST_CALL_STATUS_SIZE = 32; // code:i8 + pad + RustBuffer
+export const FOREIGN_BYTES_SIZE = 8; // len:i32, dataPtr:u32
+
+const RB_CAPACITY_OFF = 0;
+const RB_LEN_OFF = 8;
+const RB_DATAPTR_OFF = 16;
+
+export interface RustBufferLike {
+  capacity: bigint;
+  len: bigint;
+  dataPtr: number;
+}
+
+export function readRustBuffer(m: Memory, ptr: number): RustBufferLike {
+  return {
+    capacity: m.readU64(ptr + RB_CAPACITY_OFF),
+    len: m.readU64(ptr + RB_LEN_OFF),
+    dataPtr: m.readU32(ptr + RB_DATAPTR_OFF),
+  };
+}
+
+export function writeRustBuffer(m: Memory, ptr: number, rb: RustBufferLike) {
+  m.writeU64(ptr + RB_CAPACITY_OFF, rb.capacity);
+  m.writeU64(ptr + RB_LEN_OFF, rb.len);
+  m.writeU32(ptr + RB_DATAPTR_OFF, rb.dataPtr);
+}
+
+/**
+ * Write a 24-byte `RustBuffer` struct at `ptr` (`capacity = len = bytes
+ * .byteLength`, `dataPtr` pointing at the payload bytes inside wasm memory).
+ *
+ * Two payload paths:
+ *
+ * 1. **Wasm-aliased view (`lower(value, rustbuffer_alloc)`):** the converter
+ *    has already written its bytes directly into a wasm allocation obtained
+ *    from `rustbuffer_alloc(n)` — `bytes.buffer` is the wasm linear memory
+ *    and `bytes.byteOffset` is the `dataPtr`. We just forward
+ *    `(byteOffset, byteLength)` into the struct.
+ *
+ * 2. **JS-owned `Uint8Array`:** allocate a fresh wasm buffer of the right
+ *    size and copy bytes in.
+ *
+ * Used on every wasm2 lower path that hands a `Uint8Array` to Rust through
+ * a `RustBuffer` slot — top-level args, callback args/returns,
+ * `RustCallStatus.errorBuf`, and `RustBuffer` fields inside structs.
+ * Ownership of the payload bytes transfers to Rust, so the caller does
+ * not free `dataPtr`.
+ *
+ * Throws if `bytes` is a detached view. A detached view is unrecoverable
+ * (we cannot read its contents to copy them, and the source buffer is no
+ * longer valid wasm memory either). It indicates a contract violation —
+ * a wasm-aliased view was held across an operation that grew wasm memory.
+ */
+export function writeRustBufferPayload(
+  m: Memory,
+  alloc: (size: number, align: number) => number,
+  ptr: number,
+  bytes: Uint8Array,
+): void {
+  const len = bytes.byteLength;
+  let dataPtr = 0;
+  if (len > 0) {
+    if (bytes.buffer === m.buffer()) {
+      // Already aliased to wasm memory — no realloc, no copy.
+      dataPtr = bytes.byteOffset;
+    } else if (bytes.buffer.byteLength === 0) {
+      // The source view's ArrayBuffer was detached, almost certainly because
+      // wasm memory grew between `rustbuffer_alloc(n)` and this call. We
+      // cannot recover: the bytes are unreadable.
+      throw new Error(
+        "writeRustBufferPayload: source view is detached — wasm memory grew " +
+          "between rustbuffer_alloc(n) and the FFI call. The view must not " +
+          "be held across any operation that can grow wasm memory.",
+      );
+    } else {
+      // JS-owned `Uint8Array` — allocate wasm memory and copy.
+      dataPtr = alloc(len, 1);
+      m.writeBytes(dataPtr, bytes);
+    }
+  }
+  const blen = BigInt(len);
+  writeRustBuffer(m, ptr, { capacity: blen, len: blen, dataPtr });
+}
+
+const RCS_CODE_OFF = 0;
+export const RCS_ERROR_BUF_OFF = 8;
+
+export interface RustCallStatusLike {
+  code: number;
+  errorBuf: RustBufferLike;
+}
+
+export function readRustCallStatus(m: Memory, ptr: number): RustCallStatusLike {
+  return {
+    code: m.readU8(ptr + RCS_CODE_OFF),
+    errorBuf: readRustBuffer(m, ptr + RCS_ERROR_BUF_OFF),
+  };
+}
+
+export function writeRustCallStatusZero(m: Memory, ptr: number) {
+  // Status is exactly 32 bytes; write zeros via two u64 + one u64 + alignment.
+  for (let i = 0; i < RUST_CALL_STATUS_SIZE; i += 8) {
+    m.writeU64(ptr + i, 0n);
+  }
+}
+
+const FB_LEN_OFF = 0;
+const FB_DATAPTR_OFF = 4;
+
+export interface ForeignBytesLike {
+  len: number;
+  dataPtr: number;
+}
+
+export function readForeignBytes(m: Memory, ptr: number): ForeignBytesLike {
+  return {
+    len: m.readI32(ptr + FB_LEN_OFF),
+    dataPtr: m.readU32(ptr + FB_DATAPTR_OFF),
+  };
+}
+
+export function writeForeignBytes(
+  m: Memory,
+  ptr: number,
+  fb: ForeignBytesLike,
+) {
+  m.writeI32(ptr + FB_LEN_OFF, fb.len);
+  m.writeU32(ptr + FB_DATAPTR_OFF, fb.dataPtr);
+}
+
+export interface FieldDesc {
+  name: string;
+  type: FfiTypeDesc;
+}
+
+export interface CompiledField {
+  name: string;
+  offset: number;
+  type: FfiTypeDesc;
+  shape: ScalarShape;
+}
+
+export interface StructLayout {
+  size: number;
+  // Per-field offset/shape/type, in declaration order. The dispatcher walks
+  // these directly when an arg of type `Reference(Struct(name))` needs custom
+  // per-field handling — e.g. installing a JS function as a wasm callback for
+  // `Callback`-typed fields in vtables.
+  fields: CompiledField[];
+  read: (m: Memory, ptr: number) => Record<string, unknown>;
+  write: (m: Memory, ptr: number, value: Record<string, unknown>) => void;
+}
+
+export interface ScalarShape {
+  size: number;
+  align: number;
+  read: (m: Memory, p: number) => unknown;
+  write: (m: Memory, p: number, v: any) => void;
+}
+
+function shapeFor(type: FfiTypeDesc): ScalarShape {
+  switch (type.tag) {
+    case "UInt8":
+    case "Int8":
+      return {
+        size: 1,
+        align: 1,
+        read: (m, p) => m.readU8(p),
+        write: (m, p, v) => m.writeU8(p, v),
+      };
+    case "UInt32":
+    case "Int32":
+    case "VoidPointer":
+    case "Callback":
+    case "Reference":
+    case "MutReference":
+      return {
+        size: 4,
+        align: 4,
+        read: (m, p) => m.readU32(p),
+        write: (m, p, v) => m.writeU32(p, v),
+      };
+    case "UInt64":
+    case "Int64":
+    // UniFFI handles are u64 (registry slots); reading/writing them as 32-bit
+    // would silently drop the high half — see e.g.
+    // `ForeignFutureDroppedCallbackStruct` which has a `handle: Handle` field.
+    case "Handle":
+      return {
+        size: 8,
+        align: 8,
+        read: (m, p) => m.readU64(p),
+        write: (m, p, v) => m.writeU64(p, v),
+      };
+    case "Float32":
+      return {
+        size: 4,
+        align: 4,
+        read: (m, p) => m.readF32(p),
+        write: (m, p, v) => m.writeF32(p, v),
+      };
+    case "Float64":
+      return {
+        size: 8,
+        align: 8,
+        read: (m, p) => m.readF64(p),
+        write: (m, p, v) => m.writeF64(p, v),
+      };
+    case "RustBuffer":
+      return {
+        size: RUST_BUFFER_SIZE,
+        align: 8,
+        read: (m, p) => readRustBuffer(m, p),
+        write: (m, p, v) => writeRustBuffer(m, p, v),
+      };
+    case "ForeignBytes":
+      return {
+        size: FOREIGN_BYTES_SIZE,
+        align: 4,
+        read: (m, p) => readForeignBytes(m, p),
+        write: (m, p, v) => writeForeignBytes(m, p, v),
+      };
+    case "RustCallStatus":
+      return {
+        size: RUST_CALL_STATUS_SIZE,
+        align: 8,
+        read: (m, p) => readRustCallStatus(m, p),
+        write: () => {
+          throw new Error("RustCallStatus is not directly writable");
+        },
+      };
+    default:
+      throw new Error(
+        `shapeFor: nested type ${type.tag} not yet supported in struct fields`,
+      );
+  }
+}
+
+const align = (off: number, a: number) => (off + (a - 1)) & ~(a - 1);
+
+export function compileStructLayout(fields: FieldDesc[]): StructLayout {
+  const compiled: CompiledField[] = [];
+  let off = 0;
+  let maxAlign = 1;
+  for (const f of fields) {
+    const shape = shapeFor(f.type);
+    off = align(off, shape.align);
+    compiled.push({ name: f.name, offset: off, type: f.type, shape });
+    off += shape.size;
+    if (shape.align > maxAlign) maxAlign = shape.align;
+  }
+  const size = align(off, maxAlign);
+
+  return {
+    size,
+    fields: compiled,
+    read(m, ptr) {
+      const out: Record<string, unknown> = {};
+      for (const c of compiled) out[c.name] = c.shape.read(m, ptr + c.offset);
+      return out;
+    },
+    write(m, ptr, value) {
+      for (const c of compiled)
+        c.shape.write(m, ptr + c.offset, (value as any)[c.name]);
+    },
+  };
+}
+
+/**
+ * Lift a `RustBufferLike` view into a `RustBuffer` that aliases the wasm
+ * `Memory.buffer()` directly — no intermediate copy. Use this on the hot
+ * path for record-shaped types so lift/lower can read/write straight out
+ * of wasm memory. The returned `RustBuffer` is only valid until the next
+ * memory growth or boundary crossing that may detach the buffer.
+ */
+export function liftRustBufferOverMemory(
+  m: Memory,
+  rb: RustBufferLike,
+): RustBuffer {
+  return RustBuffer.fromWasmMemory(m.buffer(), rb.dataPtr, Number(rb.len));
+}

--- a/runtimes/wasm/core/src/memory.ts
+++ b/runtimes/wasm/core/src/memory.ts
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+export class Memory {
+  private memory: WebAssembly.Memory;
+  private cachedDv: DataView;
+  private cachedU8: Uint8Array;
+
+  constructor(memory: WebAssembly.Memory) {
+    this.memory = memory;
+    this.cachedDv = new DataView(memory.buffer);
+    this.cachedU8 = new Uint8Array(memory.buffer);
+  }
+
+  /** Always-current DataView. Cheap if memory has not grown. */
+  dv(): DataView {
+    if (this.cachedDv.buffer !== this.memory.buffer) {
+      this.cachedDv = new DataView(this.memory.buffer);
+    }
+    return this.cachedDv;
+  }
+
+  /** Always-current Uint8Array. Cheap if memory has not grown. */
+  view(): Uint8Array {
+    if (this.cachedU8.buffer !== this.memory.buffer) {
+      this.cachedU8 = new Uint8Array(this.memory.buffer);
+    }
+    return this.cachedU8;
+  }
+
+  buffer(): ArrayBuffer {
+    return this.memory.buffer;
+  }
+
+  readU8(ptr: number): number {
+    return this.dv().getUint8(ptr);
+  }
+  readU32(ptr: number): number {
+    return this.dv().getUint32(ptr, true);
+  }
+  readI32(ptr: number): number {
+    return this.dv().getInt32(ptr, true);
+  }
+  readU64(ptr: number): bigint {
+    return this.dv().getBigUint64(ptr, true);
+  }
+  readF32(ptr: number): number {
+    return this.dv().getFloat32(ptr, true);
+  }
+  readF64(ptr: number): number {
+    return this.dv().getFloat64(ptr, true);
+  }
+
+  writeU8(ptr: number, v: number) {
+    this.dv().setUint8(ptr, v);
+  }
+  writeU32(ptr: number, v: number) {
+    this.dv().setUint32(ptr, v, true);
+  }
+  writeI32(ptr: number, v: number) {
+    this.dv().setInt32(ptr, v, true);
+  }
+  writeU64(ptr: number, v: bigint) {
+    this.dv().setBigUint64(ptr, v, true);
+  }
+  writeF32(ptr: number, v: number) {
+    this.dv().setFloat32(ptr, v, true);
+  }
+  writeF64(ptr: number, v: number) {
+    this.dv().setFloat64(ptr, v, true);
+  }
+
+  /** Returns a fresh `Uint8Array` copy of `[ptr, ptr+len)`. */
+  readBytes(ptr: number, len: number): Uint8Array {
+    return this.view().slice(ptr, ptr + len);
+  }
+
+  writeBytes(ptr: number, src: Uint8Array) {
+    this.view().set(src, ptr);
+  }
+}

--- a/runtimes/wasm/core/src/module.ts
+++ b/runtimes/wasm/core/src/module.ts
@@ -1,0 +1,382 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { Memory } from "./memory.js";
+import { Scratch } from "./scratch.js";
+import {
+  compileStructLayout,
+  type FieldDesc,
+  type StructLayout,
+} from "./marshal.js";
+import {
+  specializeFunction,
+  getCapacityHint,
+  canUseFunctionConstructor,
+  type DispatchContext,
+  type FunctionDef,
+} from "./call.js";
+import { CallbackTable, type CallbackDef } from "./callback.js";
+import { FutureRegistry } from "./future.js";
+
+export type WasmSource =
+  | WebAssembly.Module
+  | ArrayBuffer
+  | Uint8Array
+  | Response
+  | URL
+  | string;
+
+export interface ModuleDefinitions {
+  symbols: {
+    rustbuffer_alloc: string;
+    rustbuffer_free: string;
+    rustbuffer_from_bytes: string;
+  };
+  functions: Record<string, FunctionDef>;
+  callbacks: Record<string, CallbackDef>;
+  structs: Record<string, FieldDesc[]>;
+}
+
+export type NativeModuleInterface = Record<string, (...args: any[]) => any>;
+
+const REQUIRED_EXPORTS = ["__ubrn_alloc", "__ubrn_free", "memory"] as const;
+
+const SCRATCH_BYTES = 64 * 1024;
+
+/**
+ * Resolver for unrecognized wasm import modules. The runner side may run
+ * `wasm-bindgen-cli --target bundler` against the cdylib, leaving the
+ * rewritten wasm with imports against `./<crate>_bg.js`. The env-specific
+ * entry (node/browser) supplies a resolver that dynamic-imports those
+ * relative module paths and hands the named exports back. Any module the
+ * resolver can't satisfy is filled with throwing stubs so calling into a
+ * truly-unwired path fails loudly rather than silently no-op'ing.
+ */
+export type ImportResolver = (
+  moduleName: string,
+) => Promise<Record<string, unknown> | undefined>;
+
+async function buildImports(
+  compiled: WebAssembly.Module,
+  importObject: WebAssembly.Imports,
+  resolveModule: ImportResolver | undefined,
+): Promise<{ resolved: Map<string, Record<string, unknown>> }> {
+  const resolved = new Map<string, Record<string, unknown>>();
+  const seenModules = new Set<string>();
+  for (const imp of WebAssembly.Module.imports(compiled)) {
+    seenModules.add(imp.module);
+  }
+  if (resolveModule) {
+    for (const moduleName of seenModules) {
+      if (moduleName in importObject) continue;
+      const exports = await resolveModule(moduleName);
+      if (exports) {
+        resolved.set(moduleName, exports);
+        (importObject as Record<string, unknown>)[moduleName] = exports;
+      }
+    }
+  }
+  for (const imp of WebAssembly.Module.imports(compiled)) {
+    const slotKey = imp.module;
+    let slot = (importObject as Record<string, Record<string, unknown>>)[
+      slotKey
+    ];
+    if (slot && imp.name in slot) continue;
+    if (!slot) {
+      slot = {};
+      (importObject as Record<string, Record<string, unknown>>)[slotKey] = slot;
+    }
+    switch (imp.kind) {
+      case "function":
+        slot[imp.name] = (..._args: any[]) => {
+          throw new Error(
+            `wasm import ${imp.module}.${imp.name} is a stub — ` +
+              `no resolver provided exports for "${imp.module}".`,
+          );
+        };
+        break;
+      case "global":
+        slot[imp.name] = new WebAssembly.Global(
+          { value: "i32", mutable: false },
+          0,
+        );
+        break;
+      case "memory":
+        slot[imp.name] = new WebAssembly.Memory({ initial: 1 });
+        break;
+      case "table":
+        slot[imp.name] = new WebAssembly.Table({
+          initial: 0,
+          element: "anyfunc",
+        });
+        break;
+    }
+  }
+  return { resolved };
+}
+
+/** Install a JS function in `__indirect_function_table` to receive Rust
+ * panic messages, and tell the helper crate's panic-log slot to dispatch
+ * to it. The helper crate doesn't import an env-namespaced
+ * `__ubrn_panic_log` (that would force every linking cdylib to declare an
+ * unresolvable env import — see `helper-crate/src/lib.rs`); the player
+ * wires it up here via the same trampoline machinery callbacks use. */
+function installPanicLog(
+  callbacks: CallbackTable,
+  memory: Memory,
+  exports: WebAssembly.Exports,
+): void {
+  const setSlot = exports.__ubrn_set_panic_log as
+    | ((idx: number) => void)
+    | undefined;
+  if (typeof setSlot !== "function") return;
+  const panicLogDef: CallbackDef = {
+    args: [{ tag: "UInt32" } as const, { tag: "UInt32" } as const],
+    ret: { tag: "Void" } as const,
+    hasRustCallStatus: false,
+  };
+  const slot = callbacks.installCallbackFunction((ptr: number, len: number) => {
+    const bytes = memory.readBytes(ptr, len);
+    const msg = new TextDecoder().decode(bytes);
+    // eslint-disable-next-line no-console
+    console.error("[Rust panic] " + msg + "\n" + new Error().stack);
+  }, panicLogDef);
+  setSlot(slot);
+}
+
+export class UniffiNativeModule {
+  readonly memory: Memory;
+  readonly scratch: Scratch;
+  readonly exports: WebAssembly.Exports;
+  readonly instance: WebAssembly.Instance;
+  readonly callbacks: CallbackTable;
+  readonly futures: FutureRegistry;
+  readonly alloc: (size: number, align: number) => number;
+  readonly free: (ptr: number, size: number, align: number) => void;
+
+  private constructor(instance: WebAssembly.Instance) {
+    this.instance = instance;
+    this.exports = instance.exports;
+
+    for (const name of REQUIRED_EXPORTS) {
+      if (!(name in this.exports)) {
+        throw new Error(
+          `UniffiNativeModule.open: required export "${name}" not found in wasm module`,
+        );
+      }
+    }
+
+    const wm = this.exports.memory as WebAssembly.Memory;
+    this.memory = new Memory(wm);
+
+    const allocFn = this.exports.__ubrn_alloc as (
+      size: number,
+      align: number,
+    ) => number;
+    const freeFn = this.exports.__ubrn_free as (
+      ptr: number,
+      size: number,
+      align: number,
+    ) => void;
+    this.alloc = allocFn;
+    this.free = freeFn;
+
+    const arenaPtr = allocFn(SCRATCH_BYTES, 8);
+    if (arenaPtr === 0) {
+      throw new Error(
+        "UniffiNativeModule.open: __ubrn_alloc returned 0 for scratch arena",
+      );
+    }
+    this.scratch = new Scratch(
+      arenaPtr,
+      SCRATCH_BYTES,
+      (size) => allocFn(size, 8),
+      (ptr, size) => freeFn(ptr, size, 8),
+    );
+
+    // Build the callback dispatch infrastructure first — `installPanicLog`
+    // emits a trampoline through it, and the `__ubrn_dispatch` import
+    // closure forwards to `callbacks.dispatch` so any later panic from
+    // inside an FFI call routes correctly.
+    this.callbacks = new CallbackTable(this.memory, this.exports, true);
+    this.futures = new FutureRegistry(this.callbacks);
+
+    installPanicLog(this.callbacks, this.memory, this.exports);
+    if (typeof this.exports.__ubrn_install_panic_hook === "function") {
+      (this.exports.__ubrn_install_panic_hook as () => void)();
+    }
+  }
+
+  static async open(
+    source: WasmSource,
+    options?: { resolveModule?: ImportResolver },
+  ): Promise<UniffiNativeModule> {
+    let compiled: WebAssembly.Module;
+    if (source instanceof WebAssembly.Module) {
+      compiled = source;
+    } else if (source instanceof ArrayBuffer || source instanceof Uint8Array) {
+      compiled = await WebAssembly.compile(source as BufferSource);
+    } else if (typeof Response !== "undefined" && source instanceof Response) {
+      compiled = await WebAssembly.compileStreaming(source);
+    } else {
+      throw new Error(
+        "UniffiNativeModule.open: URL/string sources must be resolved by the env-specific entry",
+      );
+    }
+
+    // Per-instance imports: the closures below close over `created`, which we
+    // populate after instantiation. They will reject if invoked during the
+    // instantiation start function (start-section panics happen before we have
+    // a UniffiNativeModule to dispatch through).
+    let created: UniffiNativeModule | null = null;
+
+    const importObject: WebAssembly.Imports = {
+      env: {
+        __ubrn_dispatch: (...args: any[]) => {
+          const mod = created;
+          if (!mod) {
+            throw new Error(
+              "__ubrn_dispatch invoked before module construction completed",
+            );
+          }
+          return mod.callbacks.dispatch(...(args as [number, ...any[]]));
+        },
+      },
+    };
+    const { resolved } = await buildImports(
+      compiled,
+      importObject,
+      options?.resolveModule,
+    );
+
+    const instance = await WebAssembly.instantiate(compiled, importObject);
+
+    // wasm-bindgen-bundler glue files expose `__wbg_set_wasm` so JS-side
+    // helpers can reach back into the wasm exports. Wire that up before
+    // calling any exports, then run `__wbindgen_start` (wasm-bindgen's
+    // initializer; it sets up the panic hook the wbg-glued bindings need).
+    for (const exports of resolved.values()) {
+      const setter = exports["__wbg_set_wasm"];
+      if (typeof setter === "function") {
+        (setter as (w: WebAssembly.Exports) => void)(instance.exports);
+      }
+    }
+    const startFn = instance.exports["__wbindgen_start"];
+    if (typeof startFn === "function") {
+      (startFn as () => void)();
+    }
+
+    created = new UniffiNativeModule(instance);
+    return created;
+  }
+
+  async register(
+    definitions: ModuleDefinitions,
+    opts?: { disableJit?: boolean },
+  ): Promise<NativeModuleInterface> {
+    return this.registerSync(definitions, opts);
+  }
+
+  registerSync(
+    definitions: ModuleDefinitions,
+    opts?: { disableJit?: boolean },
+  ): NativeModuleInterface {
+    if (!definitions.symbols.rustbuffer_alloc) {
+      throw new Error(
+        "register: definitions.symbols.rustbuffer_alloc must be a non-empty string",
+      );
+    }
+    if (!definitions.symbols.rustbuffer_free) {
+      throw new Error(
+        "register: definitions.symbols.rustbuffer_free must be a non-empty string",
+      );
+    }
+    const structs = new Map<string, StructLayout>();
+    for (const [name, fields] of Object.entries(definitions.structs)) {
+      structs.set(name, compileStructLayout(fields));
+    }
+    const callbackDefs = new Map(Object.entries(definitions.callbacks));
+    // Hand the resolution context to the CallbackTable so that when a
+    // wasm-to-JS dispatch lifts a `Callback`-typed arg (a function-table
+    // index Rust passed in), we can wrap it in a JS callable that lowers
+    // its args via the registered shape's `args` and the compiled struct
+    // layouts.
+    this.callbacks.setRegistrationContext({ callbackDefs, structs });
+    // Probe once at register time: under strict CSP `new Function` throws,
+    // and the caller may explicitly opt out via `disableJit` (used by tests
+    // that want to exercise the interpreted path).
+    const useJit = !opts?.disableJit && canUseFunctionConstructor();
+    const ctx: DispatchContext = {
+      memory: this.memory,
+      scratch: this.scratch,
+      structs,
+      callbackDefs,
+      alloc: this.alloc,
+      free: this.free,
+      installCallback: (fn, def) =>
+        this.callbacks.installCallbackFunction(fn, def),
+      useJit,
+    };
+
+    const result: NativeModuleInterface = Object.create(null);
+    for (const [fnName, def] of Object.entries(definitions.functions)) {
+      const exportFn = this.exports[fnName];
+      if (typeof exportFn !== "function") {
+        throw new Error(`register: wasm export "${fnName}" not found`);
+      }
+      result[fnName] = specializeFunction(ctx, exportFn, def, fnName);
+    }
+
+    // JS-callable allocator pair, exposed alongside the per-function entries.
+    // A converter handed `rustbuffer_alloc` as its `lower(value, alloc)`
+    // writes its payload straight into a view over wasm memory;
+    // `writeRustBufferPayload` then spots the wasm-aliased view and forwards
+    // `(byteOffset, byteLength)` into the `RustBuffer` struct, so neither
+    // side copies.
+    //
+    // The helper crate's `__ubrn_alloc` / `__ubrn_free` back this rather than
+    // `ffi_<crate>_rustbuffer_alloc`. Both reach the same Rust global
+    // allocator, so Rust can still take ownership via `Vec::from_raw_parts`,
+    // and the path stays crate-agnostic — no per-crate symbol lookup at
+    // register time.
+    const memory = this.memory;
+    const alloc = this.alloc;
+    const free = this.free;
+    /**
+     * Allocate `n` bytes of wasm linear memory and return a Uint8Array view
+     * over them. The view aliases wasm memory directly — no copy.
+     *
+     * Lifetime: the caller MUST call `rustbuffer_free(view)` before any other
+     * wasm operation that could trigger `WebAssembly.Memory.grow` (which
+     * detaches the underlying ArrayBuffer). Common detaching operations
+     * include subsequent `rustbuffer_alloc` calls and FFI calls that allocate
+     * Rust-side. After detachment, the view's byteLength becomes 0 and
+     * `rustbuffer_free(view)` will leak the original allocation.
+     */
+    result.rustbuffer_alloc = (n: number): Uint8Array => {
+      if (n === 0) return new Uint8Array(0);
+      const ptr = alloc(n, 1);
+      return new Uint8Array(memory.buffer(), ptr, n);
+    };
+    result.rustbuffer_free = (view: Uint8Array): void => {
+      const hint = getCapacityHint(view);
+      if (view.byteLength === 0 && hint === undefined) return;
+      if ((view.buffer as ArrayBuffer).byteLength === 0) {
+        throw new Error(
+          "rustbuffer_free: view is detached (held across a wasm memory growth?)",
+        );
+      }
+      // Rust may over-allocate a returned RustBuffer, so its capacity can
+      // exceed the view's byteLength. The handoff path stashes the real
+      // capacity via `setCapacityHint`. Views from `rustbuffer_alloc` carry no
+      // hint because their length already is the allocation size.
+      const cap = hint ?? view.byteLength;
+      if (cap === 0) return;
+      free(view.byteOffset, cap, 1);
+    };
+
+    return result;
+  }
+}

--- a/runtimes/wasm/core/src/scratch.ts
+++ b/runtimes/wasm/core/src/scratch.ts
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+type Alloc = (size: number) => number;
+type Free = (ptr: number, size: number) => void;
+
+/**
+ * Stack-discipline bump arena over a region of wasm linear memory.
+ *
+ * `push(n)` returns a pointer to `n` bytes. If the arena is full, falls
+ * back to the supplied allocator. `pop(ptr)` must be called in LIFO order
+ * with the value returned by the matching `push`. If the pointer was an
+ * overflow allocation, it is freed via the supplied free fn.
+ */
+export class Scratch {
+  private mark = 0; // offset within arena
+  private reservedHigh = 0; // boundary between reserved (below) and push/pop (above)
+  private hasPushed = false; // once true, no more reserve() calls allowed
+  private overflow = new Map<number, number>(); // ptr -> size
+  private maxArenaSize: number;
+
+  constructor(
+    private arenaPtr: number,
+    private arenaSize: number,
+    private alloc: Alloc,
+    private free: Free,
+    maxArenaSize?: number,
+  ) {
+    this.maxArenaSize = maxArenaSize ?? arenaSize;
+  }
+
+  /**
+   * Carve a permanent region from the arena, returning its starting offset
+   * within wasm memory. Must be called BEFORE any push(). Survives every
+   * push/pop cycle for the arena's lifetime.
+   *
+   * Note: the returned region is a SINGLE address shared across every caller
+   * that holds it. It is suitable only for transient scratch within a single
+   * synchronous call frame — callers must not assume its contents survive
+   * across re-entry. If the wasm export whose dispatcher owns this region is
+   * synchronously re-entered (e.g. via a JS callback that calls the same
+   * export), the inner call will overwrite the outer call's scratch (status
+   * byte, sret slot, lowered arg buffers). Callers that need re-entrant
+   * isolation must use `push`/`pop` per call instead of reserving up front.
+   */
+  reserve(size: number): number {
+    if (this.hasPushed) {
+      throw new Error("Scratch.reserve: cannot reserve after the first push()");
+    }
+    // Callers lay RustCallStatus / RustBuffer structs out relative to the
+    // returned base assuming it is 8-byte aligned (both have align 8). The
+    // arena base is 8-aligned, so keep every carve-off 8-aligned too.
+    const start = (this.reservedHigh + 7) & ~7;
+    if (start + size > this.arenaSize) {
+      throw new Error(
+        `Scratch.reserve: arena exhausted (need ${size}, have ${this.arenaSize - start})`,
+      );
+    }
+    const p = this.arenaPtr + start;
+    this.reservedHigh = start + size;
+    this.mark = this.reservedHigh;
+    return p;
+  }
+
+  push(size: number): number {
+    this.hasPushed = true;
+    if (this.mark + size > this.maxArenaSize) {
+      const p = this.alloc(size);
+      this.overflow.set(p, size);
+      return p;
+    }
+    const p = this.arenaPtr + this.mark;
+    this.mark += size;
+    return p;
+  }
+
+  pop(ptr: number): void {
+    const overflowSize = this.overflow.get(ptr);
+    if (overflowSize !== undefined) {
+      this.overflow.delete(ptr);
+      this.free(ptr, overflowSize);
+      return;
+    }
+    // Stack discipline: ptr must be the most recent in-arena push.
+    const offset = ptr - this.arenaPtr;
+    if (offset < this.reservedHigh || offset >= this.arenaSize) {
+      throw new Error(
+        `Scratch.pop: pointer ${ptr} not within push region (reserved high=${this.reservedHigh})`,
+      );
+    }
+    this.mark = offset;
+  }
+}

--- a/runtimes/wasm/core/src/trampoline.ts
+++ b/runtimes/wasm/core/src/trampoline.ts
@@ -1,0 +1,172 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Hand-rolled wasm encoder for the *single* shape we emit: a trampoline
+// function that pushes a shape id and forwards its args to a JS-imported
+// `env.__ubrn_dispatch`. Encoding here rather than in the helper crate keeps
+// the wasm-encoder crate — some 4 MB per cdylib — out of every fixture.
+//
+// Output layout:
+//
+//   (module
+//     (type $trampoline (func (param ...) (result ...)))
+//     (type $dispatch   (func (param i32 ...) (result ...)))
+//     (import "env" "__ubrn_dispatch" (func $dispatch (type 1)))
+//     (func $trampoline (type 0)
+//       i32.const <shape_id>
+//       local.get 0 ... local.get N
+//       call $dispatch)
+//     (export "trampoline" (func $trampoline)))
+
+export const TAG_I32 = 0;
+export const TAG_I64 = 1;
+export const TAG_F32 = 2;
+export const TAG_F64 = 3;
+
+const VALTYPE_I32 = 0x7f;
+const VALTYPE_I64 = 0x7e;
+const VALTYPE_F32 = 0x7d;
+const VALTYPE_F64 = 0x7c;
+
+function tagToValtype(tag: number): number {
+  switch (tag) {
+    case TAG_I32:
+      return VALTYPE_I32;
+    case TAG_I64:
+      return VALTYPE_I64;
+    case TAG_F32:
+      return VALTYPE_F32;
+    case TAG_F64:
+      return VALTYPE_F64;
+    default:
+      throw new Error(`emitTrampoline: unknown type tag ${tag}`);
+  }
+}
+
+/** Append unsigned LEB128 of `n` (≥ 0) to `out`. */
+function leb128(out: number[], n: number): void {
+  do {
+    let byte = n & 0x7f;
+    n >>>= 7;
+    if (n !== 0) byte |= 0x80;
+    out.push(byte);
+  } while (n !== 0);
+}
+
+/** Append signed LEB128 of `n` to `out`. */
+function sleb128(out: number[], n: number): void {
+  for (;;) {
+    let byte = n & 0x7f;
+    // Arithmetic shift right preserves sign.
+    n >>= 7;
+    const sign = byte & 0x40;
+    if ((n === 0 && sign === 0) || (n === -1 && sign !== 0)) {
+      out.push(byte);
+      return;
+    }
+    out.push(byte | 0x80);
+  }
+}
+
+const ASCII = new TextEncoder();
+function encodeName(out: number[], s: string): void {
+  const bytes = ASCII.encode(s);
+  leb128(out, bytes.length);
+  for (const b of bytes) out.push(b);
+}
+
+function pushSection(out: number[], id: number, payload: number[]): void {
+  out.push(id);
+  leb128(out, payload.length);
+  for (const b of payload) out.push(b);
+}
+
+function encodeFuncType(
+  out: number[],
+  params: number[],
+  results: number[],
+): void {
+  out.push(0x60);
+  leb128(out, params.length);
+  for (const p of params) out.push(p);
+  leb128(out, results.length);
+  for (const r of results) out.push(r);
+}
+
+/**
+ * Emit a wasm trampoline module. `paramTags` are the trampoline's
+ * exposed parameter type tags; `returnTag` is `undefined` for void.
+ * `shapeId` is forwarded as the first arg to `__ubrn_dispatch`. */
+export function emitTrampoline(
+  shapeId: number,
+  paramTags: number[],
+  returnTag: number | undefined,
+): Uint8Array {
+  const params = paramTags.map(tagToValtype);
+  const results = returnTag !== undefined ? [tagToValtype(returnTag)] : [];
+
+  // -- Type section: type 0 = trampoline, type 1 = dispatch (i32, ...params)
+  const typeSection: number[] = [];
+  leb128(typeSection, 2); // 2 type definitions
+  encodeFuncType(typeSection, params, results);
+  encodeFuncType(typeSection, [VALTYPE_I32, ...params], results);
+
+  // -- Import section: env.__ubrn_dispatch (func type 1) — function index 0
+  const importSection: number[] = [];
+  leb128(importSection, 1);
+  encodeName(importSection, "env");
+  encodeName(importSection, "__ubrn_dispatch");
+  importSection.push(0x00); // import kind: function
+  leb128(importSection, 1); // type index 1
+
+  // -- Function section: 1 local function of type 0 (function index 1)
+  const funcSection: number[] = [];
+  leb128(funcSection, 1);
+  leb128(funcSection, 0);
+
+  // -- Export section: "trampoline" -> function index 1
+  const exportSection: number[] = [];
+  leb128(exportSection, 1);
+  encodeName(exportSection, "trampoline");
+  exportSection.push(0x00); // export kind: function
+  leb128(exportSection, 1); // function index 1
+
+  // -- Code section: one function body, no locals.
+  //    Body: i32.const shapeId, local.get 0..N-1, call 0, end.
+  const body: number[] = [];
+  leb128(body, 0); // 0 local declarations
+  body.push(0x41); // i32.const
+  sleb128(body, shapeId);
+  for (let i = 0; i < params.length; i++) {
+    body.push(0x20); // local.get
+    leb128(body, i);
+  }
+  body.push(0x10); // call
+  leb128(body, 0); // function index 0 (the imported dispatch)
+  body.push(0x0b); // end
+
+  const codeSection: number[] = [];
+  leb128(codeSection, 1); // 1 function body
+  leb128(codeSection, body.length); // body length
+  for (const b of body) codeSection.push(b);
+
+  const out: number[] = [
+    0x00,
+    0x61,
+    0x73,
+    0x6d, // magic: \0asm
+    0x01,
+    0x00,
+    0x00,
+    0x00, // version: 1
+  ];
+  pushSection(out, 1, typeSection);
+  pushSection(out, 2, importSection);
+  pushSection(out, 3, funcSection);
+  pushSection(out, 7, exportSection);
+  pushSection(out, 10, codeSection);
+
+  return new Uint8Array(out);
+}

--- a/runtimes/wasm/core/tests/browser-entry.test.ts
+++ b/runtimes/wasm/core/tests/browser-entry.test.ts
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Smoke tests for the browser entry; every fixture goes through
+// `@ubjs/wasm/node` instead.
+//
+// Node supplies `Response` and `instantiateStreaming`, so `openWasm` is driven
+// as a page would drive it. This covers our code, not a browser engine or a
+// bundler.
+import { test } from "node:test";
+import assert from "node:assert";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { openWasm } from "../../browser/src/index.js";
+
+/** The same pre-assembled host module `module.test.ts` uses: exports
+ * `memory`, `__ubrn_alloc`, `__ubrn_free`, `__ubrn_install_panic_hook` and
+ * `__ubrn_emit_trampoline`, which is the minimum `UniffiNativeModule.open`
+ * requires. Assembled with `wat2wasm`; see that file for the source .wat. */
+const WASM = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 29, 5, 96, 2, 127, 127, 0, 96, 2, 127, 127, 1,
+  127, 96, 3, 127, 127, 127, 0, 96, 0, 0, 96, 4, 127, 127, 127, 127, 1, 127, 2,
+  24, 1, 3, 101, 110, 118, 16, 95, 95, 117, 98, 114, 110, 95, 112, 97, 110, 105,
+  99, 95, 108, 111, 103, 0, 0, 3, 5, 4, 1, 2, 3, 4, 5, 3, 1, 0, 1, 7, 92, 5, 6,
+  109, 101, 109, 111, 114, 121, 2, 0, 12, 95, 95, 117, 98, 114, 110, 95, 97,
+  108, 108, 111, 99, 0, 1, 11, 95, 95, 117, 98, 114, 110, 95, 102, 114, 101,
+  101, 0, 2, 25, 95, 95, 117, 98, 114, 110, 95, 105, 110, 115, 116, 97, 108,
+  108, 95, 112, 97, 110, 105, 99, 95, 104, 111, 111, 107, 0, 3, 22, 95, 95, 117,
+  98, 114, 110, 95, 101, 109, 105, 116, 95, 116, 114, 97, 109, 112, 111, 108,
+  105, 110, 101, 0, 4, 10, 18, 4, 5, 0, 65, 128, 8, 11, 2, 0, 11, 2, 0, 11, 4,
+  0, 65, 0, 11,
+]);
+
+function wasmResponse(bytes: Uint8Array): Response {
+  return new Response(bytes as unknown as BodyInit, {
+    headers: { "content-type": "application/wasm" },
+  });
+}
+
+test("browser openWasm accepts a Response", async () => {
+  const mod = await openWasm(wasmResponse(WASM));
+  assert.ok(mod, "expected a module back");
+});
+
+test("browser openWasm accepts a Promise<Response>", async () => {
+  // Its own WasmSource union advertises this; a bare `fetch(...)` produces it.
+  const mod = await openWasm(Promise.resolve(wasmResponse(WASM)));
+  assert.ok(mod, "expected a module back from a Promise<Response>");
+});
+
+test("browser openWasm accepts raw bytes", async () => {
+  const mod = await openWasm(WASM);
+  assert.ok(mod, "expected a module back from a BufferSource");
+});
+
+test("the browser entry pulls in no node built-ins", async () => {
+  // A generated `-ffi.ts` importing `@ubjs/wasm/node` would drag
+  // `node:fs/promises` and `node:url` into every browser and React Native
+  // bundle.
+  const src = await readFile(
+    fileURLToPath(new URL("../../browser/src/index.ts", import.meta.url)),
+    "utf8",
+  );
+  const offenders = [...src.matchAll(/from\s+"(node:[^"]+)"/g)].map(
+    (m) => m[1],
+  );
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    `browser entry must not import node built-ins, found: ${offenders.join(", ")}`,
+  );
+});

--- a/runtimes/wasm/core/tests/call.test.ts
+++ b/runtimes/wasm/core/tests/call.test.ts
@@ -1,0 +1,324 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { UniffiNativeModule } from "../src/module.js";
+import { FfiType } from "../src/ffi-type.js";
+import {
+  buildJitDispatcher,
+  canUseFunctionConstructor,
+  type DispatchContext,
+  type FunctionDef,
+} from "../src/call.js";
+import { Memory } from "../src/memory.js";
+import { Scratch } from "../src/scratch.js";
+
+/**
+ * Pre-assembled bytes for a synthetic wasm module with one user function and
+ * the required helper exports. Generated via:
+ *
+ *   wat2wasm /tmp/host-call.wat -o /tmp/host-call.wasm
+ *
+ * from the following .wat:
+ *
+ *   (module
+ *     (memory (export "memory") 1)
+ *     (func (export "uniffi_test_add") (param i32 i32 i32) (result i32)
+ *       local.get 0 local.get 1 i32.add)
+ *     (func (export "__ubrn_alloc") (param i32 i32) (result i32) i32.const 1024)
+ *     (func (export "__ubrn_free") (param i32 i32 i32))
+ *     (func (export "__ubrn_emit_trampoline") (param i32 i32 i32 i32) (result i32) i32.const 0)
+ *   )
+ *
+ * `uniffi_test_add` declares three i32 params because the UniFFI Rust call
+ * convention passes the `out_status` pointer as the LAST i32. The wasm body
+ * only adds the first two; the third (status pointer) is unused but must be
+ * present in the type.
+ */
+const HOST_BYTES = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 28, 4, 96, 3, 127, 127, 127, 1, 127, 96, 2,
+  127, 127, 1, 127, 96, 3, 127, 127, 127, 0, 96, 4, 127, 127, 127, 127, 1, 127,
+  3, 5, 4, 0, 1, 2, 3, 5, 3, 1, 0, 1, 7, 82, 5, 6, 109, 101, 109, 111, 114, 121,
+  2, 0, 15, 117, 110, 105, 102, 102, 105, 95, 116, 101, 115, 116, 95, 97, 100,
+  100, 0, 0, 12, 95, 95, 117, 98, 114, 110, 95, 97, 108, 108, 111, 99, 0, 1, 11,
+  95, 95, 117, 98, 114, 110, 95, 102, 114, 101, 101, 0, 2, 22, 95, 95, 117, 98,
+  114, 110, 95, 101, 109, 105, 116, 95, 116, 114, 97, 109, 112, 111, 108, 105,
+  110, 101, 0, 3, 10, 23, 4, 7, 0, 32, 0, 32, 1, 106, 11, 5, 0, 65, 128, 8, 11,
+  2, 0, 11, 4, 0, 65, 0, 11,
+]);
+
+test("specialized dispatcher calls the wasm fn and reads sret/status", async () => {
+  const mod = await UniffiNativeModule.open(HOST_BYTES);
+  const nm = await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {
+      uniffi_test_add: {
+        args: [FfiType.Int32, FfiType.Int32],
+        ret: FfiType.Int32,
+        hasRustCallStatus: true,
+      },
+    },
+    callbacks: {},
+    structs: {},
+  });
+  const status = { code: 0 };
+  const result = nm.uniffi_test_add(3, 4, status);
+  assert.strictEqual(result, 7);
+  assert.strictEqual(status.code, 0);
+});
+
+// No RustBuffer round-trip here: a synthetic one needs a working bump
+// allocator inside the test wasm. The fixture suite covers it end to end —
+// every fixture using a record or string crosses planArg + planRet with a
+// real wasm-side allocator.
+
+test("canUseFunctionConstructor returns true in Node without CSP", () => {
+  assert.strictEqual(canUseFunctionConstructor(), true);
+});
+
+/**
+ * Hand `buildJitDispatcher` a stub exportFn and a synthetic memory/scratch
+ * backed by a plain WebAssembly.Memory, and check that the JIT body
+ *   - zeros the status region before the call,
+ *   - forwards the user arg through to exportFn unchanged (modulo |0),
+ *   - appends the status pointer to the wasm-side arg list,
+ *   - reads the u8 status byte after the call,
+ *   - returns the scalar value the exportFn produced.
+ */
+test("buildJitDispatcher emits a body that calls fn + reads status (u32 → u32)", () => {
+  const wasmMem = new WebAssembly.Memory({ initial: 1 });
+  const memory = new Memory(wasmMem);
+  // Pretend bump-allocator: hand out monotonically increasing offsets,
+  // starting well past the scratch region.
+  let allocCursor = 8192;
+  const scratch = new Scratch(
+    256,
+    1024,
+    (size) => {
+      const p = allocCursor;
+      allocCursor += size;
+      return p;
+    },
+    (_ptr, _size) => {},
+  );
+
+  const calls: any[][] = [];
+  const exportFn = (...args: any[]) => {
+    calls.push(args);
+    // Caller passed (a0, statusPtr). Echo a0 back as the scalar return.
+    return args[0];
+  };
+
+  const ctx: DispatchContext = {
+    memory,
+    scratch,
+    structs: new Map(),
+    callbackDefs: new Map(),
+    alloc: (size, _align) => {
+      const p = allocCursor;
+      allocCursor += size;
+      return p;
+    },
+    free: () => {},
+    installCallback: () => {
+      throw new Error("not used");
+    },
+    useJit: true,
+  };
+
+  const def: FunctionDef = {
+    args: [FfiType.UInt32],
+    ret: FfiType.UInt32,
+    hasRustCallStatus: true,
+  };
+
+  // Pre-poison the status byte so we can verify the JIT body zeros it.
+  // The reserved layout starts at the arena base (256) with status at
+  // offset 0 and is 32 bytes wide.
+  memory.writeU8(256, 0x7f);
+
+  const dispatch = buildJitDispatcher(ctx, exportFn, def, "test_fn");
+  assert.ok(dispatch, "buildJitDispatcher returned a function");
+
+  const status = { code: 0xff, errorBuf: undefined as any };
+  const result = (dispatch as (...a: any[]) => unknown)(42, status);
+
+  assert.strictEqual(result, 42, "scalar return value forwarded");
+  assert.strictEqual(calls.length, 1, "exportFn called exactly once");
+  // Wasm-side args: (a0, statusPtr). a0 coerced via `| 0` is still 42.
+  assert.strictEqual(calls[0][0], 42);
+  assert.strictEqual(typeof calls[0][1], "number");
+  // Status code must be re-read from memory (we zeroed it before the call,
+  // and exportFn didn't touch it, so it reads back as 0).
+  assert.strictEqual(status.code, 0, "status.code reflects the zeroed byte");
+});
+
+/**
+ * The error path of the JIT test above. The stub `exportFn` writes `code=1`
+ * to the status byte and points the errorBuf RustBuffer slot at a fixed
+ * payload in wasm memory. The dispatcher must:
+ *   - read the non-zero status code into statusObj.code,
+ *   - copy the errorBuf payload bytes into a JS-owned Uint8Array on
+ *     statusObj.errorBuf (matching what `copyAndFreeRustBuffer` returns),
+ *   - return undefined (skipping the sret read on the error path).
+ */
+test("buildJitDispatcher error path: code != 0 populates statusObj.errorBuf", () => {
+  const wasmMem = new WebAssembly.Memory({ initial: 1 });
+  const memory = new Memory(wasmMem);
+  let allocCursor = 8192;
+  const frees: Array<[number, number]> = [];
+  const scratch = new Scratch(
+    256,
+    1024,
+    (size) => {
+      const p = allocCursor;
+      allocCursor += size;
+      return p;
+    },
+    (_ptr, _size) => {},
+  );
+
+  // Stash the errorBuf payload at a known location in wasm memory, well
+  // outside the scratch region.
+  const ERROR_PAYLOAD = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+  const errorPayloadPtr = 16384;
+  memory.writeBytes(errorPayloadPtr, ERROR_PAYLOAD);
+
+  // Reserved layout (computed in buildJitDispatcher via computeAndReserveLayout):
+  // status at base+0 (32 bytes: code u8 + pad, then RustBuffer at +8).
+  // RustBuffer layout: capacity u64 at +0, len u64 at +8, dataPtr u32 at +16.
+  const STATUS_BASE = 256;
+  const ERRBUF_BASE = STATUS_BASE + 8; // RCS_ERROR_BUF_OFF
+
+  const exportFn = (...args: any[]) => {
+    // Last arg is the status pointer. Write code=1 and populate errorBuf.
+    const statusPtr = args[args.length - 1];
+    memory.writeU8(statusPtr, 1);
+    // errorBuf: capacity=4, len=4, dataPtr=errorPayloadPtr.
+    memory.writeU64(statusPtr + 8 + 0, 4n);
+    memory.writeU64(statusPtr + 8 + 8, 4n);
+    memory.writeU32(statusPtr + 8 + 16, errorPayloadPtr);
+    // Scalar return is meaningless on the error path; Rust hasn't written
+    // a valid value, but we still return *something* so the host call
+    // completes normally — the dispatcher must skip the sret read anyway.
+    return 0;
+  };
+
+  const ctx: DispatchContext = {
+    memory,
+    scratch,
+    structs: new Map(),
+    callbackDefs: new Map(),
+    alloc: (size, _align) => {
+      const p = allocCursor;
+      allocCursor += size;
+      return p;
+    },
+    free: (ptr, size, _align) => {
+      frees.push([ptr, size]);
+    },
+    installCallback: () => {
+      throw new Error("not used");
+    },
+    useJit: true,
+  };
+
+  const def: FunctionDef = {
+    args: [FfiType.UInt32],
+    ret: FfiType.UInt32,
+    hasRustCallStatus: true,
+  };
+
+  const dispatch = buildJitDispatcher(ctx, exportFn, def, "test_err_fn");
+  assert.ok(dispatch, "buildJitDispatcher returned a function");
+
+  const status = { code: 0, errorBuf: undefined as any };
+  const result = (dispatch as (...a: any[]) => unknown)(99, status);
+
+  assert.strictEqual(result, undefined, "error path returns undefined");
+  assert.strictEqual(status.code, 1, "status.code propagated from wasm memory");
+  // copyAndFreeRustBuffer reads `len` bytes from dataPtr into a fresh
+  // Uint8Array and frees the wasm allocation.
+  assert.ok(
+    status.errorBuf instanceof Uint8Array,
+    "errorBuf lifted into a Uint8Array",
+  );
+  assert.strictEqual(
+    (status.errorBuf as Uint8Array).byteLength,
+    4,
+    "errorBuf length matches the wasm-side RustBuffer.len",
+  );
+  assert.deepStrictEqual(
+    Array.from(status.errorBuf as Uint8Array),
+    Array.from(ERROR_PAYLOAD),
+    "errorBuf payload copied byte-for-byte from wasm memory",
+  );
+  // The copy path also frees the wasm allocation (capacity bytes).
+  assert.deepStrictEqual(
+    frees,
+    [[errorPayloadPtr, 4]],
+    "copyAndFreeRustBuffer freed the errorBuf allocation",
+  );
+});
+
+test("buildJitDispatcher returns undefined for unsupported (callback) arg", () => {
+  const wasmMem = new WebAssembly.Memory({ initial: 1 });
+  const memory = new Memory(wasmMem);
+  const scratch = new Scratch(
+    256,
+    1024,
+    () => 0,
+    () => {},
+  );
+  const ctx: DispatchContext = {
+    memory,
+    scratch,
+    structs: new Map(),
+    callbackDefs: new Map(),
+    alloc: () => 0,
+    free: () => {},
+    installCallback: () => 0,
+    useJit: true,
+  };
+  const def: FunctionDef = {
+    args: [FfiType.Callback("cb")],
+    ret: FfiType.Void,
+    hasRustCallStatus: false,
+  };
+  const jit = buildJitDispatcher(ctx, () => 0, def, "f");
+  assert.strictEqual(jit, undefined);
+});
+
+test("registerSync({disableJit:true}) still produces a working dispatcher", async () => {
+  const mod = await UniffiNativeModule.open(HOST_BYTES);
+  const nm = mod.registerSync(
+    {
+      symbols: {
+        rustbuffer_alloc: "_",
+        rustbuffer_free: "_",
+        rustbuffer_from_bytes: "_",
+      },
+      functions: {
+        uniffi_test_add: {
+          args: [FfiType.Int32, FfiType.Int32],
+          ret: FfiType.Int32,
+          hasRustCallStatus: true,
+        },
+      },
+      callbacks: {},
+      structs: {},
+    },
+    { disableJit: true },
+  );
+  const status = { code: 0 };
+  const result = nm.uniffi_test_add(5, 6, status);
+  assert.strictEqual(result, 11);
+  assert.strictEqual(status.code, 0);
+});

--- a/runtimes/wasm/core/tests/callback.test.ts
+++ b/runtimes/wasm/core/tests/callback.test.ts
@@ -1,0 +1,260 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { UniffiNativeModule } from "../src/module.js";
+import { FfiType } from "../src/ffi-type.js";
+
+/**
+ * Pre-assembled bytes for a synthetic host wasm module that lets us exercise
+ * the JS-side CallbackTable end-to-end without the helper crate's cdylib.
+ *
+ * Shape:
+ *
+ *   (module
+ *     (memory (export "memory") 1)
+ *     (table (export "__indirect_function_table") 4 funcref)
+ *     (type $cb (func (param i32 i32) (result i32))) ;; (handle, x) -> i32
+ *
+ *     ;; Bump-allocator backed by a mutable global at 1024.
+ *     (func (export "__ubrn_alloc") (param i32 i32) (result i32) ...)
+ *     (func (export "__ubrn_free") (param i32 i32 i32))
+ *
+ *     ;; __ubrn_emit_trampoline(out_ptr, out_cap, _sig_ptr, _sig_len) -> i32
+ *     ;; ignores the descriptor and copies a pre-baked trampoline blob
+ *     ;; (shapeId=0, params=[i32,i32], ret=i32) from memory[0..len) to out_ptr.
+ *     (func (export "__ubrn_emit_trampoline") ...)
+ *
+ *     ;; uniffi_invoke(x): call_indirect (type $cb) (handle=1) (x) (table_index=0)
+ *     (func (export "uniffi_invoke") (param i32) (result i32) ...))
+ *
+ * Per the UniFFI vtable convention `fn(self_handle, args...)`, the host
+ * passes the *handle* as the first argument; the JS dispatcher in
+ * `callback.ts` strips it to look up the closure.
+ */
+// host wasm bytes (length=359)
+// trampoline blob length: 83
+const CB_HOST_BYTES = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 35, 6, 96, 0, 0, 96, 2, 127, 127, 1, 127, 96,
+  3, 127, 127, 127, 0, 96, 4, 127, 127, 127, 127, 1, 127, 96, 1, 127, 1, 127,
+  96, 2, 127, 127, 1, 127, 2, 1, 0, 3, 5, 4, 1, 2, 3, 4, 4, 4, 1, 112, 0, 4, 5,
+  3, 1, 0, 4, 6, 7, 1, 127, 1, 65, 128, 8, 11, 7, 108, 6, 6, 109, 101, 109, 111,
+  114, 121, 2, 0, 25, 95, 95, 105, 110, 100, 105, 114, 101, 99, 116, 95, 102,
+  117, 110, 99, 116, 105, 111, 110, 95, 116, 97, 98, 108, 101, 1, 0, 12, 95, 95,
+  117, 98, 114, 110, 95, 97, 108, 108, 111, 99, 0, 0, 11, 95, 95, 117, 98, 114,
+  110, 95, 102, 114, 101, 101, 0, 1, 22, 95, 95, 117, 98, 114, 110, 95, 101,
+  109, 105, 116, 95, 116, 114, 97, 109, 112, 111, 108, 105, 110, 101, 0, 2, 13,
+  117, 110, 105, 102, 102, 105, 95, 105, 110, 118, 111, 107, 101, 0, 3, 9, 1, 0,
+  10, 78, 4, 32, 1, 1, 127, 35, 0, 32, 1, 65, 1, 107, 106, 32, 1, 65, 1, 107,
+  65, 127, 115, 113, 33, 2, 32, 2, 32, 0, 106, 36, 0, 32, 2, 11, 2, 0, 11, 28,
+  0, 32, 1, 65, 211, 0, 73, 4, 64, 65, 0, 15, 11, 32, 0, 65, 0, 65, 211, 0, 252,
+  10, 0, 0, 65, 211, 0, 11, 11, 0, 65, 1, 32, 0, 65, 0, 17, 5, 0, 11, 11, 89, 1,
+  0, 65, 0, 11, 83, 0, 97, 115, 109, 1, 0, 0, 0, 1, 14, 2, 96, 2, 127, 127, 1,
+  127, 96, 3, 127, 127, 127, 1, 127, 2, 23, 1, 3, 101, 110, 118, 15, 95, 95,
+  117, 98, 114, 110, 95, 100, 105, 115, 112, 97, 116, 99, 104, 0, 1, 3, 2, 1, 0,
+  7, 14, 1, 10, 116, 114, 97, 109, 112, 111, 108, 105, 110, 101, 0, 1, 10, 12,
+  1, 10, 0, 65, 0, 32, 0, 32, 1, 16, 0, 11,
+]);
+
+test("callback round-trip through trampoline + dispatch", async () => {
+  const mod = await UniffiNativeModule.open(CB_HOST_BYTES);
+
+  // The "Doubler" callback shape: (handle: i32, x: i32) -> i32.
+  // The first arg is the registry handle (UniFFI vtable convention); the
+  // user-visible argument is `x`.
+  const doublerDef = {
+    args: [FfiType.Int32, FfiType.Int32],
+    ret: FfiType.Int32,
+    hasRustCallStatus: false,
+  };
+
+  const nm = await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {
+      uniffi_invoke: {
+        args: [FfiType.Int32],
+        ret: FfiType.Int32,
+        hasRustCallStatus: false,
+      },
+    },
+    callbacks: { Doubler: doublerDef },
+    structs: {},
+  });
+
+  // Register a JS callback. The trampoline pushes (shape_id, handle, x); the
+  // JS dispatcher strips both shape_id AND handle before invoking the
+  // closure, so the closure receives only the user args.
+  const handle = mod.callbacks.register(
+    "Doubler",
+    (x: number) => x * 2,
+    doublerDef,
+  );
+  assert.strictEqual(
+    handle,
+    1,
+    "first registration on this shape should be handle=1",
+  );
+
+  const shapeId = mod.callbacks.defineShape("Doubler", doublerDef);
+  mod.callbacks.installAt(0, shapeId);
+
+  // Host's `uniffi_invoke(21)` does `call_indirect[0](handle=1, 21)`, which
+  // hits the trampoline, which pushes shape_id=0 and forwards (1, 21) to
+  // dispatch. We recover the closure from (shapeId=0, handle=1) and invoke
+  // it with (21,), returning 42.
+  assert.strictEqual(nm.uniffi_invoke(21), 42);
+});
+
+test("multiple registrations of the same shape get distinct handles", async () => {
+  const mod = await UniffiNativeModule.open(CB_HOST_BYTES);
+  const def = {
+    args: [FfiType.Int32, FfiType.Int32],
+    ret: FfiType.Int32,
+    hasRustCallStatus: false,
+  };
+  await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: { Shape: def },
+    structs: {},
+  });
+
+  const h1 = mod.callbacks.register("Shape", (x: number) => x, def);
+  const h2 = mod.callbacks.register("Shape", (x: number) => x, def);
+  assert.notStrictEqual(h1, h2);
+});
+
+test("unregister removes the closure but keeps the trampoline", async () => {
+  const mod = await UniffiNativeModule.open(CB_HOST_BYTES);
+  const def = {
+    args: [FfiType.Int32, FfiType.Int32],
+    ret: FfiType.Int32,
+    hasRustCallStatus: false,
+  };
+  const nm = await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {
+      uniffi_invoke: {
+        args: [FfiType.Int32],
+        ret: FfiType.Int32,
+        hasRustCallStatus: false,
+      },
+    },
+    callbacks: { Shape: def },
+    structs: {},
+  });
+
+  const h = mod.callbacks.register("Shape", (x: number) => x + 1, def);
+  const shapeId = mod.callbacks.defineShape("Shape", def);
+  mod.callbacks.installAt(0, shapeId);
+  assert.strictEqual(nm.uniffi_invoke(5), 6);
+
+  mod.callbacks.unregister(h, def);
+  assert.throws(() => nm.uniffi_invoke(5), /unknown handle/);
+});
+
+test("callback registry shrinks on unregister", async () => {
+  const mod = await UniffiNativeModule.open(CB_HOST_BYTES);
+  const def = {
+    args: [FfiType.Int32, FfiType.Int32],
+    ret: FfiType.Int32,
+    hasRustCallStatus: false,
+  };
+  await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: { Doubler: def },
+    structs: {},
+  });
+  const handle = mod.callbacks.register("Doubler", () => 0, def);
+  assert.strictEqual(mod.callbacks.size(def), 1);
+  mod.callbacks.unregister(handle, def);
+  assert.strictEqual(mod.callbacks.size(def), 0);
+});
+
+// Shape ids have no ceiling: `trampoline.ts` emits one as a multi-byte signed
+// LEB128 `i32.const` and `__ubrn_dispatch` takes it as an i32. These tests pin
+// that, and the property that keeps ids scarce anyway — instances share a
+// shape, so shape use is bounded by the API surface.
+
+const SHAPE_DEF = {
+  args: [FfiType.Int32, FfiType.Int32],
+  ret: FfiType.Int32,
+  hasRustCallStatus: false,
+};
+
+async function openHost() {
+  const mod = await UniffiNativeModule.open(CB_HOST_BYTES);
+  await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: { Shape: SHAPE_DEF },
+    structs: {},
+  });
+  return mod;
+}
+
+test("registering many instances does not consume shapes", async () => {
+  const mod = await openHost();
+  const before = mod.callbacks.defineShape("Shape", SHAPE_DEF);
+  for (let i = 0; i < 1000; i++) {
+    mod.callbacks.register("Shape", (x: number) => x + i, SHAPE_DEF);
+  }
+  const after = mod.callbacks.defineShape("Shape", SHAPE_DEF);
+  assert.strictEqual(
+    after,
+    before,
+    "1000 registrations should reuse one shape, not allocate more",
+  );
+  assert.strictEqual(mod.callbacks.size(SHAPE_DEF), 1000);
+});
+
+test("installing the same closure repeatedly reuses its slot", async () => {
+  const mod = await openHost();
+  const fn = (x: number) => x;
+  const first = mod.callbacks.installCallbackFunction(fn, SHAPE_DEF);
+  for (let i = 0; i < 100; i++) {
+    assert.strictEqual(
+      mod.callbacks.installCallbackFunction(fn, SHAPE_DEF),
+      first,
+      "same (closure, signature) must reuse the installed slot",
+    );
+  }
+});
+
+test("shape ids are not capped at 255", async () => {
+  const mod = await openHost();
+  // Distinct closures each take their own shape by design, so 300 of them
+  // means 300 shapes.
+  let slot = -1;
+  for (let i = 0; i < 300; i++) {
+    slot = mod.callbacks.installCallbackFunction(
+      (x: number) => x + i,
+      SHAPE_DEF,
+    );
+  }
+  assert.ok(slot > 255, `expected a slot past the old cap, got ${slot}`);
+});

--- a/runtimes/wasm/core/tests/ffi-type.test.ts
+++ b/runtimes/wasm/core/tests/ffi-type.test.ts
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { FfiType } from "../src/ffi-type.js";
+
+test("scalar tags are stable references", () => {
+  assert.strictEqual(FfiType.UInt32.tag, "UInt32");
+  assert.strictEqual(FfiType.UInt32, FfiType.UInt32);
+});
+
+test("Callback builder yields a tagged object with a name", () => {
+  const cb = FfiType.Callback("vt_calc_add");
+  assert.deepStrictEqual(cb, { tag: "Callback", name: "vt_calc_add" });
+});
+
+test("Reference / MutReference / Struct builders compose", () => {
+  assert.deepStrictEqual(FfiType.Struct("VTable_X"), {
+    tag: "Struct",
+    name: "VTable_X",
+  });
+  assert.deepStrictEqual(FfiType.Reference(FfiType.UInt32), {
+    tag: "Reference",
+    inner: FfiType.UInt32,
+  });
+  assert.deepStrictEqual(FfiType.MutReference(FfiType.UInt8), {
+    tag: "MutReference",
+    inner: FfiType.UInt8,
+  });
+});

--- a/runtimes/wasm/core/tests/future.test.ts
+++ b/runtimes/wasm/core/tests/future.test.ts
@@ -1,0 +1,122 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { UniffiNativeModule } from "../src/module.js";
+
+/**
+ * Pre-assembled bytes for a synthetic future-host wasm module.
+ *
+ * Shape:
+ *
+ *   (module
+ *     (memory (export "memory") 1)
+ *     (table (export "__indirect_function_table") 4 funcref)
+ *     (type $cont (func (param i64 i32))) ;; (data, code) -> ()
+ *
+ *     (func (export "__ubrn_alloc") ...)
+ *     (func (export "__ubrn_free") ...)
+ *
+ *     ;; copies a pre-baked continuation trampoline (shapeId=0,
+ *     ;; params=[i64, i32], no return) from a data segment into the
+ *     ;; caller's buffer.
+ *     (func (export "__ubrn_emit_trampoline") ...)
+ *
+ *     ;; uniffi_poll(handle: i64, cb: i32, data: i64):
+ *     ;;   call_indirect (type $cont) [data, code=0] @ table_index=cb
+ *     (func (export "uniffi_poll") (param i64 i32 i64) ...))
+ *
+ * The continuation shape does *not* follow the (handle, ...args) UniFFI
+ * vtable convention. The host pushes (data: u64, code: i8/i32) directly and
+ * the continuation route in CallbackTable.dispatch bypasses the
+ * registry-by-handle lookup, treating `data` as a u64 cookie that maps to a
+ * resolver in `FutureRegistry`.
+ */
+// host wasm bytes (length=352)
+// trampoline blob length: 81
+const FUTURE_BYTES = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 32, 5, 96, 2, 127, 127, 1, 127, 96, 3, 127,
+  127, 127, 0, 96, 4, 127, 127, 127, 127, 1, 127, 96, 3, 126, 127, 126, 0, 96,
+  2, 126, 127, 0, 2, 1, 0, 3, 5, 4, 0, 1, 2, 3, 4, 4, 1, 112, 0, 4, 5, 3, 1, 0,
+  4, 6, 7, 1, 127, 1, 65, 128, 8, 11, 7, 106, 6, 6, 109, 101, 109, 111, 114,
+  121, 2, 0, 25, 95, 95, 105, 110, 100, 105, 114, 101, 99, 116, 95, 102, 117,
+  110, 99, 116, 105, 111, 110, 95, 116, 97, 98, 108, 101, 1, 0, 12, 95, 95, 117,
+  98, 114, 110, 95, 97, 108, 108, 111, 99, 0, 0, 11, 95, 95, 117, 98, 114, 110,
+  95, 102, 114, 101, 101, 0, 1, 22, 95, 95, 117, 98, 114, 110, 95, 101, 109,
+  105, 116, 95, 116, 114, 97, 109, 112, 111, 108, 105, 110, 101, 0, 2, 11, 117,
+  110, 105, 102, 102, 105, 95, 112, 111, 108, 108, 0, 3, 9, 1, 0, 10, 78, 4, 32,
+  1, 1, 127, 35, 0, 32, 1, 65, 1, 107, 106, 32, 1, 65, 1, 107, 65, 127, 115,
+  113, 33, 2, 32, 2, 32, 0, 106, 36, 0, 32, 2, 11, 2, 0, 11, 28, 0, 32, 1, 65,
+  209, 0, 73, 4, 64, 65, 0, 15, 11, 32, 0, 65, 0, 65, 209, 0, 252, 10, 0, 0, 65,
+  209, 0, 11, 11, 0, 32, 2, 65, 0, 32, 1, 17, 4, 0, 11, 11, 87, 1, 0, 65, 0, 11,
+  81, 0, 97, 115, 109, 1, 0, 0, 0, 1, 12, 2, 96, 2, 126, 127, 0, 96, 3, 127,
+  126, 127, 0, 2, 23, 1, 3, 101, 110, 118, 15, 95, 95, 117, 98, 114, 110, 95,
+  100, 105, 115, 112, 97, 116, 99, 104, 0, 1, 3, 2, 1, 0, 7, 14, 1, 10, 116,
+  114, 97, 109, 112, 111, 108, 105, 110, 101, 0, 1, 10, 12, 1, 10, 0, 65, 0, 32,
+  0, 32, 1, 16, 0, 11,
+]);
+
+test("RustFutureContinuation resolves the awaiting promise", async () => {
+  const mod = await UniffiNativeModule.open(FUTURE_BYTES);
+  await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: {},
+    structs: {},
+  });
+
+  // Install the continuation trampoline at table slot 0; this is the index
+  // the host wasm expects.
+  const idx = mod.futures.installContinuation(0);
+  assert.strictEqual(idx, 0);
+
+  const code = await new Promise<number>((resolve) => {
+    const data = mod.futures.allocateContinuation(resolve);
+    // uniffi_poll(handle, cb, data) — synchronously resolves to READY=0.
+    (mod.exports.uniffi_poll as any)(0n, idx, data);
+  });
+  assert.strictEqual(code, 0); // READY = 0
+});
+
+test("Multiple in-flight continuations dispatch by data cookie", async () => {
+  const mod = await UniffiNativeModule.open(FUTURE_BYTES);
+  await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: {},
+    structs: {},
+  });
+
+  mod.futures.installContinuation(0);
+
+  const got: { data: bigint; code: number }[] = [];
+  const p1 = new Promise<number>((resolve) => {
+    const d = mod.futures.allocateContinuation((c) => {
+      got.push({ data: d, code: c });
+      resolve(c);
+    });
+    (mod.exports.uniffi_poll as any)(0n, 0, d);
+  });
+  const p2 = new Promise<number>((resolve) => {
+    const d = mod.futures.allocateContinuation((c) => {
+      got.push({ data: d, code: c });
+      resolve(c);
+    });
+    (mod.exports.uniffi_poll as any)(0n, 0, d);
+  });
+
+  await Promise.all([p1, p2]);
+  assert.strictEqual(got.length, 2);
+  assert.notStrictEqual(got[0].data, got[1].data);
+});

--- a/runtimes/wasm/core/tests/marshal.test.ts
+++ b/runtimes/wasm/core/tests/marshal.test.ts
@@ -1,0 +1,98 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { Memory } from "../src/memory.js";
+import {
+  readRustBuffer,
+  writeRustBuffer,
+  readRustCallStatus,
+  writeRustCallStatusZero,
+  readForeignBytes,
+  writeForeignBytes,
+  RUST_BUFFER_SIZE,
+  RUST_CALL_STATUS_SIZE,
+  FOREIGN_BYTES_SIZE,
+  liftRustBufferOverMemory,
+} from "../src/marshal.js";
+import { compileStructLayout } from "../src/marshal.js";
+import { FfiType } from "../src/ffi-type.js";
+// Same module instance `marshal.ts` uses, so `instanceof` holds.
+import { RustBuffer } from "@ubjs/core";
+
+test("RustBuffer round-trip (capacity, len, dataPtr)", () => {
+  const m = new Memory(new WebAssembly.Memory({ initial: 1 }));
+  const rb = { capacity: 1234n, len: 56n, dataPtr: 0xc0ffee };
+  writeRustBuffer(m, 0x100, rb);
+  assert.deepStrictEqual(readRustBuffer(m, 0x100), rb);
+  assert.strictEqual(RUST_BUFFER_SIZE, 24);
+});
+
+test("writeRustCallStatusZero writes 32 zero bytes", () => {
+  const m = new Memory(new WebAssembly.Memory({ initial: 1 }));
+  // Prefill nonzero
+  for (let i = 0; i < 32; i++) m.writeU8(0x200 + i, 0xff);
+  writeRustCallStatusZero(m, 0x200);
+  for (let i = 0; i < 32; i++) assert.strictEqual(m.readU8(0x200 + i), 0);
+  assert.strictEqual(RUST_CALL_STATUS_SIZE, 32);
+});
+
+test("readRustCallStatus picks up code + error_buf", () => {
+  const m = new Memory(new WebAssembly.Memory({ initial: 1 }));
+  writeRustCallStatusZero(m, 0x200);
+  m.writeU8(0x200, 1); // code = 1 (error)
+  writeRustBuffer(m, 0x200 + 8, { capacity: 10n, len: 5n, dataPtr: 0x500 });
+  const s = readRustCallStatus(m, 0x200);
+  assert.strictEqual(s.code, 1);
+  assert.deepStrictEqual(s.errorBuf, {
+    capacity: 10n,
+    len: 5n,
+    dataPtr: 0x500,
+  });
+});
+
+test("ForeignBytes round-trip (i32 len, ptr)", () => {
+  const m = new Memory(new WebAssembly.Memory({ initial: 1 }));
+  writeForeignBytes(m, 0x300, { len: 7, dataPtr: 0xabcd });
+  assert.deepStrictEqual(readForeignBytes(m, 0x300), {
+    len: 7,
+    dataPtr: 0xabcd,
+  });
+  assert.strictEqual(FOREIGN_BYTES_SIZE, 8);
+});
+
+test("liftRustBufferOverMemory aliases wasm memory directly", () => {
+  const wm = new WebAssembly.Memory({ initial: 1 });
+  const view = new Uint8Array(wm.buffer);
+  view.set([1, 2, 3, 4], 200);
+  const m = new Memory(wm);
+  const rb = liftRustBufferOverMemory(m, {
+    capacity: 4n,
+    len: 4n,
+    dataPtr: 200,
+  });
+  assert.ok(rb instanceof RustBuffer);
+  assert.deepStrictEqual(Array.from(rb.readByteArray(4)), [1, 2, 3, 4]);
+});
+
+test("compileStructLayout produces a working pair for {u32, u8, RustBuffer}", () => {
+  const m = new Memory(new WebAssembly.Memory({ initial: 1 }));
+  const fields = [
+    { name: "a", type: FfiType.UInt32 },
+    { name: "b", type: FfiType.UInt8 },
+    { name: "rb", type: FfiType.RustBuffer },
+  ];
+  const { read, write, size } = compileStructLayout(fields);
+  assert.strictEqual(size, 4 + 1 + 3 /*pad*/ + 24);
+
+  const value = {
+    a: 0x11223344,
+    b: 0x55,
+    rb: { capacity: 100n, len: 50n, dataPtr: 0x666 },
+  };
+  write(m, 0x400, value);
+  assert.deepStrictEqual(read(m, 0x400), value);
+});

--- a/runtimes/wasm/core/tests/memory.test.ts
+++ b/runtimes/wasm/core/tests/memory.test.ts
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { Memory } from "../src/memory.js";
+
+function makeMem(initialPages = 1) {
+  return new WebAssembly.Memory({ initial: initialPages });
+}
+
+test("readU32 / writeU32 round-trip", () => {
+  const m = new Memory(makeMem());
+  m.writeU32(0x100, 0xdeadbeef);
+  assert.strictEqual(m.readU32(0x100), 0xdeadbeef);
+});
+
+test("readU64 / writeU64 round-trip via bigint", () => {
+  const m = new Memory(makeMem());
+  const v = 0x0102030405060708n;
+  m.writeU64(0x200, v);
+  assert.strictEqual(m.readU64(0x200), v);
+});
+
+test("readBytes returns a copy, not a live view", () => {
+  const m = new Memory(makeMem());
+  m.writeU32(0x300, 0xaabbccdd);
+  const copy = m.readBytes(0x300, 4);
+  m.writeU32(0x300, 0);
+  assert.deepStrictEqual(Array.from(copy), [0xdd, 0xcc, 0xbb, 0xaa]);
+});
+
+test("views are re-acquired after memory.grow()", () => {
+  const wm = makeMem(1);
+  const m = new Memory(wm);
+  // Touch the view first so it caches.
+  m.writeU32(0x100, 1);
+  wm.grow(1);
+  // After grow, old buffer is detached; reading must NOT throw and must
+  // read the freshly written value.
+  m.writeU32(0x100, 0xfeedface);
+  assert.strictEqual(m.readU32(0x100), 0xfeedface);
+});

--- a/runtimes/wasm/core/tests/module.test.ts
+++ b/runtimes/wasm/core/tests/module.test.ts
@@ -1,0 +1,119 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { UniffiNativeModule } from "../src/module.js";
+
+/**
+ * Pre-assembled bytes for a minimal host wasm module that exports the
+ * helper-crate symbols our player expects. Generated via:
+ *
+ *   wat2wasm /tmp/host.wat -o /tmp/host.wasm
+ *
+ * from the following .wat (the import comes first so import indices line up):
+ *
+ *   (module
+ *     (import "env" "__ubrn_panic_log" (func (param i32 i32)))
+ *     (memory (export "memory") 1)
+ *     (func (export "__ubrn_alloc") (param i32 i32) (result i32) i32.const 1024)
+ *     (func (export "__ubrn_free") (param i32 i32 i32))
+ *     (func (export "__ubrn_install_panic_hook"))
+ *     (func (export "__ubrn_emit_trampoline") (param i32 i32 i32 i32) (result i32) i32.const 0)
+ *   )
+ */
+const HOST_WASM_BYTES = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 29, 5, 96, 2, 127, 127, 0, 96, 2, 127, 127, 1,
+  127, 96, 3, 127, 127, 127, 0, 96, 0, 0, 96, 4, 127, 127, 127, 127, 1, 127, 2,
+  24, 1, 3, 101, 110, 118, 16, 95, 95, 117, 98, 114, 110, 95, 112, 97, 110, 105,
+  99, 95, 108, 111, 103, 0, 0, 3, 5, 4, 1, 2, 3, 4, 5, 3, 1, 0, 1, 7, 92, 5, 6,
+  109, 101, 109, 111, 114, 121, 2, 0, 12, 95, 95, 117, 98, 114, 110, 95, 97,
+  108, 108, 111, 99, 0, 1, 11, 95, 95, 117, 98, 114, 110, 95, 102, 114, 101,
+  101, 0, 2, 25, 95, 95, 117, 98, 114, 110, 95, 105, 110, 115, 116, 97, 108,
+  108, 95, 112, 97, 110, 105, 99, 95, 104, 111, 111, 107, 0, 3, 22, 95, 95, 117,
+  98, 114, 110, 95, 101, 109, 105, 116, 95, 116, 114, 97, 109, 112, 111, 108,
+  105, 110, 101, 0, 4, 10, 18, 4, 5, 0, 65, 128, 8, 11, 2, 0, 11, 2, 0, 11, 4,
+  0, 65, 0, 11,
+]);
+
+test("UniffiNativeModule.open resolves required helper exports", async () => {
+  const mod = await UniffiNativeModule.open(HOST_WASM_BYTES);
+  assert.ok(mod);
+  assert.ok(mod.memory);
+  assert.ok(mod.scratch);
+  assert.ok("__ubrn_alloc" in mod.exports);
+  assert.ok("__ubrn_emit_trampoline" in mod.exports);
+});
+
+test("UniffiNativeModule.open rejects when __ubrn_alloc is missing", async () => {
+  // Smallest valid wasm: just the magic bytes + version. WebAssembly.instantiate
+  // accepts this (it produces a module with no imports and no exports), so the
+  // rejection comes from our own missing-export check inside the constructor.
+  const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 1, 0, 0, 0]);
+  await assert.rejects(() => UniffiNativeModule.open(bytes), /__ubrn_alloc/);
+});
+
+test("registered module exposes rustbuffer_alloc / rustbuffer_free", async () => {
+  const mod = await UniffiNativeModule.open(HOST_WASM_BYTES);
+  const nm = await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: {},
+    structs: {},
+  });
+
+  assert.strictEqual(typeof nm.rustbuffer_alloc, "function");
+  assert.strictEqual(typeof nm.rustbuffer_free, "function");
+
+  const view = nm.rustbuffer_alloc(16) as Uint8Array;
+  assert.ok(
+    view instanceof Uint8Array,
+    "rustbuffer_alloc returns a Uint8Array",
+  );
+  assert.strictEqual(view.byteLength, 16);
+  assert.strictEqual(
+    view.buffer,
+    mod.memory.buffer(),
+    "view aliases wasm linear memory directly",
+  );
+
+  // Mutate the view — round-trip through Memory.readBytes to confirm the
+  // bytes landed inside wasm memory at view.byteOffset.
+  view[0] = 0xab;
+  view[15] = 0xcd;
+  const readBack = mod.memory.readBytes(view.byteOffset, 16);
+  assert.strictEqual(readBack[0], 0xab);
+  assert.strictEqual(readBack[15], 0xcd);
+
+  // Symmetric free — accepts the Uint8Array and reconstructs (ptr, len).
+  // The host wasm's __ubrn_free is a no-op stub, so this just verifies
+  // the call shape works.
+  nm.rustbuffer_free(view);
+});
+
+test("rustbuffer_alloc(0) returns an empty view without allocating", async () => {
+  const mod = await UniffiNativeModule.open(HOST_WASM_BYTES);
+  const nm = await mod.register({
+    symbols: {
+      rustbuffer_alloc: "_",
+      rustbuffer_free: "_",
+      rustbuffer_from_bytes: "_",
+    },
+    functions: {},
+    callbacks: {},
+    structs: {},
+  });
+
+  const empty = nm.rustbuffer_alloc(0) as Uint8Array;
+  assert.ok(empty instanceof Uint8Array);
+  assert.strictEqual(empty.byteLength, 0);
+  // Free of a zero-length view must be a safe no-op (don't call __ubrn_free
+  // with a 0-length range, which would be a no-op anyway but the ptr may be 0).
+  nm.rustbuffer_free(empty);
+});

--- a/runtimes/wasm/core/tests/scratch.test.ts
+++ b/runtimes/wasm/core/tests/scratch.test.ts
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { Scratch } from "../src/scratch.js";
+
+function makeFakeAllocator(arenaPtr: number, arenaSize: number) {
+  const allocs = new Map<number, number>(); // ptr -> size (for overflow)
+  let nextPtr = 0x10000;
+  return {
+    arenaPtr,
+    arenaSize,
+    alloc(size: number) {
+      const p = nextPtr;
+      nextPtr += size;
+      allocs.set(p, size);
+      return p;
+    },
+    free(ptr: number, size: number) {
+      assert.strictEqual(allocs.get(ptr), size, "free with wrong size");
+      allocs.delete(ptr);
+    },
+    pendingAllocs: () => allocs.size,
+  };
+}
+
+test("push/pop returns pointers within the arena", () => {
+  const a = makeFakeAllocator(0x1000, 1024);
+  const s = new Scratch(a.arenaPtr, a.arenaSize, a.alloc, a.free);
+  const p = s.push(64);
+  assert.ok(p >= 0x1000 && p < 0x1000 + 1024);
+  s.pop(p);
+});
+
+test("nested push/pop preserves stack discipline", () => {
+  const a = makeFakeAllocator(0x1000, 1024);
+  const s = new Scratch(a.arenaPtr, a.arenaSize, a.alloc, a.free);
+  const p1 = s.push(64);
+  const p2 = s.push(128);
+  assert.ok(p2 >= p1 + 64);
+  s.pop(p2);
+  s.pop(p1);
+});
+
+test("overflow falls back to allocator and free returns it", () => {
+  const a = makeFakeAllocator(0x1000, 64);
+  const s = new Scratch(a.arenaPtr, a.arenaSize, a.alloc, a.free);
+  const p = s.push(128); // larger than arena
+  assert.strictEqual(a.pendingAllocs(), 1);
+  s.pop(p);
+  assert.strictEqual(a.pendingAllocs(), 0);
+});
+
+test("Scratch.reserve carves a permanent region", () => {
+  const memory: number[] = [];
+  const alloc = (n: number) => {
+    memory.push(n);
+    return 0x1000 + memory.length * 1000;
+  };
+  const free = (_p: number, _n: number) => {};
+  const arena = new Scratch(0x1000, 256, alloc, free);
+
+  const slot1 = arena.reserve(24);
+  const slot2 = arena.reserve(32);
+
+  // Reserved regions sit at the front of the arena.
+  assert.strictEqual(slot1, 0x1000);
+  assert.strictEqual(slot2, 0x1000 + 24);
+
+  // push() picks up after the reserved region.
+  const tmp = arena.push(16);
+  assert.strictEqual(tmp, 0x1000 + 24 + 32);
+
+  // pop() must not invalidate reserved regions.
+  arena.pop(tmp);
+  const tmp2 = arena.push(8);
+  assert.strictEqual(tmp2, 0x1000 + 24 + 32);
+});
+
+test("Scratch.reserve refuses growth after first push", () => {
+  const arena = new Scratch(
+    0x1000,
+    256,
+    () => 0,
+    () => {},
+  );
+  arena.push(8);
+  assert.throws(() => arena.reserve(16));
+});
+
+test("Scratch caps push to maxArenaSize, overflowing to alloc", () => {
+  let overflowCount = 0;
+  const alloc = (n: number) => {
+    overflowCount++;
+    return 0x9000;
+  };
+  const free = (_p: number, _n: number) => {};
+  const arena = new Scratch(0x1000, 256, alloc, free, /*maxArenaSize*/ 128);
+
+  arena.push(64); // ok, fits under cap
+  arena.push(64); // ok, at the cap exactly
+  const p = arena.push(8); // would exceed cap → overflow to alloc
+  assert.strictEqual(p, 0x9000);
+  assert.strictEqual(overflowCount, 1);
+});

--- a/runtimes/wasm/helper-crate/Cargo.toml
+++ b/runtimes/wasm/helper-crate/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uniffi-runtime-wasm"
+version = "0.31.0-3"
+edition = "2021"
+description = "Runtime helpers (alloc/free/panic hook) for the wasm2 UniFFI player"
+license = "MPL-2.0"
+repository = "https://github.com/jhugman/uniffi-bindgen-react-native"
+readme = "README.md"
+keywords = ["ffi", "uniffi", "wasm", "webassembly", "code-generation"]
+categories = ["api-bindings", "development-tools::ffi", "wasm"]
+publish = true
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+
+[features]
+default = []

--- a/runtimes/wasm/helper-crate/README.md
+++ b/runtimes/wasm/helper-crate/README.md
@@ -1,0 +1,31 @@
+# uniffi-runtime-wasm
+
+Runtime helpers for the wasm2 player in
+[`uniffi-bindgen-react-native`][bindgen]. Add it to a crate you are building
+for `wasm32-unknown-unknown`; you do not call it yourself.
+
+[bindgen]: https://github.com/jhugman/uniffi-bindgen-react-native
+
+The crate exports two things from your `cdylib` that the JavaScript side needs
+and cannot supply itself: an allocator for linear-memory scratch space, and a
+panic hook that forwards Rust panics to a JS function the player installs in
+`__indirect_function_table`.
+
+## Usage
+
+```toml
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = "0.31.0-3"
+
+[dependencies]
+uniffi_core = { version = "0.31", features = ["wasm-unstable-single-threaded"] }
+```
+
+`ubrn build wasm2` checks all three of these and explains what is missing.
+
+The JavaScript half ships separately, as [`@ubjs/wasm`][npm] on npm.
+
+[npm]: https://www.npmjs.com/package/@ubjs/wasm

--- a/runtimes/wasm/helper-crate/build.rs
+++ b/runtimes/wasm/helper-crate/build.rs
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+fn main() {
+    // Required so the player can install trampolines into the cdylib's
+    // exported function table at runtime.
+    //
+    // Gate on the build target: these are wasm-ld flags that the host linker
+    // (cc/ld) does not understand, so emitting them on host targets breaks
+    // host test builds (`cargo test -p uniffi-runtime-wasm`).
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.starts_with("wasm32") {
+        println!("cargo:rustc-link-arg=--export-table");
+        println!("cargo:rustc-link-arg=--growable-table");
+    }
+}

--- a/runtimes/wasm/helper-crate/src/lib.rs
+++ b/runtimes/wasm/helper-crate/src/lib.rs
@@ -1,0 +1,99 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+//! Runtime helpers consumed by the Wasm2 UniFFI player.
+//!
+//! All functions here are exported from the consumer crate's cdylib so that
+//! the JS-side player can:
+//!   * allocate/free linear-memory scratch space
+//!   * forward Rust panics to a JS function the player has installed in
+//!     `__indirect_function_table`.
+//!
+//! Trampoline encoding lives on the TS side, in
+//! `runtimes/wasm/core/src/trampoline.ts`. Keeping `wasm-encoder` out of
+//! here holds the per-cdylib cost near 700 KB rather than ~5 MB.
+
+use std::alloc::{alloc, dealloc, Layout};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// # Safety
+///
+/// `size` and `align` must form a valid `Layout` (non-zero `align`, power of
+/// two, and `size` rounded up to `align` must not overflow `isize::MAX`).
+/// The caller (the JS-side player) is responsible for later freeing the
+/// returned pointer via `__ubrn_free` with the same `size` and `align`.
+#[no_mangle]
+pub unsafe extern "C" fn __ubrn_alloc(size: u32, align: u32) -> *mut u8 {
+    let layout = Layout::from_size_align(size as usize, align as usize)
+        .expect("__ubrn_alloc: invalid layout");
+    // `std::alloc::alloc` is UB for a zero-sized layout. Zero-sized requests do
+    // reach here (e.g. a vtable struct with no fields), so hand back the
+    // canonical dangling-but-aligned pointer instead; `__ubrn_free` mirrors it.
+    if layout.size() == 0 {
+        return layout.align() as *mut u8;
+    }
+    alloc(layout)
+}
+
+/// # Safety
+///
+/// `ptr` must be a pointer previously returned by `__ubrn_alloc` (or an
+/// equivalent allocator call) with the same `size` and `align`, and must
+/// not have been freed already. After this call the pointer is invalid.
+#[no_mangle]
+pub unsafe extern "C" fn __ubrn_free(ptr: *mut u8, size: u32, align: u32) {
+    let layout = Layout::from_size_align(size as usize, align as usize)
+        .expect("__ubrn_free: invalid layout");
+    // Mirrors the zero-sized branch in `__ubrn_alloc`: nothing was allocated.
+    if layout.size() == 0 {
+        return;
+    }
+    dealloc(ptr, layout);
+}
+
+/// Index in `__indirect_function_table` of a player-installed JS function
+/// with signature `fn(msg_ptr: *const u8, msg_len: u32)`. The panic hook
+/// loads this slot and dispatches to it on every Rust panic. `0` means
+/// "no logger installed yet" — panics are silent rather than aborting.
+///
+/// A table index rather than an `extern "C"` import, so linking cdylibs need
+/// not declare `env.__ubrn_panic_log`. Node's `--experimental-wasm-modules`,
+/// which the legacy Wasm flavor loads through, cannot resolve an unrecognised
+/// `env` module.
+static PANIC_LOG_FN: AtomicU32 = AtomicU32::new(0);
+
+/// Install (or replace) the JS function the panic hook dispatches to.
+/// `table_index` must point at a function with signature
+/// `(i32 msg_ptr, i32 msg_len) -> ()` in the cdylib's
+/// `__indirect_function_table`.
+#[no_mangle]
+pub extern "C" fn __ubrn_set_panic_log(table_index: u32) {
+    PANIC_LOG_FN.store(table_index, Ordering::Relaxed);
+}
+
+/// Install the Rust panic hook. Idempotent — safe to call multiple times.
+/// The player invokes this once during `open()`. Panics fired before
+/// `__ubrn_set_panic_log` is called land at slot 0 and are dropped
+/// silently.
+#[no_mangle]
+pub extern "C" fn __ubrn_install_panic_hook() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        std::panic::set_hook(Box::new(|info| {
+            let idx = PANIC_LOG_FN.load(Ordering::Relaxed);
+            if idx == 0 {
+                return;
+            }
+            // On wasm32, a Rust `fn` pointer is exactly the
+            // `__indirect_function_table` index — same 32-bit
+            // representation — so transmute round-trips cleanly.
+            type PanicLogFn = extern "C" fn(*const u8, u32);
+            let f: PanicLogFn = unsafe { std::mem::transmute(idx as usize) };
+            let msg = format!("{info}");
+            f(msg.as_ptr(), msg.len() as u32);
+        }));
+    });
+}

--- a/runtimes/wasm/node/src/index.ts
+++ b/runtimes/wasm/node/src/index.ts
@@ -1,0 +1,51 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+import { readFile } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  UniffiNativeModule,
+  type ImportResolver,
+  type WasmSource,
+  type ModuleDefinitions,
+  type NativeModuleInterface,
+} from "../../core/src/module.js";
+
+export { FfiType } from "../../core/src/ffi-type.js";
+export { UniffiNativeModule };
+export type { WasmSource };
+
+/**
+ * `options.resolveModule` supplies the wasm's own module imports. A cdylib
+ * that reached wasm-bindgen through its dependencies imports `./<lib>_bg.js`,
+ * and the caller must hand that glue over — generated bindings import it
+ * statically and pass it here. Without it, instantiation fails naming the
+ * import it could not satisfy.
+ */
+export async function openWasm(
+  source: WasmSource,
+  options?: { resolveModule?: ImportResolver },
+): Promise<UniffiNativeModule> {
+  if (typeof source === "string") {
+    const bytes = await readFile(source);
+    return UniffiNativeModule.open(bytes, options);
+  }
+  if (source instanceof URL) {
+    const bytes = await readFile(fileURLToPath(source));
+    return UniffiNativeModule.open(bytes, options);
+  }
+  return UniffiNativeModule.open(source, options);
+}
+
+/**
+ * Node-only sync registration over an already-instantiated source. The fixture
+ * test runner uses this path via wasm-as-ESM imports.
+ */
+export function registerSync(
+  mod: UniffiNativeModule,
+  defs: ModuleDefinitions,
+): NativeModuleInterface {
+  return mod.registerSync(defs);
+}

--- a/runtimes/wasm/package-lock.json
+++ b/runtimes/wasm/package-lock.json
@@ -1,0 +1,608 @@
+{
+  "name": "@ubjs/wasm",
+  "version": "0.31.0-3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ubjs/wasm",
+      "version": "0.31.0-3",
+      "license": "MPL-2.0",
+      "devDependencies": {
+        "@types/node": "^20",
+        "@ubjs/core": "file:../../typescript",
+        "tsx": "^4",
+        "typescript": "^5"
+      },
+      "peerDependencies": {
+        "@ubjs/core": "^0.31.0-3"
+      }
+    },
+    "../../typescript": {
+      "name": "@ubjs/core",
+      "version": "0.31.0-3",
+      "dev": true,
+      "license": "MPL-2.0",
+      "devDependencies": {
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@ubjs/core": {
+      "resolved": "../../typescript",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/runtimes/wasm/package.json
+++ b/runtimes/wasm/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@ubjs/wasm",
+  "version": "0.31.0-3",
+  "description": "WebAssembly player runtime for uniffi-bindgen-react-native generated bindings.",
+  "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jhugman/uniffi-bindgen-react-native.git",
+    "directory": "runtimes/wasm"
+  },
+  "license": "MPL-2.0",
+  "author": {
+    "name": "James Hugman",
+    "email": "james@hugman.tv"
+  },
+  "bugs": {
+    "url": "https://github.com/jhugman/uniffi-bindgen-react-native/issues"
+  },
+  "keywords": ["uniffi", "ffi", "rust", "wasm", "webassembly", "typescript"],
+  "type": "module",
+  "exports": {
+    ".": {
+      "browser": "./dist/browser/src/index.js",
+      "node": "./dist/node/src/index.js",
+      "default": "./dist/browser/src/index.js"
+    },
+    "./core": "./dist/core/src/index.js",
+    "./browser": "./dist/browser/src/index.js",
+    "./node": "./dist/node/src/index.js"
+  },
+  "files": ["dist/", "!dist/tsconfig.tsbuildinfo", "README.md"],
+  "scripts": {
+    "build": "tsc -b",
+    "prepare": "npm run build",
+    "test": "node --test --import tsx './core/tests/*.test.ts'"
+  },
+  "peerDependencies": {
+    "@ubjs/core": "^0.31.0-3"
+  },
+  "devDependencies": {
+    "@ubjs/core": "file:../../typescript",
+    "@types/node": "^20",
+    "tsx": "^4",
+    "typescript": "^5"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/runtimes/wasm/tsconfig.json
+++ b/runtimes/wasm/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["core/src/**/*", "browser/src/**/*", "node/src/**/*"]
+}


### PR DESCRIPTION
Node and browser entries differ only in how they fetch the module, so the
core stays environment-neutral and bundles anywhere.

Add `uniffi-runtime-wasm`, the helper crate a consuming cdylib links. It
exports the allocator pair the player allocates through and forwards Rust
panics to a JS logger installed in the function table.

Exclude `runtimes/wasm` from the workspace glob, since it holds the npm
package rather than a crate, and register the helper crate as a member.

Note in the napi runtime that its capacity symbol has a wasm2 counterpart.