### PR TITLE
fix(bindgen): free the RustBuffer returned by async calls

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/CallBodyMacros.ts
@@ -267,7 +267,20 @@ console.debug(`-- {{ ffi_name }}`);
             // RustBuffer comes back via the shared `rust_future_complete_*`
             // export. The bytes the runtime hands back must be deserialized
             // here using the per-callable return-type converter.
+            {%- if return_type.is_rust_buffer %}
+            // Borrowed view over foreign memory: the call site owns the free,
+            // as on the sync paths. Unconditional — a no-op where buffers are
+            // already JS-owned.
+            /*liftFunc:*/ (__rb) => {
+                try {
+                    return {{ return_type.ffi_converter }}.lift(__rb);
+                } finally {
+                    nativeModule().rustbuffer_free(__rb);
+                }
+            },
+            {%- else %}
             /*liftFunc:*/ {{ return_type.ffi_converter }}.lift.bind({{ return_type.ffi_converter }}),
+            {%- endif %}
             {%- when None %}
             /*liftFunc:*/ (_v) => {},
             {%- endmatch %}


### PR DESCRIPTION
Fix a fairly serious memory leak, introduced by #394 , when rustbuffers alloc'd in Rust were being used directly to lift, rather than copying (then freeing), then lifting from the copy, which would get GC'd.

This landed on May 18, and the 0.31.0-3 release was released May 28. This is the latest release.

It affects async calls used from JSI and NAPI.

`napi::test_benchmark` provides RSS measurements for the `getBytes` and `getString` methods to see this. JSI appeared ok, but hermes doesn't provide access to RSS.

Once this lands, I will do another release.

--- 

Sync call sites free the returned buffer in a try/finally, but the async path delegates lifting to the shared `uniffiRustCallAsync`, whose `finally` frees only the future handle. Runtimes that hand JS a borrowed view over foreign memory therefore leaked one buffer per async call returning a string, byte array, record or list.

Measured on a 1MB payload:

  jsi    644 MB -> 42 MB peak RSS over 300 calls
  napi   1.115 -> 0.030 MB/call
  wasm2  0.999 -> 0.000 MB/call

wasm1 was unaffected: its buffers are plain JS Uint8Arrays and its `rustbuffer_free` is a no-op. That is also why the free is unconditional rather than gated by flavor -- releasing a RustBuffer you are done with is correct everywhere, and each flavor defines what that means for its own, exactly as on the sync paths.

The leak also cost throughput: wasm2 async getString(1MB) goes 44.5ms ->
14.1ms, ahead of wasm1's 17.8ms.

