### PR TITLE
feat(bindgen): generate player FFI for the Wasm2 flavor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -1851,6 +1852,7 @@ dependencies = [
  "ubrn_common",
  "uniffi_bindgen",
  "uniffi_meta",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2803,6 +2805,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/crates/ubrn_bindgen/Cargo.toml
+++ b/crates/ubrn_bindgen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = []
-wasm = ["quote", "prettyplease", "syn", "proc-macro2"]
+wasm = ["quote", "prettyplease", "syn", "proc-macro2", "wasmparser", "ubrn_common/wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -38,6 +38,10 @@ optional = true
 
 [dependencies.proc-macro2]
 version = "1.0"
+optional = true
+
+[dependencies.wasmparser]
+version = "0.244"
 optional = true
 
 [dev-dependencies]

--- a/crates/ubrn_bindgen/src/bindings/entrypoint.rs
+++ b/crates/ubrn_bindgen/src/bindings/entrypoint.rs
@@ -22,5 +22,7 @@ pub fn generate_entrypoint(
         AbiFlavor::Napi => Ok(String::new()),
         #[cfg(feature = "wasm")]
         AbiFlavor::Wasm => gen_rust::generate_entrypoint(crate_, modules),
+        #[cfg(feature = "wasm")]
+        AbiFlavor::Wasm2 => Ok(String::new()),
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_rust/mod.rs
@@ -122,6 +122,7 @@ impl From<&AbiFlavor> for FlavorParams<'_> {
             AbiFlavor::Jsi => unreachable!("Jsi should be only generating C++ not Rust"),
             AbiFlavor::Napi => unreachable!("Napi should be only generating TypeScript not Rust"),
             AbiFlavor::Wasm => wasm_flavor(),
+            AbiFlavor::Wasm2 => unreachable!("Wasm2 has no per-crate Rust shim"),
         }
     }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/builder.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/builder.rs
@@ -19,8 +19,9 @@ impl PlayerFfiModule {
     pub(crate) fn from_general(
         namespace: &general::Namespace,
         config: &TsConfig,
+        flavor: &crate::AbiFlavor,
         crate_name: String,
-        lib_resolution: LibResolution,
+        lib_resolution: Option<LibResolution>,
     ) -> Self {
         let has_async = namespace_has_async(namespace);
 
@@ -35,6 +36,7 @@ impl PlayerFfiModule {
 
         Self {
             strict_type_checking: config.strict_type_checking,
+            flavor: flavor.clone(),
             crate_name,
             lib_resolution,
             symbols,

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/mod.rs
@@ -17,8 +17,9 @@ pub fn render_minimal_for_test(lib_resolution: LibResolution, crate_name: &str) 
     use nodes::{PlayerFfiModule, PlayerSymbols};
     let module = PlayerFfiModule {
         strict_type_checking: false,
+        flavor: crate::AbiFlavor::Napi,
         crate_name: crate_name.to_string(),
-        lib_resolution,
+        lib_resolution: Some(lib_resolution),
         symbols: PlayerSymbols {
             rustbuffer_alloc: "ubrn_test_alloc".into(),
             rustbuffer_free: "ubrn_test_free".into(),

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/ffi_module_player/nodes.rs
@@ -54,10 +54,15 @@ impl TripleStyle {
 pub(crate) struct PlayerFfiModule {
     /// Whether to suppress `@ts-nocheck` for strict type checking.
     pub strict_type_checking: bool,
-    /// The crate name, passed to `resolveLibPath` so error messages name it.
+    /// The ABI flavor this module targets (Napi, Wasm2, etc.).
+    pub flavor: crate::AbiFlavor,
+    /// The crate name. For napi, passed to `resolveLibPath` so error messages
+    /// name it. For wasm2, used to build the URL for the side-by-side `.wasm`
+    /// file.
     pub crate_name: String,
-    /// How the player should locate the library at runtime.
-    pub lib_resolution: LibResolution,
+    /// How the napi player should locate the library at runtime.
+    /// `None` for non-napi flavors (e.g. wasm2).
+    pub lib_resolution: Option<LibResolution>,
     /// Rustbuffer management symbol names.
     pub symbols: PlayerSymbols,
     /// FFI function registrations for `register({ functions: { ... } })`.
@@ -114,4 +119,29 @@ pub(crate) struct PlayerFieldDef {
     pub name: String,
     /// Player FfiType expression (e.g. "FfiType.Callback(\"calc_add\")").
     pub type_expr: String,
+}
+
+impl PlayerFfiModule {
+    /// Construct a minimal `PlayerFfiModule` with empty collections and the
+    /// given flavor. Used by codegen snapshot tests to exercise the template
+    /// branches without needing to materialize a full `general::Namespace`.
+    #[doc(hidden)]
+    pub fn empty_for_test(flavor: crate::AbiFlavor) -> Self {
+        Self {
+            strict_type_checking: true,
+            flavor,
+            crate_name: "ubrn_test_crate".into(),
+            lib_resolution: None,
+            symbols: PlayerSymbols {
+                rustbuffer_alloc: "ubrn_test_rb_alloc".into(),
+                rustbuffer_free: "ubrn_test_rb_free".into(),
+                rustbuffer_from_bytes: "ubrn_test_rb_from_bytes".into(),
+            },
+            functions: Vec::new(),
+            callbacks: Vec::new(),
+            structs: Vec::new(),
+            typed_functions: Vec::new(),
+            typed_definitions: Vec::new(),
+        }
+    }
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/mod.rs
@@ -37,10 +37,17 @@ pub(crate) fn generate_player_lowlevel_code(
 pub(crate) fn generate_index_code(
     modules: Vec<ModuleMetadata>,
     flavor: AbiFlavor,
+    wasm_stem: String,
+    has_wasm_bindgen_glue: bool,
 ) -> Result<String> {
-    IndexTsWrapper { modules, flavor }
-        .render()
-        .context("generating index.ts from IR failed")
+    IndexTsWrapper {
+        modules,
+        flavor,
+        wasm_stem,
+        has_wasm_bindgen_glue,
+    }
+    .render()
+    .context("generating index.ts from IR failed")
 }
 
 pub(crate) fn generate_api_code_from_ir(api_module: api_module::TsApiModule) -> Result<String> {
@@ -90,4 +97,20 @@ impl PlayerLowlevelTsWrapper {
 struct IndexTsWrapper {
     modules: Vec<ModuleMetadata>,
     flavor: AbiFlavor,
+    /// File stem of the module this index loads, which staging places
+    /// alongside it. Empty for flavors that load no wasm.
+    wasm_stem: String,
+    /// Whether the module imports wasm-bindgen's placeholder namespace, in
+    /// which case staging writes a `<stem>_bg.js` for us to import.
+    has_wasm_bindgen_glue: bool,
+}
+
+/// Test-only entry point: render the player lowlevel TS wrapper for a
+/// minimal `PlayerFfiModule` configured with the given flavor. Used by
+/// integration tests to assert template branching without standing up a
+/// full `general::Namespace`.
+#[doc(hidden)]
+pub fn render_player_lowlevel_for_test(flavor: &crate::AbiFlavor) -> Result<String> {
+    let module = ffi_module_player::PlayerFfiModule::empty_for_test(flavor.clone());
+    generate_player_lowlevel_code(module)
 }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/index.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/index.ts
@@ -18,12 +18,49 @@ if (!initialized) {
 
 export async function uniffiInitAsync() { /* sync flavor: no-op */ }
 {% else %}
+// The module is opened here rather than in an environment-specific entrypoint:
+// `@ubjs/wasm` resolves to its browser or node build through the
+// package's `exports` conditions, leaving this the one place that loads.
+import { openWasm, type WasmSource } from '@ubjs/wasm';
+{%- for m in modules %}
+import {
+  PLAYER_DEFINITIONS as PLAYER_DEFINITIONS_{{ m.ts() }},
+  setNativeModule as setNativeModule_{{ m.ts() }},
+} from './{{ m.ts_ffi() }}';
+{%- endfor %}
+{%- if has_wasm_bindgen_glue %}
+// This crate reaches wasm-bindgen through its dependencies, so the module
+// imports glue that only wasm-bindgen can write. Importing it here keeps it in
+// the bundler's graph; the alternative is fetching it at runtime, which no
+// bundler can see and which needs the file served beside the wasm.
+import * as wasmBindgenGlue from './{{ wasm_stem }}_bg.js';
+{%- endif %}
+
+/**
+ * Open the module and register every namespace. Idempotent.
+ *
+ * `{{ wasm_stem }}.wasm` is staged beside this file. There is no default,
+ * because naming an asset is the one thing only the host knows: a bundler
+ * rewrites the URL when it copies the file, so name it the way your
+ * environment does.
+ *
+ *     import wasm from './{{ wasm_stem }}.wasm';                   // bundler
+ *     const wasm = new URL('./{{ wasm_stem }}.wasm', import.meta.url); // node
+ *     await uniffiInitAsync(wasm);
+ */
 let initPromise: Promise<void> | undefined;
-export function uniffiInitAsync(): Promise<void> {
+export function uniffiInitAsync(source: WasmSource): Promise<void> {
   if (!initPromise) {
     initPromise = (async () => {
+      const wasmModule = await openWasm(source as any{% if has_wasm_bindgen_glue %}, {
+        resolveModule: async (name: string) =>
+          name.endsWith('{{ wasm_stem }}_bg.js')
+            ? (wasmBindgenGlue as unknown as Record<string, unknown>)
+            : undefined,
+      }{% endif %});
       {%- for m in modules %}
-      await {{ m.ts() }}.default.initialize();
+      setNativeModule_{{ m.ts() }}(wasmModule.registerSync(PLAYER_DEFINITIONS_{{ m.ts() }}));
+      {{ m.ts() }}.default.initialize();
       {%- endfor %}
     })();
   }

--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/wrapper-ffi-player.ts
@@ -7,8 +7,15 @@
 // @ts-nocheck
 {%- endif %}
 
+{%- if module.flavor.is_wasm2() %}
+// Only `/core`, which is environment-neutral. Opening the `.wasm` is the
+// generated `index.ts`'s job, so this module
+// bundles for node, browsers and React Native alike.
+import { FfiType } from "@ubjs/wasm/core";
+{%- else %}
 import lib from "@ubjs/node";
 const { UniffiNativeModule, FfiType, resolveLibPath } = lib;
+{%- endif %}
 
 import {
   type StructuralEquality as UniffiStructuralEquality,
@@ -73,6 +80,25 @@ interface NativeModuleInterface {
     rustbuffer_free(view: Uint8Array): void;
 }
 
+{%- if module.flavor.is_wasm2() %}
+let _nativeModule: NativeModuleInterface | undefined;
+const getter: () => NativeModuleInterface = () => {
+  if (!_nativeModule) {
+    throw new Error(
+      "{{ module.crate_name }}: wasm module not initialised. Await " +
+      "`uniffiInitAsync(...)` from the generated entrypoint before calling " +
+      "into this module.",
+    );
+  }
+  return _nativeModule;
+};
+export const PLAYER_DEFINITIONS = DEFINITIONS;
+// Takes the runtime's loose record — `registerSync` cannot know this
+// module's exports — and narrows it once, here, rather than at each call.
+export function setNativeModule(m: Record<string, (...args: any[]) => any>) {
+  _nativeModule = m as unknown as NativeModuleInterface;
+}
+{%- else %}
 let _nativeModule: NativeModuleInterface | undefined;
 const getter: () => NativeModuleInterface = () => {
   if (!_nativeModule) {
@@ -80,12 +106,16 @@ const getter: () => NativeModuleInterface = () => {
       crateName: "{{ module.crate_name }}",
       callerUrl: import.meta.url,
       {%- match module.lib_resolution %}
-      {%- when LibResolution::Colocated %}
-      {%- when LibResolution::Absolute with (path) %}
+      {%- when Some with (resolution) %}
+        {%- match resolution %}
+        {%- when LibResolution::Colocated %}
+        {%- when LibResolution::Absolute with (path) %}
       override: "{{ path }}",
       {%- when LibResolution::Require { base, triple_style } %}
       npmPackageBase: "{{ base }}",
       tripleStyle: "{{ triple_style.as_runtime_tag() }}",
+        {%- endmatch %}
+      {%- when None %}
       {%- endmatch %}
     });
     const mod_ = UniffiNativeModule.open(libPath);
@@ -93,6 +123,7 @@ const getter: () => NativeModuleInterface = () => {
   }
   return _nativeModule;
 };
+{%- endif %}
 export default getter;
 
 // Structs and function types for calling back into Typescript from Rust.

--- a/crates/ubrn_bindgen/src/bindings/mod.rs
+++ b/crates/ubrn_bindgen/src/bindings/mod.rs
@@ -13,3 +13,6 @@ pub(crate) mod gen_typescript;
 pub(crate) mod metadata;
 
 pub use self::entrypoint::generate_entrypoint;
+
+#[doc(hidden)]
+pub use self::gen_typescript::render_player_lowlevel_for_test;

--- a/crates/ubrn_bindgen/src/cli.rs
+++ b/crates/ubrn_bindgen/src/cli.rs
@@ -15,7 +15,7 @@ use uniffi_bindgen::{
 };
 
 #[cfg(feature = "wasm")]
-use super::{bindings::gen_rust, wasm::generate_rs};
+use super::{bindings::gen_rust, wasm::generate_rs, wasm_metadata};
 use super::{
     bindings::{gen_cpp, gen_typescript, metadata::ModuleMetadata},
     react_native::generate_cpp,
@@ -164,7 +164,7 @@ impl BindingsArgs {
         // C++/Rust generation via ComponentInterface
         match &switches.flavor {
             AbiFlavor::Jsi => {
-                let metadata = loader.load_metadata(&source_path)?;
+                let metadata = load_metadata(&loader, &source_path)?;
                 let cis = loader.load_cis(metadata)?;
                 let mut components = loader.load_components(cis, parse_cpp_config)?;
                 for c in components.iter_mut() {
@@ -175,7 +175,7 @@ impl BindingsArgs {
             AbiFlavor::Napi => { /* No C++ generation for Napi */ }
             #[cfg(feature = "wasm")]
             AbiFlavor::Wasm => {
-                let metadata = loader.load_metadata(&source_path)?;
+                let metadata = load_metadata(&loader, &source_path)?;
                 let cis = loader.load_cis(metadata)?;
                 let mut components = loader.load_components(cis, parse_rust_config)?;
                 for c in components.iter_mut() {
@@ -183,6 +183,8 @@ impl BindingsArgs {
                 }
                 generate_rs(&components, &switches, &abi_dir, !out.no_format)?;
             }
+            #[cfg(feature = "wasm")]
+            AbiFlavor::Wasm2 => { /* No native shim for Wasm2 */ }
         }
 
         // TypeScript generation via pipeline
@@ -190,7 +192,7 @@ impl BindingsArgs {
         // each namespace gets its own crate's uniffi.toml (e.g. custom type mappings).
         // TODO check this is the desired behavior in uniffi-rs 0.31.x.
         let pipeline_loader = self.create_pipeline_loader(manifest_path)?;
-        let metadata = pipeline_loader.load_metadata(&source_path)?;
+        let metadata = load_metadata(&pipeline_loader, &source_path)?;
         let initial_root = pipeline_loader.load_pipeline_initial_root(&source_path, metadata)?;
         let general_root = general::pipeline("react-native").execute(initial_root)?;
 
@@ -201,8 +203,8 @@ impl BindingsArgs {
             self.lib_resolution.clone(),
         )?;
         let modules = generate_api_from_pipeline(&general_root, &switches, &ts_dir)?;
-        if switches.flavor == AbiFlavor::Napi {
-            generate_index_from_modules(&modules, &switches, &ts_dir)?;
+        if switches.flavor.supports_index_ts_at_generation() {
+            generate_index_from_modules(&modules, &switches, &ts_dir, &source_path)?;
         }
         if !out.no_format {
             gen_typescript::format_directory(&ts_dir)?;
@@ -273,8 +275,22 @@ fn generate_index_from_modules(
     modules: &[ModuleMetadata],
     switches: &SwitchArgs,
     ts_dir: &Utf8Path,
+    source_path: &Utf8Path,
 ) -> Result<()> {
-    let code = gen_typescript::generate_index_code(modules.to_vec(), switches.flavor.clone())?;
+    // For wasm2 the source *is* the module, and staging copies it beside the
+    // generated TypeScript under the same name.
+    let wasm_stem = source_path.file_stem().unwrap_or_default().to_string();
+    // Staging will run wasm-bindgen over a module that imports its placeholder
+    // namespace, leaving a `<stem>_bg.js` beside the wasm. Ask the same
+    // question here so the index imports exactly what staging produces.
+    let has_wasm_bindgen_glue = switches.flavor.is_wasm2()
+        && ubrn_common::has_wasm_bindgen_imports(source_path).unwrap_or(false);
+    let code = gen_typescript::generate_index_code(
+        modules.to_vec(),
+        switches.flavor.clone(),
+        wasm_stem,
+        has_wasm_bindgen_glue,
+    )?;
     let path = ts_dir.join("index.ts");
     ubrn_common::write_file(path, code)?;
     Ok(())
@@ -321,8 +337,22 @@ fn generate_ffi_from_pipeline(
                     gen_typescript::ffi_module_player::PlayerFfiModule::from_general(
                         namespace,
                         &config,
+                        &switches.flavor,
                         crate_name,
-                        lib_resolution,
+                        Some(lib_resolution),
+                    );
+                gen_typescript::generate_player_lowlevel_code(player_module)?
+            }
+            #[cfg(feature = "wasm")]
+            AbiFlavor::Wasm2 => {
+                let crate_name = namespace.crate_name.clone();
+                let player_module =
+                    gen_typescript::ffi_module_player::PlayerFfiModule::from_general(
+                        namespace,
+                        &config,
+                        &switches.flavor,
+                        crate_name,
+                        None,
                     );
                 gen_typescript::generate_player_lowlevel_code(player_module)?
             }
@@ -339,6 +369,33 @@ fn generate_ffi_from_pipeline(
         ubrn_common::write_file(path, code)?;
     }
     Ok(())
+}
+
+/// Load metadata, transparently handling `wasm32-unknown-unknown` cdylibs.
+///
+/// When the `wasm` feature is enabled, this peeks at the source file and, if
+/// it looks like a WebAssembly module, extracts UNIFFI_META_* blobs directly
+/// from its globals + data segments instead of falling through to the native
+/// dylib symbol-table reader. Non-wasm sources (UDL, native libraries) take
+/// the unchanged default path.
+fn load_metadata(
+    loader: &uniffi_bindgen::BindgenLoader,
+    source_path: &Utf8Path,
+) -> Result<uniffi_meta::MetadataGroupMap> {
+    #[cfg(feature = "wasm")]
+    {
+        loader.load_metadata_specialized(source_path, |_path, bytes| {
+            if wasm_metadata::looks_like_wasm(bytes) {
+                Ok(Some(wasm_metadata::extract_from_wasm_bytes(bytes)?))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+    #[cfg(not(feature = "wasm"))]
+    {
+        loader.load_metadata(source_path)
+    }
 }
 
 fn parse_cpp_config(_ci: &ComponentInterface, toml: toml::Value) -> Result<gen_cpp::Config> {

--- a/crates/ubrn_bindgen/src/lib.rs
+++ b/crates/ubrn_bindgen/src/lib.rs
@@ -9,6 +9,8 @@ mod react_native;
 mod switches;
 #[cfg(feature = "wasm")]
 mod wasm;
+#[cfg(feature = "wasm")]
+mod wasm_metadata;
 
 pub use self::{
     bindings::{generate_entrypoint, metadata::ModuleMetadata},
@@ -26,3 +28,6 @@ pub mod __player_template_test {
         render_minimal_for_test, LibResolution, TripleStyle,
     };
 }
+
+#[doc(hidden)]
+pub use self::bindings::render_player_lowlevel_for_test;

--- a/crates/ubrn_bindgen/src/switches.rs
+++ b/crates/ubrn_bindgen/src/switches.rs
@@ -33,6 +33,8 @@ pub enum AbiFlavor {
     Napi,
     #[cfg(feature = "wasm")]
     Wasm,
+    #[cfg(feature = "wasm")]
+    Wasm2,
 }
 
 impl AbiFlavor {
@@ -42,6 +44,8 @@ impl AbiFlavor {
             Self::Napi => "", // No native entrypoint needed
             #[cfg(feature = "wasm")]
             Self::Wasm => "src/lib.rs",
+            #[cfg(feature = "wasm")]
+            Self::Wasm2 => "",
         }
     }
 
@@ -57,18 +61,39 @@ impl AbiFlavor {
     /// Whether the runtime uses a player (dlopen + register) rather than
     /// compiled-in bindings.
     pub fn supports_player(&self) -> bool {
-        matches!(self, Self::Napi)
+        #[cfg(feature = "wasm")]
+        {
+            matches!(self, Self::Napi | Self::Wasm2)
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            matches!(self, Self::Napi)
+        }
     }
 
     /// Whether FFI function names on the native module use the `ubrn_` prefix.
     /// JSI and WASM both use this prefix; the Napi player uses raw symbol names.
     pub fn supports_ubrn_prefix(&self) -> bool {
-        !matches!(self, Self::Napi)
+        #[cfg(feature = "wasm")]
+        {
+            !matches!(self, Self::Napi | Self::Wasm2)
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            !matches!(self, Self::Napi)
+        }
     }
 
     /// Whether the runtime uses a plain `{ code: 0 }` object for RustCallStatus.
     pub fn supports_plain_call_status(&self) -> bool {
-        matches!(self, Self::Jsi | Self::Napi)
+        #[cfg(feature = "wasm")]
+        {
+            matches!(self, Self::Jsi | Self::Napi | Self::Wasm2)
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            matches!(self, Self::Jsi | Self::Napi)
+        }
     }
 
     pub fn supports_text_encoder(&self) -> bool {
@@ -76,7 +101,14 @@ impl AbiFlavor {
     }
 
     pub fn supports_rust_backtrace(&self) -> bool {
-        !matches!(self, Self::Jsi | Self::Napi)
+        #[cfg(feature = "wasm")]
+        {
+            matches!(self, Self::Wasm | Self::Wasm2)
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            false
+        }
     }
 
     pub fn supports_finalization_registry(&self) -> bool {
@@ -90,5 +122,37 @@ impl AbiFlavor {
     /// flavors (Wasm) defer all initialization into `uniffiInitAsync`.
     pub fn supports_sync_initialization(&self) -> bool {
         matches!(self, Self::Jsi | Self::Napi)
+    }
+
+    /// Whether the bindgen emits an `index.ts` beside the per-module wrappers.
+    ///
+    /// It is the single import surface for a crate with several namespaces.
+    /// jsi and wasm get an entrypoint from `ubrn_cli` instead — a turbo module
+    /// and `index.web.ts` respectively — so a second index here would be
+    /// redundant for them.
+    pub fn supports_index_ts_at_generation(&self) -> bool {
+        #[cfg(feature = "wasm")]
+        {
+            matches!(self, Self::Napi | Self::Wasm2)
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            matches!(self, Self::Napi)
+        }
+    }
+
+    /// Wasm2 specifically — the per-module wrapper stays environment-neutral,
+    /// exporting `PLAYER_DEFINITIONS` / `setNativeModule` and leaving the
+    /// opening of the `.wasm` to a generated entrypoint, so it bundles for
+    /// node, browsers and React Native alike.
+    pub fn is_wasm2(&self) -> bool {
+        #[cfg(feature = "wasm")]
+        {
+            matches!(self, Self::Wasm2)
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            false
+        }
     }
 }

--- a/crates/ubrn_bindgen/src/wasm_metadata.rs
+++ b/crates/ubrn_bindgen/src/wasm_metadata.rs
@@ -1,0 +1,338 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+//! Extract UniFFI metadata directly from a `wasm32-unknown-unknown` cdylib.
+//!
+//! When Rust compiles a UniFFI crate to wasm, each `UNIFFI_META_*` symbol
+//! becomes an exported i32 global whose value is a linear-memory address
+//! pointing into a data segment. The bytes at that address use the same
+//! self-describing binary format as native (ELF/Mach-O/PE) builds, so we
+//! feed them directly into [`uniffi_meta::read_metadata`].
+//!
+//! This lets the bindings generator skip the second native cargo build whose
+//! sole purpose was to populate a dylib symbol table.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use uniffi_meta::Metadata;
+use wasmparser::{
+    Export, ExternalKind, GlobalType, Imports, Operator, Parser, Payload, TypeRef, ValType,
+};
+
+/// Returns true if `bytes` looks like a WebAssembly module (magic + version).
+pub(crate) fn looks_like_wasm(bytes: &[u8]) -> bool {
+    bytes.len() >= 8 && &bytes[..4] == b"\0asm"
+}
+
+/// Read a wasm cdylib from disk and extract every `UNIFFI_META_*` blob.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn extract_from_wasm(path: &Path) -> Result<Vec<Metadata>> {
+    let wasm_bytes =
+        std::fs::read(path).with_context(|| format!("failed to read WASM: {}", path.display()))?;
+    extract_from_wasm_bytes(&wasm_bytes)
+}
+
+/// Same as [`extract_from_wasm`], but takes pre-loaded bytes.
+pub(crate) fn extract_from_wasm_bytes(wasm_bytes: &[u8]) -> Result<Vec<Metadata>> {
+    let blobs = read_meta_blobs(wasm_bytes)?;
+    blobs
+        .into_iter()
+        .map(|(name, bytes)| {
+            uniffi_meta::read_metadata(bytes)
+                .with_context(|| format!("failed to parse metadata for '{name}'"))
+        })
+        .collect()
+}
+
+/// Locate every `UNIFFI_META_*` exported global and return `(symbol, &bytes)`
+/// pairs pointing into the module's data segments. Split out so tests can
+/// inspect raw bytes without a fully-formed `Metadata`.
+fn read_meta_blobs(wasm_bytes: &[u8]) -> Result<Vec<(String, &[u8])>> {
+    let mut imported_global_count: u32 = 0;
+    let mut globals: Vec<i32> = Vec::new();
+    let mut meta_exports: BTreeMap<String, u32> = BTreeMap::new();
+    let mut data_segments: Vec<(u32, &[u8])> = Vec::new();
+
+    for payload in Parser::new(0).parse_all(wasm_bytes) {
+        let payload = payload.context("failed to parse WASM payload")?;
+        match payload {
+            Payload::ImportSection(reader) => {
+                for group in reader {
+                    let group = group.context("failed to parse WASM import")?;
+                    imported_global_count += count_imported_globals(group)?;
+                }
+            }
+            Payload::GlobalSection(reader) => {
+                for global in reader {
+                    let global = global.context("failed to parse WASM global")?;
+                    let value = eval_i32_const_expr(&global.ty, &global.init_expr)?;
+                    globals.push(value);
+                }
+            }
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let Export { name, kind, index } =
+                        export.context("failed to parse WASM export")?;
+                    if kind == ExternalKind::Global && is_uniffi_meta_symbol(name) {
+                        meta_exports.insert(name.to_string(), index);
+                    }
+                }
+            }
+            Payload::DataSection(reader) => {
+                for data in reader {
+                    let data = data.context("failed to parse WASM data segment")?;
+                    if let wasmparser::DataKind::Active {
+                        memory_index: 0,
+                        offset_expr,
+                    } = &data.kind
+                    {
+                        let base = eval_i32_init_expr(offset_expr)?;
+                        data_segments.push((base as u32, data.data));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if meta_exports.is_empty() {
+        bail!("no UNIFFI_META_* exports found in WASM file - is this a UniFFI crate?");
+    }
+
+    let mut out = Vec::with_capacity(meta_exports.len());
+    for (name, global_index) in meta_exports {
+        let local_index = global_index
+            .checked_sub(imported_global_count)
+            .ok_or_else(|| {
+                anyhow!(
+                    "global index {global_index} refers to an imported global \
+                 (not a local data pointer) for export '{name}'"
+                )
+            })?;
+        let addr = *globals.get(local_index as usize).ok_or_else(|| {
+            anyhow!("global index {global_index} out of range for export '{name}'")
+        })? as u32;
+
+        let bytes = read_from_data_segments(&data_segments, addr).with_context(|| {
+            format!("failed to read metadata bytes for '{name}' at address {addr:#x}")
+        })?;
+        out.push((name, bytes));
+    }
+
+    Ok(out)
+}
+
+/// Count the globals an import group contributes. `wasmparser::Imports` has
+/// three variants — `Single` and two compact encodings — all of which can
+/// carry them.
+fn count_imported_globals(group: Imports<'_>) -> Result<u32> {
+    Ok(match group {
+        Imports::Single(_, import) => u32::from(matches!(import.ty, TypeRef::Global(_))),
+        Imports::Compact1 { items, .. } => {
+            let mut n = 0u32;
+            for item in items {
+                let item = item.context("failed to parse compact import item")?;
+                if matches!(item.ty, TypeRef::Global(_)) {
+                    n += 1;
+                }
+            }
+            n
+        }
+        Imports::Compact2 { ty, names, .. } => {
+            if matches!(ty, TypeRef::Global(_)) {
+                let mut n = 0u32;
+                for name in names {
+                    let _ = name.context("failed to parse compact import name")?;
+                    n += 1;
+                }
+                n
+            } else {
+                0
+            }
+        }
+    })
+}
+
+fn eval_i32_const_expr(ty: &GlobalType, init_expr: &wasmparser::ConstExpr) -> Result<i32> {
+    if ty.content_type != ValType::I32 {
+        bail!("expected i32 global, got {:?}", ty.content_type);
+    }
+    eval_i32_init_expr(init_expr)
+}
+
+fn eval_i32_init_expr(expr: &wasmparser::ConstExpr) -> Result<i32> {
+    let mut reader = expr.get_operators_reader();
+    match reader.read()? {
+        Operator::I32Const { value } => Ok(value),
+        other => bail!("expected I32Const in const expr, got: {other:?}"),
+    }
+}
+
+fn is_uniffi_meta_symbol(name: &str) -> bool {
+    let name = name.strip_prefix('_').unwrap_or(name);
+    name.starts_with("UNIFFI_META")
+}
+
+fn read_from_data_segments<'a>(segments: &[(u32, &'a [u8])], addr: u32) -> Result<&'a [u8]> {
+    for (base, data) in segments {
+        let end = base.saturating_add(data.len() as u32);
+        if addr >= *base && addr < end {
+            let offset = (addr - base) as usize;
+            return Ok(&data[offset..]);
+        }
+    }
+    bail!("address {addr:#x} not found in any active data segment");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Hand-rolled minimal wasm module:
+    ///   - 1 memory (1 page)
+    ///   - 1 i32 global, init = i32.const 1024
+    ///   - exports the global as `UNIFFI_META_NS_demo`
+    ///   - 1 active data segment at offset 1024 containing the bytes 1..=8
+    ///
+    /// We assert `read_meta_blobs` finds the export and slices out the right
+    /// bytes; we deliberately don't pipe through `read_metadata` because the
+    /// payload isn't a real metadata blob.
+    fn build_minimal_wasm() -> Vec<u8> {
+        // Sections are LEB128-prefixed payloads. For tiny known sizes we can
+        // hand-encode lengths as single bytes (all values < 0x80).
+        let mut out = Vec::new();
+        // magic + version
+        out.extend_from_slice(b"\0asm");
+        out.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+
+        // ---- memory section (id=5): 1 memory, limits min=1, no max
+        let mem_payload = vec![0x01, 0x00, 0x01];
+        push_section(&mut out, 5, &mem_payload);
+
+        // ---- global section (id=6): 1 global, type=i32 (0x7f) mut=0, init expr i32.const 1024 end
+        // 1024 in signed-LEB128 = 0x80 0x08
+        let global_payload = vec![
+            0x01, // count
+            0x7f, 0x00, // valtype i32, immutable
+            0x41, 0x80, 0x08, 0x0b, // i32.const 1024 ; end
+        ];
+        push_section(&mut out, 6, &global_payload);
+
+        // ---- export section (id=7): 1 export, name "UNIFFI_META_NS_demo", kind=global(2), index=0
+        let name = b"UNIFFI_META_NS_demo";
+        let mut export_payload = vec![0x01, name.len() as u8];
+        export_payload.extend_from_slice(name);
+        export_payload.extend_from_slice(&[0x03, 0x00]); // kind global (0x03), index 0
+        push_section(&mut out, 7, &export_payload);
+
+        // ---- data section (id=11): 1 active segment, memidx=0, offset=i32.const 1024 end, 8 bytes
+        let mut data_payload = vec![
+            0x01, // segment count
+            0x00, // active in memory 0
+            0x41, 0x80, 0x08, 0x0b, // i32.const 1024 ; end
+            0x08, // 8 bytes
+        ];
+        data_payload.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        push_section(&mut out, 11, &data_payload);
+
+        out
+    }
+
+    fn push_section(out: &mut Vec<u8>, id: u8, payload: &[u8]) {
+        out.push(id);
+        // payload length as LEB128; for our small payloads single-byte is enough
+        assert!(payload.len() < 0x80, "payload too big for single-byte LEB");
+        out.push(payload.len() as u8);
+        out.extend_from_slice(payload);
+    }
+
+    #[test]
+    fn extracts_meta_blob_from_minimal_wasm() {
+        let wasm = build_minimal_wasm();
+        assert!(looks_like_wasm(&wasm));
+        let blobs = read_meta_blobs(&wasm).expect("should parse minimal wasm");
+        assert_eq!(blobs.len(), 1);
+        let (name, bytes) = &blobs[0];
+        assert_eq!(name, "UNIFFI_META_NS_demo");
+        // The data segment is exactly 8 bytes and the address points at its base,
+        // so the returned slice begins with our sentinel and is at least 8 bytes.
+        assert!(bytes.len() >= 8);
+        assert_eq!(&bytes[..8], &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn rejects_wasm_with_no_meta_exports() {
+        // A genuinely empty wasm module - just the header.
+        let wasm: Vec<u8> = b"\0asm\x01\x00\x00\x00".to_vec();
+        let err = read_meta_blobs(&wasm).expect_err("should fail without meta exports");
+        assert!(err.to_string().contains("no UNIFFI_META_*"));
+    }
+
+    /// Extract from *every* fixture wasm the wasm2 harness has built. Between
+    /// them the fixtures cover metadata shapes no single crate does — async,
+    /// callback interfaces, trait methods, external types — so this is what
+    /// shows wasm extraction can stand in for the native build.
+    ///
+    /// `#[ignore]` because the inputs live under `target/tmp/` and only exist
+    /// once the wasm2 fixture suite has run. To regenerate: run
+    /// `cargo test -- wasm2::`, then `cargo test -p ubrn_bindgen --features
+    /// wasm -- --ignored extract_from_real_fixture_wasm`.
+    #[test]
+    #[ignore]
+    fn extract_from_real_fixture_wasm() {
+        // Resolve the workspace root from CARGO_MANIFEST_DIR so the test
+        // doesn't depend on the current working directory.
+        let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("crate is at <workspace>/crates/ubrn_bindgen")
+            .to_path_buf();
+        // `ubrn_fixture_testing::wasm2::compile_wasm32` builds `--release`.
+        let dir = workspace_root
+            .join("target/tmp/ubrn-tests-shared/wasm2-target/wasm32-unknown-unknown/release");
+        let mut wasms: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "no fixture wasms at {}: {e}. Build them first.",
+                    dir.display()
+                )
+            })
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "wasm"))
+            // A lib artifact is named after `[lib] name`, which cannot contain
+            // a hyphen; a bin artifact keeps its name verbatim. So a hyphen
+            // means an executable, which carries no UniFFI metadata.
+            .filter(|p| {
+                !p.file_stem()
+                    .is_some_and(|s| s.to_string_lossy().contains('-'))
+            })
+            .collect();
+        wasms.sort();
+        assert!(!wasms.is_empty(), "no .wasm files in {}", dir.display());
+
+        let mut failures = Vec::new();
+        for path in &wasms {
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            match extract_from_wasm(path) {
+                Err(e) => failures.push(format!("{name}: {e:#}")),
+                Ok(items) if items.is_empty() => failures.push(format!("{name}: no metadata")),
+                Ok(items) if !items.iter().any(|m| matches!(m, Metadata::Namespace(_))) => {
+                    failures.push(format!("{name}: no Namespace metadata"))
+                }
+                Ok(_) => {}
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{} of {} fixture wasms failed extraction:\n  {}",
+            failures.len(),
+            wasms.len(),
+            failures.join("\n  ")
+        );
+        eprintln!("extracted metadata from {} fixture wasms", wasms.len());
+    }
+}

--- a/crates/ubrn_bindgen/tests/wasm2_codegen.rs
+++ b/crates/ubrn_bindgen/tests/wasm2_codegen.rs
@@ -1,0 +1,89 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+//! Checks that `wrapper-ffi-player.ts` renders its Wasm2 branches: the
+//! runtime import comes from `@ubjs/wasm/core`, the module exports
+//! `PLAYER_DEFINITIONS` and `setNativeModule`, and the napi-only
+//! `UniffiNativeModule.open(...)` path is absent.
+
+#![cfg(feature = "wasm")]
+
+use ubrn_bindgen::{render_player_lowlevel_for_test, AbiFlavor};
+
+#[test]
+fn wasm2_player_ffi_renders_expected_markers() {
+    let rendered = render_player_lowlevel_for_test(&AbiFlavor::Wasm2)
+        .expect("rendering wasm2 player wrapper-ffi.ts should succeed");
+
+    // Wasm2 imports FfiType from the wasm runtime, not the napi runtime.
+    assert!(
+        rendered.contains(r#"import { FfiType } from "@ubjs/wasm/core""#),
+        "expected wasm2 runtime import in rendered output:\n{rendered}"
+    );
+
+    // Wasm2 exposes the player definitions for late binding by the runtime.
+    assert!(
+        rendered.contains("export const PLAYER_DEFINITIONS = DEFINITIONS;"),
+        "expected PLAYER_DEFINITIONS export in rendered output:\n{rendered}"
+    );
+
+    // Wasm2 lets the runtime push the native module in via setNativeModule.
+    assert!(
+        rendered.contains("export function setNativeModule"),
+        "expected setNativeModule export in rendered output:\n{rendered}"
+    );
+
+    // The napi getter path (which calls UniffiNativeModule.open) must not
+    // appear in the wasm2 output.
+    assert!(
+        !rendered.contains("UniffiNativeModule.open"),
+        "wasm2 rendering must not include the napi UniffiNativeModule.open call:\n{rendered}"
+    );
+
+    // The wrapper must stay environment-neutral: opening the `.wasm` belongs to
+    // the generated entrypoint, so importing an environment-specific subpath
+    // here would make every browser and React Native bundle pull in node
+    // built-ins.
+    assert!(
+        !rendered.contains("@ubjs/wasm/node") && !rendered.contains("@ubjs/wasm/browser"),
+        "wasm2 wrapper must import only /core, not an environment subpath:\n{rendered}"
+    );
+    assert!(
+        rendered.contains(r#"import { FfiType } from "@ubjs/wasm/core""#),
+        "expected the neutral /core import in wasm2 rendering:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("openWasm"),
+        "wasm2 wrapper must not open the wasm itself:\n{rendered}"
+    );
+    // Uninitialised use should say what to do rather than dereference undefined.
+    assert!(
+        rendered.contains("wasm module not initialised") && rendered.contains("uniffiInitAsync"),
+        "expected an actionable not-initialised error in wasm2 rendering:\n{rendered}"
+    );
+}
+
+#[test]
+fn napi_player_ffi_still_uses_native_module_open() {
+    // Sanity check that the non-Wasm2 player flavor still goes through the
+    // napi UniffiNativeModule.open(...) path. This guards against the wasm2
+    // branch accidentally being taken for non-wasm2 flavors.
+    let rendered = render_player_lowlevel_for_test(&AbiFlavor::Napi)
+        .expect("rendering napi player wrapper-ffi.ts should succeed");
+
+    assert!(
+        rendered.contains("UniffiNativeModule.open"),
+        "expected napi flavor to use UniffiNativeModule.open:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains(r#"import { FfiType } from "@ubjs/wasm/core""#),
+        "napi flavor must not import from @ubjs/wasm/core:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("export const PLAYER_DEFINITIONS"),
+        "napi flavor must not export PLAYER_DEFINITIONS:\n{rendered}"
+    );
+}


### PR DESCRIPTION
Add the `Wasm2` ABI flavor. Its per-module wrapper exports
`PLAYER_DEFINITIONS` and `setNativeModule` rather than opening the module
itself, so it stays environment-neutral and bundles for node, browsers and
React Native alike. A generated `index.ts` does the opening.

Read UniFFI metadata straight out of the cdylib's `UNIFFI_META_*` wasm
globals. The blobs use the same format as a native build's symbol table, so
`wasm_metadata` feeds them to `uniffi_meta::read_metadata` and the second,
native-only cargo build disappears.

Import wasm-bindgen's glue statically where the crate reached wasm-bindgen
through its dependencies. A static import keeps the glue in the bundler's
graph; fetching it at runtime would be invisible to bundlers and would need
the file served beside the wasm.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>