### PR TITLE
test(wasm2): run the fixture suite under the player

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
  "dunce",
  "heck",
  "pathdiff",
+ "ubrn_common",
 ]
 
 [[package]]
@@ -2069,6 +2070,8 @@ dependencies = [
  "ubrn_macros",
  "ubrn_testing",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2084,6 +2087,8 @@ dependencies = [
  "ubrn_macros",
  "ubrn_testing",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2099,6 +2104,8 @@ dependencies = [
  "ubrn_macros",
  "ubrn_testing",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2114,6 +2121,8 @@ dependencies = [
  "ubrn_macros",
  "ubrn_testing",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2123,6 +2132,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2133,6 +2144,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2144,6 +2157,8 @@ dependencies = [
  "ubrn_macros",
  "ubrn_testing",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
  "wasm-bindgen-futures",
 ]
 
@@ -2156,6 +2171,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
  "uniffi_meta",
 ]
 
@@ -2168,6 +2185,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2187,6 +2206,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2198,6 +2219,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2214,6 +2237,8 @@ dependencies = [
  "uniffi-fixture-ext-types-external-crate",
  "uniffi-fixture-ext-types-lib-one",
  "uniffi-fixture-ext-types-sub-lib",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
  "url",
 ]
 
@@ -2279,6 +2304,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2291,6 +2318,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2312,6 +2341,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2323,6 +2354,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2334,6 +2367,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]
@@ -2343,6 +2378,8 @@ dependencies = [
  "ubrn_fixture_testing",
  "ubrn_macros",
  "uniffi",
+ "uniffi-runtime-wasm",
+ "uniffi_core",
 ]
 
 [[package]]

--- a/crates/ubrn_fixture_testing/Cargo.toml
+++ b/crates/ubrn_fixture_testing/Cargo.toml
@@ -10,3 +10,4 @@ cargo_metadata = { workspace = true }
 dunce = "1.0.5"
 heck = { workspace = true }
 pathdiff = { workspace = true }
+ubrn_common = { path = "../ubrn_common", features = ["wasm"] }

--- a/crates/ubrn_fixture_testing/src/Cargo.template.toml
+++ b/crates/ubrn_fixture_testing/src/Cargo.template.toml
@@ -12,7 +12,12 @@ path = "{{lib_rs_path}}"
 default = ["console_error_panic_hook"]
 
 [dependencies]
-# Pin wasm-bindgen to avoid js-sys compile time regression introduced in 0.2.101+.
+# Must match the workspace's `wasm-bindgen-cli-support`: the rewriter demands
+# schema-version equality with the crate the wasm was built against. Two more
+# reasons to stay on 0.2.100 — 0.2.101+ revives a js-sys compile-time
+# regression, and it changes async-callback vtable codegen in a way the legacy
+# `Wasm` runtime rejects ("Callback interface method returned unexpected
+# error").
 wasm-bindgen = "=0.2.100"
 {{crate_name}} = { path = "{{crate_path}}" }
 uniffi-runtime-javascript = { path = "{{uniffi_runtime_javascript}}", features = ["wasm32"] }

--- a/crates/ubrn_fixture_testing/src/lib.rs
+++ b/crates/ubrn_fixture_testing/src/lib.rs
@@ -11,13 +11,15 @@ pub mod jsi;
 pub mod napi;
 pub mod ts;
 pub mod wasm;
+pub mod wasm2;
 
-/// Test flavor: JSI (Hermes native), WASM (Node.js), or Napi (Node.js N-API).
+/// Test flavor: JSI (Hermes native), WASM (Node.js), Napi (Node.js N-API), or Wasm2 (Player-based WASM).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Flavor {
     Jsi,
     Wasm,
     Napi,
+    Wasm2,
 }
 
 impl Flavor {
@@ -26,6 +28,7 @@ impl Flavor {
             Flavor::Jsi => "jsi",
             Flavor::Wasm => "wasm",
             Flavor::Napi => "napi",
+            Flavor::Wasm2 => "wasm2",
         }
     }
 }
