### PR TITLE
feat(common): add wasm post-processing and crate queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +500,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +649,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -764,6 +807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 1.9.3",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +858,22 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "serde",
 ]
 
 [[package]]
@@ -928,6 +998,9 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "idna"
@@ -948,6 +1021,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -984,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1000,6 +1083,12 @@ checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -1289,6 +1378,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1425,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -1467,7 +1582,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -1645,7 +1760,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -1678,7 +1793,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -1762,6 +1877,8 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "toml 0.8.23",
+ "walrus",
+ "wasm-bindgen-cli-support",
  "which",
 ]
 
@@ -2274,7 +2391,7 @@ dependencies = [
  "glob",
  "goblin",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "once_cell",
  "serde",
  "tempfile",
@@ -2318,7 +2435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2361,7 +2478,7 @@ checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "tempfile",
  "uniffi_internal_macros",
 ]
@@ -2428,6 +2545,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walrus"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6481311b98508f4bc2d0abbfa5d42172e7a54b4b24d8f15e28b0dc650be0c59f"
+dependencies = [
+ "anyhow",
+ "gimli",
+ "id-arena",
+ "leb128",
+ "log",
+ "rayon",
+ "walrus-macro",
+ "wasm-encoder 0.214.0",
+ "wasmparser 0.214.0",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,25 +2599,70 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
+name = "wasm-bindgen-cli-support"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "21e1a4a49abe9cd6f762fc65fac2ef5732afeeb66be369d2f71a85b165a533cf"
+dependencies = [
+ "anyhow",
+ "base64",
+ "log",
+ "rustc-demangle",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "walrus",
+ "wasm-bindgen-externref-xform",
+ "wasm-bindgen-multi-value-xform",
+ "wasm-bindgen-shared",
+ "wasm-bindgen-threads-xform",
+ "wasm-bindgen-wasm-conventions",
+ "wasm-bindgen-wasm-interpreter",
+]
+
+[[package]]
+name = "wasm-bindgen-externref-xform"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940542c5cdbe96c35f98b5da5c65fb9d18df55a0cb1d81fc5ca4acc4fda4d61c"
+dependencies = [
+ "anyhow",
+ "walrus",
+ "wasm-bindgen-wasm-conventions",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
- "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -2474,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2484,24 +2681,80 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
+ "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.114"
+name = "wasm-bindgen-multi-value-xform"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "64b5ad2e97adde0c3e4369c38e0dbaee329ad8f6cc2ee8e01d1d0b13bd8b14cf"
+dependencies = [
+ "anyhow",
+ "walrus",
+ "wasm-bindgen-wasm-conventions",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-threads-xform"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbdf2d55a50f7edc9dd9aecae7a3a40e9736fda851bd8816f98a86167c8c277"
+dependencies = [
+ "anyhow",
+ "walrus",
+ "wasm-bindgen-wasm-conventions",
+]
+
+[[package]]
+name = "wasm-bindgen-wasm-conventions"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c24fcaa34d2d84407122cfb1d3f37c3586756cf462be18e049b49245a16c08"
+dependencies = [
+ "anyhow",
+ "leb128",
+ "log",
+ "walrus",
+ "wasmparser 0.214.0",
+]
+
+[[package]]
+name = "wasm-bindgen-wasm-interpreter"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f24921401faadd6944206f9d6837d07bbb5ff766ed51ad34528089f66550e0"
+dependencies = [
+ "anyhow",
+ "log",
+ "walrus",
+ "wasm-bindgen-wasm-conventions",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
+dependencies = [
+ "leb128",
 ]
 
 [[package]]
@@ -2511,7 +2764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2521,9 +2774,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "indexmap 2.13.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -2534,15 +2801,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2722,7 +2989,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2753,14 +3020,14 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.244.0",
  "wit-parser",
 ]
 
@@ -2772,14 +3039,14 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2819,6 +3086,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/ubrn_common/Cargo.toml
+++ b/crates/ubrn_common/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+default = []
+# Post-processing of built `.wasm` modules. Off by default so the walrus and
+# wasm-bindgen dependencies stay out of builds that never touch wasm.
+wasm = ["dep:walrus", "dep:wasm-bindgen-cli-support"]
+
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
@@ -15,4 +21,6 @@ serde = { workspace = true }
 serde_json = "1.0.117"
 serde_yaml = "0.9.34"
 toml = { workspace = true }
+walrus = { workspace = true, optional = true }
+wasm-bindgen-cli-support = { workspace = true, optional = true }
 which = "6.0.1"

--- a/crates/ubrn_common/src/commands.rs
+++ b/crates/ubrn_common/src/commands.rs
@@ -48,6 +48,27 @@ pub fn run_cmd(cmd: &mut Command) -> Result<()> {
     Ok(())
 }
 
+/// Run work in-process that stands in for an external command.
+///
+/// Recording mode intercepts subprocesses at [`run_cmd`]; work we do
+/// through a library instead of shelling out would otherwise slip past it
+/// and touch the filesystem. `descriptor` is the equivalent command line:
+/// it is what gets recorded, so callers of either flavour look the same to
+/// tests.
+pub fn run_in_process<F>(descriptor: &Command, work: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    if is_recording_enabled() {
+        record_command(descriptor);
+        eprintln!("Recording in-process command: {descriptor:?}");
+        return Ok(());
+    }
+
+    eprintln!("Running in-process {descriptor:?}");
+    work()
+}
+
 /// Run the given command, and only output if there is an error.
 pub fn run_cmd_quietly(cmd: &mut Command) -> Result<()> {
     // If we're in recording mode, just record the command and return success
@@ -76,7 +97,7 @@ mod tests {
 
     use crate::{
         clear_recorded_commands, disable_command_recording, enable_command_recording,
-        get_recorded_commands, run_cmd,
+        get_recorded_commands, run_cmd, run_in_process,
     };
 
     fn assert_command_run_with_args(program: &str, args: &[&str]) -> bool {
@@ -128,5 +149,53 @@ mod tests {
 
         // Cleanup
         disable_command_recording();
+    }
+
+    #[test]
+    fn test_in_process_recording() {
+        enable_command_recording();
+        clear_recorded_commands();
+
+        let mut descriptor = Command::new("wasm-bindgen");
+        descriptor.args(["--target", "web"]);
+
+        let mut ran = false;
+        run_in_process(&descriptor, || {
+            ran = true;
+            Ok(())
+        })
+        .expect("Should succeed in recording mode");
+
+        // Recording stands in for the work: the closure must not run.
+        assert!(!ran);
+        let commands = get_recorded_commands();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].program, "wasm-bindgen");
+        assert_eq!(commands[0].args, vec!["--target", "web"]);
+
+        disable_command_recording();
+    }
+
+    #[test]
+    fn test_in_process_runs_the_work() {
+        // Recording is off by default, so the work happens for real and
+        // nothing is recorded.
+        clear_recorded_commands();
+
+        let mut ran = false;
+        run_in_process(&Command::new("wasm-bindgen"), || {
+            ran = true;
+            Ok(())
+        })
+        .expect("Should run the work");
+
+        assert!(ran);
+        assert!(get_recorded_commands().is_empty());
+
+        // Errors from the work propagate to the caller.
+        let err = run_in_process(&Command::new("wasm-bindgen"), || {
+            anyhow::bail!("no such wasm file")
+        });
+        assert_eq!(err.unwrap_err().to_string(), "no such wasm file");
     }
 }

--- a/crates/ubrn_common/src/lib.rs
+++ b/crates/ubrn_common/src/lib.rs
@@ -9,9 +9,13 @@ pub mod fmt;
 mod rust_crate;
 mod serde;
 mod testing;
+#[cfg(feature = "wasm")]
+mod wasm;
 
 pub use commands::*;
 pub use files::*;
 pub use rust_crate::*;
 pub use serde::*;
 pub use testing::*;
+#[cfg(feature = "wasm")]
+pub use wasm::*;

--- a/crates/ubrn_common/src/rust_crate.rs
+++ b/crates/ubrn_common/src/rust_crate.rs
@@ -3,11 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
-use std::{path::PathBuf, process::Command};
+use std::{collections::BTreeMap, path::PathBuf, process::Command};
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_metadata::{Metadata, MetadataCommand, TargetKind};
+use cargo_metadata::{Metadata, MetadataCommand, Package, TargetKind};
 
 use crate::{path_or_shim, run_cmd_quietly, Utf8PathExt};
 
@@ -18,6 +18,10 @@ pub struct CrateMetadata {
     pub(crate) target_dir: Utf8PathBuf,
     pub(crate) package_name: String,
     pub(crate) library_name: String,
+    pub(crate) builds_cdylib: bool,
+    /// Declared dependency name -> the features this crate asks for on it,
+    /// unioned across normal, dev and target-specific edges.
+    pub(crate) direct_dependencies: BTreeMap<String, Vec<String>>,
 }
 
 impl CrateMetadata {
@@ -70,6 +74,30 @@ impl CrateMetadata {
         &self.library_name
     }
 
+    /// Whether `[lib] crate-type` includes `cdylib`.
+    pub fn builds_cdylib(&self) -> bool {
+        self.builds_cdylib
+    }
+
+    /// Whether the crate declares `name` as a direct dependency. Includes
+    /// target-specific dependencies, so a `[target.'cfg(target_arch =
+    /// "wasm32")'.dependencies]` entry counts.
+    pub fn has_dependency(&self, name: &str) -> bool {
+        self.direct_dependencies.contains_key(name)
+    }
+
+    /// Whether *this crate's own manifest* asks for `feature` on `package`.
+    ///
+    /// Deliberately the declared edge rather than the resolved graph: `cargo
+    /// metadata` on a workspace member reports features unioned across every
+    /// member, so a sibling enabling something would make it look enabled
+    /// here.
+    pub fn declares_dependency_feature(&self, package: &str, feature: &str) -> bool {
+        self.direct_dependencies
+            .get(package)
+            .is_some_and(|fs| fs.iter().any(|f| f == feature))
+    }
+
     pub fn project_root(&self) -> &Utf8Path {
         self.target_dir
             .parent()
@@ -111,6 +139,13 @@ impl CrateMetadata {
         let package_name = find_package_name(metadata, &manifest_path)
             .expect("A [package] `name` was not found in the manifest");
         let target_dir = metadata.target_directory.clone();
+        let package = find_package(metadata, &manifest_path);
+        let builds_cdylib = package.is_some_and(|p| {
+            p.targets
+                .iter()
+                .any(|t| t.kind.contains(&TargetKind::CDyLib))
+        });
+        let direct_dependencies = package.map(declared_dependencies).unwrap_or_default();
 
         Ok(Self {
             manifest_path,
@@ -118,6 +153,8 @@ impl CrateMetadata {
             library_name,
             target_dir,
             crate_dir,
+            builds_cdylib,
+            direct_dependencies,
         })
     }
 }
@@ -193,13 +230,32 @@ fn guess_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> String {
         .replace('-', "_")
 }
 
-fn find_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<String> {
-    // Get the library name
-    let lib = TargetKind::Lib;
+/// Collect this package's declared dependencies, unioning the requested
+/// features across every edge with the same name — a crate commonly names the
+/// same dependency in `[dependencies]` and in a `[target.'cfg(...)']` block.
+fn declared_dependencies(p: &Package) -> BTreeMap<String, Vec<String>> {
+    let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for d in &p.dependencies {
+        let entry = out.entry(d.name.clone()).or_default();
+        for f in &d.features {
+            if !entry.contains(f) {
+                entry.push(f.clone());
+            }
+        }
+    }
+    out
+}
+
+fn find_package<'a>(metadata: &'a Metadata, manifest_path: &Utf8Path) -> Option<&'a Package> {
     metadata
         .packages
         .iter()
         .find(|package| package.manifest_path == *manifest_path)
+}
+
+fn find_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<String> {
+    let lib = TargetKind::Lib;
+    find_package(metadata, manifest_path)
         .and_then(|package| {
             package
                 .targets
@@ -210,9 +266,5 @@ fn find_library_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<St
 }
 
 fn find_package_name(metadata: &Metadata, manifest_path: &Utf8Path) -> Option<String> {
-    metadata
-        .packages
-        .iter()
-        .find(|package| package.manifest_path == *manifest_path)
-        .map(|package| package.name.clone())
+    find_package(metadata, manifest_path).map(|package| package.name.clone())
 }

--- a/crates/ubrn_common/src/wasm.rs
+++ b/crates/ubrn_common/src/wasm.rs
@@ -1,0 +1,168 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+use anyhow::{anyhow, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+
+/// The name wasm-ld gives the table that `call_indirect` dispatches through.
+const TABLE_EXPORT: &str = "__indirect_function_table";
+/// The import namespace wasm-bindgen leaves behind for its CLI to rewrite.
+const WBINDGEN_PLACEHOLDER: &str = "__wbindgen_placeholder__";
+
+/// Copy a built `.wasm` into `out_dir` as `<lib_stem>.wasm`, ready for the
+/// player.
+///
+/// A cdylib that pulled in wasm-bindgen-glued dependencies imports
+/// `__wbindgen_placeholder__.*`; wasm-bindgen-cli rewrites those against
+/// `./<lib_stem>_bg.js`, which the player resolves through `resolveModule`.
+/// Renaming its output is safe: the module's own import string lives inside
+/// the file. Modules without those imports are copied — wasm-bindgen-cli
+/// refuses to run without descriptors.
+///
+/// `strip_dead_code` runs [`dce_wasm`], whose keep-list is a heuristic.
+pub fn stage_wasm(
+    built: &Utf8Path,
+    out_dir: &Utf8Path,
+    lib_stem: &str,
+    strip_dead_code: bool,
+) -> Result<Utf8PathBuf> {
+    let dst = out_dir.join(format!("{lib_stem}.wasm"));
+    let _ = std::fs::remove_file(&dst);
+
+    if has_wasm_bindgen_imports(built)? {
+        // wasm-bindgen-cli runs its own DCE, and its output depends on a
+        // constellation of mangled exports (`_dyn_*`, `__externref_*`) the
+        // keep-list below can't safely capture. Trust its result.
+        run_wasm_bindgen(built, out_dir, lib_stem)?;
+        let bg_wasm = out_dir.join(format!("{lib_stem}_bg.wasm"));
+        std::fs::rename(&bg_wasm, &dst).with_context(|| format!("rename {bg_wasm} -> {dst}"))?;
+
+        // Drop wasm-bindgen's entry module, keeping only the `_bg.js` glue.
+        // The entry instantiates the wasm for you, which is the player's job:
+        // it calls `__wbg_set_wasm` and `__wbindgen_start` itself. Left in
+        // place the file is worse than redundant — it is named `<stem>.js`,
+        // which shadows the `<stem>.ts` bindings under a bundler resolving
+        // `./<stem>.js`, and it imports the `_bg.wasm` renamed above.
+        for ext in ["js", "d.ts"] {
+            let _ = std::fs::remove_file(out_dir.join(format!("{lib_stem}.{ext}")));
+        }
+    } else {
+        std::fs::copy(built, &dst).with_context(|| format!("copy {built} -> {dst}"))?;
+        if strip_dead_code {
+            dce_wasm(&dst)?;
+        }
+    }
+
+    // After whichever rewrite ran above, so neither can drop the export.
+    export_growable_table(&dst)?;
+    Ok(dst)
+}
+
+/// Whether a module imports from wasm-bindgen's placeholder namespace, and so
+/// needs `wasm-bindgen-cli` run over it before anything can instantiate it.
+///
+/// Two callers must agree on this — staging, which runs the rewrite, and the
+/// bindgen, which decides whether to import the glue it produces — so it asks
+/// the import section rather than scanning for the name, which also appears in
+/// the `name` section and in data segments.
+pub fn has_wasm_bindgen_imports(wasm_path: &Utf8Path) -> Result<bool> {
+    let module = walrus::Module::from_file(wasm_path.as_std_path())
+        .map_err(|e| anyhow!("walrus parse {wasm_path}: {e}"))?;
+    let found = module
+        .imports
+        .iter()
+        .any(|i| i.module == WBINDGEN_PLACEHOLDER);
+    Ok(found)
+}
+
+/// In-process equivalent of `wasm-bindgen <wasm> --target bundler
+/// --keep-lld-exports --out-dir <out_dir> --out-name <out_name>`.
+pub fn run_wasm_bindgen(wasm_path: &Utf8Path, out_dir: &Utf8Path, out_name: &str) -> Result<()> {
+    use wasm_bindgen_cli_support::Bindgen;
+    Bindgen::new()
+        .input_path(wasm_path.as_std_path())
+        .bundler(true)
+        .map_err(|e| anyhow!("wasm-bindgen: bundler target unavailable: {e}"))?
+        .keep_lld_exports(true)
+        .omit_default_module_path(true)
+        .out_name(out_name)
+        .generate(out_dir.as_std_path())
+        .map_err(|e| anyhow!("wasm-bindgen on {wasm_path}: {e}"))
+}
+
+/// Strip exports the player can't reach from JS, then run walrus' DCE pass.
+///
+/// wasm-ld keeps every `#[no_mangle] pub extern "C"` export, including the
+/// per-type `ffi_*_rustbuffer_reserve` and `uniffi_*_checksum_*` a given crate
+/// never uses. Dropping them from the export section lets `gc` reclaim what
+/// they held.
+///
+/// Heuristic keep-list (no bindgen manifest yet):
+///   * exports starting with `uniffi_`, `ffi_`, or `__ubrn_`
+///   * `memory` and `__indirect_function_table`
+///   * `__wbindgen_start` (wasm-bindgen-rewritten cdylibs export this)
+///
+/// Expect little: `gc` reclaims nothing, so only the export names go, about
+/// 0.26% of a release build. The `name` section is a real 27%, but dropping it
+/// means `ModuleConfig::generate_name_section(false)` and unreadable stack
+/// traces.
+pub fn dce_wasm(wasm_path: &Utf8Path) -> Result<()> {
+    let mut module = walrus::Module::from_file(wasm_path.as_std_path())
+        .map_err(|e| anyhow!("walrus parse {wasm_path}: {e}"))?;
+
+    fn keep(name: &str) -> bool {
+        matches!(
+            name,
+            "memory" | "__indirect_function_table" | "__wbindgen_start"
+        ) || name.starts_with("uniffi_")
+            || name.starts_with("ffi_")
+            || name.starts_with("__ubrn_")
+    }
+
+    let to_strip: Vec<_> = module
+        .exports
+        .iter()
+        .filter(|e| !keep(&e.name))
+        .map(|e| e.id())
+        .collect();
+    for id in to_strip {
+        module.exports.delete(id);
+    }
+
+    walrus::passes::gc::run(&mut module);
+
+    std::fs::write(wasm_path, module.emit_wasm())?;
+    Ok(())
+}
+
+/// Export a module's function table with no upper bound, so the player can
+/// grow it to install callback trampolines.
+///
+/// wasm-ld does this given `--export-table --growable-table`, but link args
+/// must sit on the cdylib's own link step, which a dependency cannot reach —
+/// every consumer would need RUSTFLAGS. Rewriting afterwards works whatever
+/// built the module.
+///
+/// A module with no function table has no `call_indirect` sites, so no
+/// callbacks to install; it is left alone.
+pub fn export_growable_table(wasm_path: &Utf8Path) -> Result<()> {
+    let mut module = walrus::Module::from_file(wasm_path.as_std_path())
+        .map_err(|e| anyhow!("walrus parse {wasm_path}: {e}"))?;
+
+    let Some(table) = module.tables.main_function_table()? else {
+        return Ok(());
+    };
+
+    // Dropping the upper bound only widens what the table accepts, so it
+    // cannot invalidate the element segments already initialising it.
+    module.tables.get_mut(table).maximum = None;
+
+    if !module.exports.iter().any(|e| e.name == TABLE_EXPORT) {
+        module.exports.add(TABLE_EXPORT, table);
+    }
+
+    std::fs::write(wasm_path, module.emit_wasm())?;
+    Ok(())
+}


### PR DESCRIPTION
Add a `wasm` feature carrying the post-link steps the player needs on a
`wasm32-unknown-unknown` cdylib:

  * `stage_wasm` copies the module beside the generated TypeScript, running
    wasm-bindgen's rewriter first when the module imports its placeholder
    namespace.
  * `export_growable_table` exports the function table with no upper bound,
    so the player can grow it to install callback trampolines. Rewriting
    post-link avoids forcing RUSTFLAGS on every consumer.
  * `dce_wasm` strips exports the player cannot reach, then runs walrus' gc.

Add `RustCrate` queries for the manifest facts the wasm2 build validates:
whether the crate is a cdylib, and whether it declares a given dependency or
feature. Read the declared edge rather than the resolved graph, because
`cargo metadata` on a workspace member unions features across every member.

Add `run_in_process`, so work done through a library rather than a
subprocess still shows up in the command-recording test harness.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>