@@ -191,6 +194,22 @@ fn tsconfig_runtimes(flavor: Flavor, rel_root: &Utf8PathBuf) -> String {
     if flavor == Flavor::Napi {
         runtime_paths.push(format!(r#""@ubjs/node": ["{rel_root}/runtimes/napi/lib"]"#));
     }
+    if flavor == Flavor::Wasm2 {
+        // `paths` bypasses the package `exports` map, so the bare specifier
+        // the generated index imports needs pointing at the node build.
+        runtime_paths.push(format!(
+            r#""@ubjs/wasm": ["{rel_root}/runtimes/wasm/node/src/index"]"#
+        ));
+        runtime_paths.push(format!(
+            r#""@ubjs/wasm/core": ["{rel_root}/runtimes/wasm/core/src/index"]"#
+        ));
+        runtime_paths.push(format!(
+            r#""@ubjs/wasm/browser": ["{rel_root}/runtimes/wasm/browser/src/index"]"#
+        ));
+        runtime_paths.push(format!(
+            r#""@ubjs/wasm/node": ["{rel_root}/runtimes/wasm/node/src/index"]"#
+        ));
+    }
     runtime_paths.join(",\n      ")
 }
 
@@ -200,6 +219,21 @@ pub(crate) fn run_tsx(test_script: &camino::Utf8Path) {
     run_cmd(
         command(&tsx)
             .arg("--experimental-wasm-modules")
+            .arg(test_script.as_str()),
+    );
+}
+
+/// As [`run_tsx`], but evaluates `preload` first. Node runs `--import` modules
+/// to completion — including their top-level `await` — before the entry
+/// module, which is what lets the preload finish opening the wasm before the
+/// test script imports anything that needs it.
+pub(crate) fn run_tsx_with_preload(test_script: &camino::Utf8Path, preload: &camino::Utf8Path) {
+    let tsx = paths::node_modules_bin().join("tsx");
+    run_cmd(
+        command(&tsx)
+            .arg("--experimental-wasm-modules")
+            .arg("--import")
+            .arg(format!("file://{preload}"))
             .arg(test_script.as_str()),
     );
 }

--- a/crates/ubrn_fixture_testing/src/ts.rs
+++ b/crates/ubrn_fixture_testing/src/ts.rs
@@ -40,6 +40,10 @@ pub fn run_test(test_script: &str, flavor: Flavor, target_tmpdir: &str) {
             paths::assert_napi_bootstrap();
             crate::run_tsx(test_script);
         }
+        Flavor::Wasm2 => {
+            paths::assert_wasm_bootstrap();
+            crate::run_tsx(test_script);
+        }
     }
 }
 

--- a/crates/ubrn_fixture_testing/src/wasm.rs
+++ b/crates/ubrn_fixture_testing/src/wasm.rs
@@ -87,7 +87,8 @@ pub fn run_test(crate_name: &str, test_script: &str, target_tmpdir: &str) {
         .join(format!("{wasm_lib_stem}.wasm"));
     let wasm_bindgen_dir = ts_dir.join("wasm-bindgen");
     std::fs::create_dir_all(&wasm_bindgen_dir).expect("failed to create wasm-bindgen dir");
-    run_wasm_bindgen(&wasm_file, &wasm_bindgen_dir);
+    ubrn_common::run_wasm_bindgen(&wasm_file, &wasm_bindgen_dir, "index")
+        .unwrap_or_else(|e| panic!("wasm-bindgen on {wasm_file}: {e:#}"));
 
     // Step 7: Write fixture tsconfig for @generated/* resolution, then run tsx.
     // The guard ensures cleanup even if run_tsx panics.
@@ -158,7 +159,19 @@ fn generate_lib_rs(src_dir: &Utf8Path, library_name: &str) {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let lib_rs = format!("#[allow(unused_imports)]\nuse {lib_ident};\n\n{mod_decls}\n");
+    // Wire `console_error_panic_hook` (an optional default feature on the
+    // wrapper-crate template) at module init so wasm panics surface as
+    // readable `console.error` traces instead of a bare `RuntimeError:
+    // unreachable`. Without this every Rust panic in the Wasm flavor is a
+    // silent debugging dead-end.
+    let lib_rs = format!(
+        "#[allow(unused_imports)]\nuse {lib_ident};\n\n\
+         #[wasm_bindgen::prelude::wasm_bindgen(start)]\n\
+         pub fn __ubrn_init() {{\n    \
+             console_error_panic_hook::set_once();\n\
+         }}\n\n\
+         {mod_decls}\n"
+    );
 
     let lib_rs_path = src_dir.join("lib.rs");
     std::fs::write(&lib_rs_path, lib_rs).expect("failed to write lib.rs");
@@ -201,20 +214,5 @@ fn compile_wasm32(cargo_toml: &Utf8Path, target_dir: &Utf8Path) {
             .arg("wasm32-unknown-unknown")
             .arg("--manifest-path")
             .arg(cargo_toml.as_str()),
-    );
-}
-
-/// Run `wasm-bindgen` to produce JS glue from the WASM binary.
-fn run_wasm_bindgen(wasm_file: &Utf8Path, out_dir: &Utf8Path) {
-    run_cmd_quietly(
-        Command::new("wasm-bindgen")
-            .arg("--target")
-            .arg("bundler")
-            .arg("--omit-default-module-path")
-            .arg("--out-name")
-            .arg("index")
-            .arg("--out-dir")
-            .arg(out_dir.as_str())
-            .arg(wasm_file.as_str()),
     );
 }

--- a/crates/ubrn_fixture_testing/src/wasm2.rs
+++ b/crates/ubrn_fixture_testing/src/wasm2.rs
@@ -1,0 +1,118 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use std::process::Command;
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{metadata, paths, run_cmd_quietly};
+
+/// Run a fixture test under the Wasm2 (player-based) flavor.
+///
+/// Builds the fixture crate once, for `wasm32-unknown-unknown` (the fixture
+/// itself depends on `uniffi-runtime-wasm` via a target-specific dep), and
+/// generates bindings from that same `.wasm` — `ubrn_bindgen` reads uniffi
+/// metadata out of its `UNIFFI_META_*` globals, so no native build is needed.
+pub fn run_test(crate_name: &str, test_script: &str, target_tmpdir: &str) {
+    // Serialize with other flavors for this fixture (they share generated/).
+    let _lock = crate::lock_fixture();
+
+    // Step 0: Check bootstrap
+    paths::assert_wasm_bootstrap();
+
+    let test_script = Utf8Path::new(test_script);
+
+    // Step 1: Build the fixture crate for wasm32 in a shared target dir.
+    let lib_stem = metadata::find_cdylib_name(crate_name);
+    let fixture_dir = metadata::find_package_dir(crate_name);
+    let shared_target_dir = Utf8PathBuf::from(target_tmpdir).join("ubrn-tests-shared/wasm2-target");
+    std::fs::create_dir_all(&shared_target_dir).expect("failed to create shared target dir");
+    compile_wasm32(crate_name, &shared_target_dir);
+    let wasm_file = shared_target_dir
+        .join("wasm32-unknown-unknown/release")
+        .join(format!("{lib_stem}.wasm"));
+
+    // Step 2: Generate TS bindings from the *unstaged* wasm. Staging strips
+    // the `UNIFFI_META_*` exports and may rewrite the module, so metadata has
+    // to come off the raw cargo output.
+    let generated = fixture_dir.join("generated/wasm2");
+    let _ = std::fs::remove_dir_all(&generated);
+    let ts_dir = generated.join("ts");
+    std::fs::create_dir_all(&ts_dir).expect("failed to create ts dir");
+    generate_bindings(&wasm_file, &ts_dir);
+
+    // Step 3: Stage the wasm next to the TS bindings, with DCE — fixture
+    // artifacts are ours, so over-stripping fails a test rather than a user.
+    ubrn_common::stage_wasm(&wasm_file, &ts_dir, &lib_stem, true)
+        .unwrap_or_else(|e| panic!("staging {wasm_file}: {e:#}"));
+
+    // Step 4: Stand in for the entrypoint a real project would use. Test
+    // scripts are shared across flavors, so they import the API module
+    // directly and never call `uniffiInitAsync`.
+    let bootstrap = write_node_bootstrap(&ts_dir, &lib_stem);
+
+    // Step 5: Write fixture tsconfig + run tsx.
+    let _tsconfig_guard = crate::CleanupFile::new(crate::write_fixture_tsconfig(
+        &fixture_dir,
+        crate::Flavor::Wasm2,
+    ));
+    crate::run_tsx_with_preload(test_script, &bootstrap);
+}
+
+/// Write the preload that initialises the generated bindings, and return its
+/// path. The index does the real loading; this only names the asset and calls
+/// it, because test scripts are shared across flavors and never call it
+/// themselves.
+fn write_node_bootstrap(ts_dir: &Utf8Path, lib_stem: &str) -> Utf8PathBuf {
+    let path = ts_dir.join("uniffi-bootstrap.node.ts");
+    std::fs::write(
+        &path,
+        format!(
+            "import {{ uniffiInitAsync }} from \"./index.js\";\n\
+             await uniffiInitAsync(new URL(\"./{lib_stem}.wasm\", import.meta.url));\n"
+        ),
+    )
+    .unwrap_or_else(|e| panic!("write {path}: {e}"));
+    path
+}
+
+/// Generate bindings via the CLI, using the `wasm2` subcommand.
+fn generate_bindings(cdylib_path: &Utf8Path, ts_dir: &Utf8Path) {
+    run_cmd_quietly(
+        Command::new("cargo")
+            .arg("run")
+            .arg("-p")
+            .arg("uniffi-bindgen-react-native")
+            .arg("--")
+            .arg("generate")
+            .arg("wasm2")
+            .arg("bindings")
+            .arg("--library")
+            .arg("--ts-dir")
+            .arg(ts_dir.as_str())
+            .arg(cdylib_path.as_str()),
+    );
+}
+
+/// `cargo build --lib -p <crate_name> --target wasm32-unknown-unknown`.
+///
+/// `--lib` because only the cdylib is consumed; a fixture also declaring a
+/// `[[bin]]` would otherwise build a multi-megabyte executable nobody reads.
+/// No RUSTFLAGS: `ubrn_common::export_growable_table` adds the growable table
+/// export to the built module instead.
+fn compile_wasm32(crate_name: &str, target_dir: &Utf8Path) {
+    run_cmd_quietly(
+        Command::new("cargo")
+            .env("CARGO_TARGET_DIR", target_dir.as_str())
+            .arg("build")
+            .arg("--release")
+            .arg("--lib")
+            .arg("-p")
+            .arg(crate_name)
+            .arg("--target")
+            .arg("wasm32-unknown-unknown"),
+    );
+}

--- a/fixtures/arc-futures/Cargo.toml
+++ b/fixtures/arc-futures/Cargo.toml
@@ -17,6 +17,8 @@ ubrn_testing = { path = "../../crates/ubrn_testing" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build", "wasm-unstable-single-threaded"] }

--- a/fixtures/arc-futures/src/lib.rs
+++ b/fixtures/arc-futures/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;

--- a/fixtures/arc-futures/tests/test_bindings.rs
+++ b/fixtures/arc-futures/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_arc_futures.ts" => [Jsi, Napi, Wasm],
+    "tests/bindings/test_arc_futures.ts" => [Jsi, Napi, Wasm, Wasm2],
 }

--- a/fixtures/async-callbacks/Cargo.toml
+++ b/fixtures/async-callbacks/Cargo.toml
@@ -19,6 +19,10 @@ tokio = { version = "1.24.1", features = ["time", "sync"] }
 once_cell = "1.18.0"
 ubrn_testing = { path = "../../crates/ubrn_testing" }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/async-callbacks/src/lib.rs
+++ b/fixtures/async-callbacks/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::{sync::Arc, time::Duration};
 
 use futures::future::{AbortHandle, Abortable, Aborted};

--- a/fixtures/async-callbacks/tests/test_bindings.rs
+++ b/fixtures/async-callbacks/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_async_callbacks.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_async_callbacks.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/async-calls/Cargo.toml
+++ b/fixtures/async-calls/Cargo.toml
@@ -25,6 +25,10 @@ uniffi = { workspace = true, features = ["tokio", "cli"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.24.1", features = ["time", "sync"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/async-calls/src/lib.rs
+++ b/fixtures/async-calls/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 mod platform_specific;
 use platform_specific::acquire_with_timeout;
 use ubrn_testing::timer::{TimerFuture, TimerService};

--- a/fixtures/async-calls/tests/test_bindings.rs
+++ b/fixtures/async-calls/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_async_calls.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_async_calls.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/async-traits/Cargo.toml
+++ b/fixtures/async-traits/Cargo.toml
@@ -19,6 +19,10 @@ tokio = { version = "1.24.1", features = ["time", "sync"] }
 once_cell = "1.18.0"
 ubrn_testing = { path = "../../crates/ubrn_testing" }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/async-traits/src/lib.rs
+++ b/fixtures/async-traits/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::{sync::Arc, time::Duration};
 
 use ubrn_testing::timer::{TimerFuture, TimerService};

--- a/fixtures/async-traits/tests/test_bindings.rs
+++ b/fixtures/async-traits/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_async_traits.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_async_traits.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/benchmark/Cargo.toml
+++ b/fixtures/benchmark/Cargo.toml
@@ -12,6 +12,10 @@ name = "uniffi_benchmark"
 [dependencies]
 uniffi = { workspace = true, features = ["tokio"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [dev-dependencies]
 ubrn_macros = { workspace = true }
 ubrn_fixture_testing = { workspace = true }

--- a/fixtures/benchmark/src/lib.rs
+++ b/fixtures/benchmark/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 

--- a/fixtures/benchmark/tests/test_bindings.rs
+++ b/fixtures/benchmark/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_benchmark.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_benchmark.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/callbacks-regression/Cargo.toml
+++ b/fixtures/callbacks-regression/Cargo.toml
@@ -16,6 +16,8 @@ thiserror = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/callbacks-regression/src/lib.rs
+++ b/fixtures/callbacks-regression/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::sync::Arc;
 use ubrn_testing::thread::spawn_task;
 

--- a/fixtures/callbacks-regression/tests/test_bindings.rs
+++ b/fixtures/callbacks-regression/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_callbacks_regression.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_callbacks_regression.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -14,6 +14,10 @@ name = "uniffi_fixture_callbacks"
 uniffi = { workspace = true, features=[] }
 thiserror = "1.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 trait ForeignGetters {
     fn get_bool(&self, v: bool, argument_two: bool) -> Result<bool, SimpleError>;
     fn get_string(&self, v: String, arg2: bool) -> Result<String, SimpleError>;

--- a/fixtures/callbacks/tests/test_bindings.rs
+++ b/fixtures/callbacks/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_callbacks.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_callbacks.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/chronological/Cargo.toml
+++ b/fixtures/chronological/Cargo.toml
@@ -15,6 +15,10 @@ uniffi = { workspace = true }
 thiserror = "1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/chronological/src/lib.rs
+++ b/fixtures/chronological/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::time::{Duration, SystemTime};
 
 use chrono::offset::Utc;

--- a/fixtures/chronological/tests/test_bindings.rs
+++ b/fixtures/chronological/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_chronological.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_chronological.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -15,6 +15,10 @@ uniffi = { workspace = true, features=[]}
 once_cell = "1.12"
 thiserror = "1.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};

--- a/fixtures/coverall/tests/test_bindings.rs
+++ b/fixtures/coverall/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_coverall.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_coverall.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/coverall2/Cargo.toml
+++ b/fixtures/coverall2/Cargo.toml
@@ -14,6 +14,10 @@ async-std = "1.12.0"
 thiserror = "1.0"
 uniffi = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/coverall2/src/lib.rs
+++ b/fixtures/coverall2/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 #[uniffi::export]
 /// This makes the byte array in rust, and the test in JS will compare it there.
 ///

--- a/fixtures/coverall2/tests/test_bindings.rs
+++ b/fixtures/coverall2/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_coverall2.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_coverall2.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/enum-types/Cargo.toml
+++ b/fixtures/enum-types/Cargo.toml
@@ -14,6 +14,10 @@ name = "enum_types"
 uniffi = { workspace = true }
 thiserror = "1.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 pub enum Animal {
     Dog,
     Cat,

--- a/fixtures/enum-types/tests/test_bindings.rs
+++ b/fixtures/enum-types/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_enum_types.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_enum_types.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/error-types/Cargo.toml
+++ b/fixtures/error-types/Cargo.toml
@@ -14,6 +14,10 @@ uniffi = { workspace = true, features = ["wasm-unstable-single-threaded"] }
 anyhow = "1"
 thiserror = "1.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build", "wasm-unstable-single-threaded"] }
 

--- a/fixtures/error-types/src/lib.rs
+++ b/fixtures/error-types/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]

--- a/fixtures/error-types/tests/test_bindings.rs
+++ b/fixtures/error-types/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_error_types.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_error_types.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/ext-types/Cargo.toml
+++ b/fixtures/ext-types/Cargo.toml
@@ -34,6 +34,10 @@ uniffi-example-custom-types = {path = "../../examples/custom-types-example"}
 
 url = "2.2"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/ext-types/src/lib.rs
+++ b/fixtures/ext-types/src/lib.rs
@@ -3,6 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
+
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use custom_types::Handle;
 use ext_types_custom::{ANestedGuid, Guid, Ouid};
 use ext_types_external_crate::{

--- a/fixtures/ext-types/tests/test_bindings.rs
+++ b/fixtures/ext-types/tests/test_bindings.rs
@@ -4,6 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_ext_types.ts" => [Jsi, Wasm, Napi],
-    "tests/bindings/test_ext_types_with_index.ts" => [Napi],
+    "tests/bindings/test_ext_types.ts" => [Jsi, Wasm, Napi, Wasm2],
+    "tests/bindings/test_ext_types_with_index.ts" => [Napi, Wasm2],
 }

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -22,6 +22,10 @@ thiserror = "1.0"
 tokio = { version = "1.24.1", features = ["time", "sync"] }
 once_cell = "1.18.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::{
     future::Future,
     pin::Pin,

--- a/fixtures/futures/tests/test_bindings.rs
+++ b/fixtures/futures/tests/test_bindings.rs
@@ -4,5 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
+    // No Wasm2 (nor Wasm): the `TimerFuture` in `src/lib.rs` wakes itself with
+    // `std::thread::spawn`, which single-threaded wasm32 cannot do. The panic
+    // aborts mid-call holding a Rust mutex, and `freeFunc` then aborts again
+    // trying to re-lock it. Re-enable once TimerFuture drops host threads.
     "tests/bindings/test_futures.ts" => [Jsi, Napi],
 }

--- a/fixtures/gc-callbacks-crasher/Cargo.toml
+++ b/fixtures/gc-callbacks-crasher/Cargo.toml
@@ -15,6 +15,10 @@ async-trait = "0.1.83"
 thiserror = "1.0"
 uniffi = { workspace = true, features = ["tokio"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/gc-callbacks-crasher/src/lib.rs
+++ b/fixtures/gc-callbacks-crasher/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::sync::Arc;
 
 #[uniffi::export(callback_interface)]

--- a/fixtures/gc-callbacks-crasher/tests/test_bindings.rs
+++ b/fixtures/gc-callbacks-crasher/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_gc_callbacks_crasher.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_gc_callbacks_crasher.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/strict-byte-arrays/Cargo.toml
+++ b/fixtures/strict-byte-arrays/Cargo.toml
@@ -14,6 +14,10 @@ async-std = "1.12.0"
 thiserror = "1.0"
 uniffi = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/strict-byte-arrays/src/lib.rs
+++ b/fixtures/strict-byte-arrays/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 #[uniffi::export]
 /// This makes the byte array in rust, and the test in JS will compare it there.
 ///

--- a/fixtures/strict-byte-arrays/tests/test_bindings.rs
+++ b/fixtures/strict-byte-arrays/tests/test_bindings.rs
@@ -4,6 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_strict_byte_arrays.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_strict_byte_arrays.ts" => [Jsi, Wasm, Napi, Wasm2],
     "tests/bindings/test_rustbuffer_alloc.ts" => [Jsi],
 }

--- a/fixtures/trait-methods/Cargo.toml
+++ b/fixtures/trait-methods/Cargo.toml
@@ -14,6 +14,10 @@ uniffi = { workspace = true }
 once_cell = "1.12"
 thiserror = "1.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/fixtures/trait-methods/src/lib.rs
+++ b/fixtures/trait-methods/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/fixtures/trait-methods/tests/test_bindings.rs
+++ b/fixtures/trait-methods/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_trait_methods.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_trait_methods.ts" => [Jsi, Wasm, Napi, Wasm2],
 }

--- a/fixtures/value-type-methods/Cargo.toml
+++ b/fixtures/value-type-methods/Cargo.toml
@@ -12,6 +12,10 @@ name = "uniffi_value_type_methods"
 [dependencies]
 uniffi = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uniffi-runtime-wasm = { workspace = true }
+uniffi_core = { workspace = true, features = ["wasm-unstable-single-threaded"] }
+
 [dev-dependencies]
 ubrn_macros = { workspace = true }
 ubrn_fixture_testing = { workspace = true }

--- a/fixtures/value-type-methods/src/lib.rs
+++ b/fixtures/value-type-methods/src/lib.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+#[cfg(target_arch = "wasm32")]
+extern crate uniffi_runtime_wasm as _;
+
 // Point: a record with methods.
 // NOTE: Record constructors via #[uniffi::constructor] are not yet supported in uniffi 0.31.0
 // because the metadata reader (uniffi_meta::reader::read_constructor) only accepts

--- a/fixtures/value-type-methods/tests/test_bindings.rs
+++ b/fixtures/value-type-methods/tests/test_bindings.rs
@@ -4,5 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 ubrn_macros::build_foreign_language_testcases! {
-    "tests/bindings/test_value_type_methods.ts" => [Jsi, Wasm, Napi],
+    "tests/bindings/test_value_type_methods.ts" => [Jsi, Wasm, Napi, Wasm2],
 }


### PR DESCRIPTION
Add a `Wasm2` flavor to the fixture harness and turn it on across the suite,
so the player is checked against the same tests every other flavor runs.

Each fixture gains `uniffi-runtime-wasm` as a wasm32-only dependency and the
uniffi_core feature the flavor needs. The harness builds the fixture once for
wasm32, generates bindings from that same module, stages it, and writes a
preload standing in for the entrypoint a real project would use — test
scripts are shared across flavors, so they never call `uniffiInitAsync`.

The futures fixture stays out, as it does for the wasm flavor: its
`TimerFuture` wakes itself with `std::thread::spawn`, which single-threaded
wasm32 cannot do.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>