### PR TITLE
Adopt library-owned RustBuffer arguments instead of copying them to attempt to address napi player memory leak

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustBufferHelper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/RustBufferHelper.cpp
@@ -30,18 +30,58 @@ template <> struct Bridging<RustBuffer> {
   static RustBuffer fromJs(jsi::Runtime &rt, std::shared_ptr<CallInvoker>,
                            const jsi::Value &value) {
     try {
+      auto obj = value.asObject(rt);
+
+      // Adoption vs copy. Two kinds of view arrive here:
+      //
+      //   * Library-owned views from `rustbuffer_alloc`. Codegen allocates one,
+      //     fills it in place, and ships it as an argument — and never frees a
+      //     lowered argument, while the view's backing `CMutableBuffer` is
+      //     non-owning (its destructor leaves `data` alone). Such a view carries
+      //     a capacity hint (stamped by `rustbuffer_alloc` in the wrapper). We
+      //     *adopt* it: hand the existing allocation to the callee, which frees
+      //     it. Copying instead would orphan the allocation and leak one whole
+      //     payload per call.
+      //   * Ordinary JS-owned arrays, which carry no hint. These are *copied*
+      //     into a fresh library allocation — they are not ours to give away.
+      //
+      // On adoption we reset the hint to 0 so a later `rustbuffer_free(view)` is
+      // a no-op rather than a double free.
+      if (obj.hasProperty(rt, uniffi_jsi::kUbrnRustCapacity)) {
+        auto capacity = static_cast<uint64_t>(
+            obj.getProperty(rt, uniffi_jsi::kUbrnRustCapacity).asNumber());
+        if (capacity == 0) {
+          // Hint present but zeroed: the view was already adopted by a previous
+          // call and its memory has been freed. Reading it would be a
+          // use-after-free, so refuse rather than hand over a dangling pointer.
+          throw jsi::JSError(
+              rt,
+              "RustBuffer argument was already consumed by a previous FFI call");
+        }
+        auto arrayBuffer =
+            obj.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
+        auto byteOffset =
+            static_cast<size_t>(obj.getProperty(rt, "byteOffset").asNumber());
+        auto byteLength =
+            static_cast<size_t>(obj.getProperty(rt, "byteLength").asNumber());
+        obj.setProperty(rt, uniffi_jsi::kUbrnRustCapacity, jsi::Value(0));
+        return RustBuffer{
+            .capacity = capacity,
+            .len = static_cast<uint64_t>(byteLength),
+            .data = arrayBuffer.data(rt) + byteOffset,
+        };
+      }
+
       auto buffer = uniffi_jsi::Bridging<jsi::ArrayBuffer>::value_to_arraybuffer(rt, value);
       auto bytes = ForeignBytes{
           .len = static_cast<int32_t>(buffer.length(rt)),
           .data = buffer.data(rt),
       };
 
-      // This buffer is constructed from foreign bytes. Rust scaffolding copies
-      // the bytes, to make the RustBuffer.
+      // No hint: an ordinary JS-owned array. Rust scaffolding copies the bytes
+      // to make the RustBuffer; the copy is destroyed when the callee
+      // deserializes its arguments.
       auto buf = rustbuffer_from_bytes(bytes);
-      // Once it leaves this function, the buffer is immediately passed back
-      // into Rust, where it's used to deserialize into the Rust versions of the
-      // arguments. At that point, the copy is destroyed.
       return buf;
     } catch (const std::logic_error &e) {
       throw jsi::JSError(rt, e.what());

--- a/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
+++ b/crates/ubrn_bindgen/src/bindings/gen_cpp/templates/wrapper.cpp
@@ -115,14 +115,24 @@ extern "C" {
                 throw jsi::JSError(rt, "rustbuffer_alloc failed: alloc returned null");
             }
             // Non-owning view over Rust-allocated memory; CMutableBuffer's destructor
-            // is the default and does not free `rb.data`. JS must call rustbuffer_free
-            // explicitly before dropping the reference.
+            // is the default and does not free `rb.data`. The allocation is released
+            // either by an explicit `rustbuffer_free(view)` or by being adopted when
+            // the view is lowered as an FFI argument.
             auto payload = std::make_shared<uniffi_jsi::CMutableBuffer>(
                 rb.data, static_cast<size_t>(rb.capacity));
             // Wrap as Uint8Array so JS can index/assign bytes directly.
-            return jsi::Value(
-                rt, uniffi_jsi::arraybufferToUint8Array(
-                        rt, jsi::ArrayBuffer(rt, payload)));
+            auto view = uniffi_jsi::arraybufferToUint8Array(
+                rt, jsi::ArrayBuffer(rt, payload));
+            // Stamp the capacity so the argument-lowering path
+            // (`Bridging<RustBuffer>::fromJs`) recognises this view as
+            // library-owned and adopts the allocation instead of copying it.
+            // Without the stamp, a lowered argument is copied and this
+            // allocation is orphaned — one leaked payload per call.
+            if (rb.capacity > 0) {
+              view.setProperty(rt, uniffi_jsi::kUbrnRustCapacity,
+                               jsi::Value(static_cast<double>(rb.capacity)));
+            }
+            return jsi::Value(rt, view);
         }
     );
 
@@ -155,6 +165,12 @@ extern "C" {
             if (view.hasProperty(rt, uniffi_jsi::kUbrnRustCapacity)) {
                 capacity = static_cast<size_t>(
                     view.getProperty(rt, uniffi_jsi::kUbrnRustCapacity).asNumber());
+            }
+            // A zero capacity marks a view already adopted as an FFI argument
+            // (its hint was reset to 0) and freed by the callee. Freeing again
+            // would be a double free, so this is a no-op.
+            if (capacity == 0) {
+                return jsi::Value::undefined();
             }
             auto buffer = view.getPropertyAsObject(rt, "buffer").getArrayBuffer(rt);
             auto byteOffset =

--- a/fixtures/strict-byte-arrays/src/lib.rs
+++ b/fixtures/strict-byte-arrays/src/lib.rs
@@ -30,4 +30,71 @@ pub fn identity_bytes_forced_read(bytes: Option<Vec<u8>>) -> Option<Vec<u8>> {
     bytes
 }
 
+// --- RustBuffer-argument leak probe ------------------------------------------
+//
+// A counting global allocator that tracks only "big" allocations (>= 64 KiB).
+// Ordinary bookkeeping (strings, small vecs) is far below that, so the only
+// things this size are the RustBuffers and lifted `Vec`s produced by a large
+// byte-array argument. Tests read the live count through `live_big_alloc_count`
+// and assert exact equality across a loop of calls — the same counter technique
+// the napi ownership tests use, chosen because RSS/heap sampling is too noisy to
+// see a per-call leak of one buffer.
+//
+// Purpose: prove empirically whether lowering a `RustBuffer` argument leaks. If
+// the runtime copies the lowered view (JSI, and napi before the adopt fix) the
+// library-owned allocation is orphaned and the live count climbs by one per
+// call; if it adopts or aliases (napi post-fix, wasm2) the count stays flat.
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicI64, Ordering};
+
+const BIG_THRESHOLD: usize = 64 * 1024;
+static LIVE_BIG_COUNT: AtomicI64 = AtomicI64::new(0);
+static LIVE_BIG_BYTES: AtomicI64 = AtomicI64::new(0);
+
+struct CountingAlloc;
+
+// SAFETY: delegates every allocation to the System allocator unchanged; the
+// atomics only observe sizes and never alter the returned pointer.
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() && layout.size() >= BIG_THRESHOLD {
+            LIVE_BIG_COUNT.fetch_add(1, Ordering::Relaxed);
+            LIVE_BIG_BYTES.fetch_add(layout.size() as i64, Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if layout.size() >= BIG_THRESHOLD {
+            LIVE_BIG_COUNT.fetch_sub(1, Ordering::Relaxed);
+            LIVE_BIG_BYTES.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        }
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+#[uniffi::export]
+/// Takes a byte array (lowered as a `RustBuffer`) and returns a scalar, so only
+/// the *argument* direction allocates a big buffer. The leak probe calls this in
+/// a loop; a leaked lowered argument shows up as growth in `live_big_alloc_count`.
+pub fn measure_bytes(bytes: Vec<u8>) -> u32 {
+    bytes.len() as u32
+}
+
+#[uniffi::export]
+/// Number of live allocations >= 64 KiB the crate currently owns.
+pub fn live_big_alloc_count() -> u32 {
+    LIVE_BIG_COUNT.load(Ordering::Relaxed).max(0) as u32
+}
+
+#[uniffi::export]
+/// Total bytes across live allocations >= 64 KiB the crate currently owns.
+pub fn live_big_alloc_bytes() -> u64 {
+    LIVE_BIG_BYTES.load(Ordering::Relaxed).max(0) as u64
+}
+
 uniffi::setup_scaffolding!();

--- a/fixtures/strict-byte-arrays/tests/bindings/test_double_free.ts
+++ b/fixtures/strict-byte-arrays/tests/bindings/test_double_free.ts
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Safety edges of the adopt-on-lower fix.
+//
+// To run:
+//   cargo test -p uniffi-fixture-strict-byte-arrays -- test_double_free
+//
+// When a library-owned `rustbuffer_alloc` view is lowered as an FFI argument it
+// is *adopted*: the existing allocation is handed to the callee (which frees it)
+// and the view's capacity hint is reset to 0. These tests pin the two guards
+// that keep that safe — the shared-fixture analog of the napi runtime's
+// "freeing an already-adopted argument view does not double free" test.
+//
+// We drive the raw scaffolding function directly (rather than the generated
+// wrapper, which lowers a fresh view of its own) so the view we adopt is one we
+// control. `measure_bytes(Vec<u8>) -> u32` is non-throwing, so the only
+// exception that can surface is the runtime's own "already consumed" guard.
+import "@/generated/uniffi_strict_byte_arrays";
+import getNativeModule from "@/generated/uniffi_strict_byte_arrays-ffi";
+import { test } from "@/asserts";
+import "@/polyfills";
+
+// Portable native-module handle: every flavor default-exports its
+// `nativeModule()` getter from the `-ffi` module (JSI resolves to the global
+// host object, napi/wasm2 to their registered module).
+const nm: any = getNativeModule();
+
+// The raw scaffolding symbol for `measure_bytes` is spelled differently per
+// runtime — JSI prefixes host functions with `ubrn_`, napi/wasm2 use the bare
+// FFI name — so probe for whichever the native module exposes.
+const MEASURE_BYTES = [
+  "ubrn_uniffi_uniffi_strict_byte_arrays_fn_func_measure_bytes",
+  "uniffi_uniffi_strict_byte_arrays_fn_func_measure_bytes",
+].find((name) => typeof nm[name] === "function");
+
+// A library-owned view whose bytes are a valid serialized empty `Vec<u8>` (a
+// 4-byte length prefix of 0), so `measure_bytes` lifts it cleanly rather than
+// reading uninitialized memory as a length.
+function allocEmptyVecView(): Uint8Array {
+  const view = nm.rustbuffer_alloc(4);
+  view[0] = 0;
+  view[1] = 0;
+  view[2] = 0;
+  view[3] = 0;
+  return view;
+}
+
+// Call the raw scaffolding function with a pre-lowered view, so *this* view is
+// the one adopted (the generated wrapper would allocate and lower its own).
+function callMeasure(view: Uint8Array): number {
+  const status = { code: 0 };
+  const result = nm[MEASURE_BYTES!](view, status);
+  if (status.code !== 0) {
+    throw new Error(`measure_bytes failed with status code ${status.code}`);
+  }
+  return result;
+}
+
+test("the raw measure_bytes scaffolding function is reachable", (t) => {
+  t.assertNotNull(
+    MEASURE_BYTES,
+    "could not find measure_bytes on the native module",
+  );
+});
+
+test("adopted argument view: a later rustbuffer_free is a no-op, not a double free", (t) => {
+  const view = allocEmptyVecView();
+
+  // Passing the view adopts it: the callee frees the allocation and the hint is
+  // reset to 0.
+  t.assertEqual(callMeasure(view), 0);
+
+  // A defensive free of the now-adopted view must be a no-op. If the guard were
+  // missing this would free already-freed memory and abort the process; reaching
+  // the next line at all is the assertion.
+  nm.rustbuffer_free(view);
+  t.assertTrue(true, "rustbuffer_free on an adopted view did not crash");
+});
+
+test("adopted argument view: reusing it as an FFI argument is refused", (t) => {
+  const view = allocEmptyVecView();
+
+  // First use adopts the view and frees its backing allocation.
+  callMeasure(view);
+
+  // A second lowering must be refused rather than handing the callee a dangling
+  // pointer into freed memory.
+  t.assertThrows(
+    (e: any) => String(e?.message ?? e).includes("already consumed"),
+    () => callMeasure(view),
+  );
+});

--- a/fixtures/strict-byte-arrays/tests/bindings/test_leak.ts
+++ b/fixtures/strict-byte-arrays/tests/bindings/test_leak.ts
@@ -1,0 +1,59 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Proves whether lowering a `RustBuffer` argument leaks the library-owned
+// allocation.
+//
+// To run:
+//   cargo test -p uniffi-fixture-strict-byte-arrays -- jsi::test_leak
+//
+// `measureBytes` takes a byte array (lowered via `rustbuffer_alloc`) and returns
+// a scalar, so only the argument direction allocates a big buffer. The fixture's
+// counting allocator (see src/lib.rs) tracks live allocations >= 64 KiB, and we
+// assert the live count is unchanged across a loop of calls. If the runtime
+// copies the lowered view instead of adopting it, the allocation from
+// `rustbuffer_alloc` is orphaned — codegen never frees a lowered argument — and
+// the count climbs by exactly one per call.
+import {
+  measureBytes,
+  liveBigAllocCount,
+  liveBigAllocBytes,
+} from "@/generated/uniffi_strict_byte_arrays";
+import { test } from "@/asserts";
+import "@/polyfills";
+
+// 256 KiB is comfortably above the allocator's 64 KiB threshold, so a leak is
+// unmistakable and the assertion is exact equality rather than a threshold.
+const PAYLOAD = 256 * 1024;
+const ITERATIONS = 64;
+
+test("lowered RustBuffer argument is not leaked across FFI calls", (t) => {
+  // Warm up once so any one-time big allocations are already reflected in the
+  // `before` snapshot and don't count as a leak.
+  measureBytes(new Uint8Array(PAYLOAD));
+
+  const beforeCount = liveBigAllocCount();
+  const beforeBytes = Number(liveBigAllocBytes());
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const view = new Uint8Array(PAYLOAD);
+    const len = measureBytes(view);
+    t.assertEqual(len, PAYLOAD);
+  }
+
+  const afterCount = liveBigAllocCount();
+  const afterBytes = Number(liveBigAllocBytes());
+
+  t.assertEqual(
+    beforeCount,
+    afterCount,
+    `leaked ${afterCount - beforeCount} big buffers over ${ITERATIONS} calls`,
+  );
+  t.assertEqual(
+    beforeBytes,
+    afterBytes,
+    `leaked ${afterBytes - beforeBytes} bytes over ${ITERATIONS} calls`,
+  );
+});

--- a/fixtures/strict-byte-arrays/tests/test_bindings.rs
+++ b/fixtures/strict-byte-arrays/tests/test_bindings.rs
@@ -6,4 +6,10 @@
 ubrn_macros::build_foreign_language_testcases! {
     "tests/bindings/test_strict_byte_arrays.ts" => [Jsi, Wasm, Napi, Wasm2],
     "tests/bindings/test_rustbuffer_alloc.ts" => [Jsi],
+    "tests/bindings/test_leak.ts" => [Jsi, Wasm, Napi, Wasm2],
+    // [Jsi, Napi] only: wasm2 aliases the argument's linear memory rather than
+    // adopting a copy, and has no "already consumed" marker, so an explicit
+    // rustbuffer_free after the callee frees the aliased buffer double-frees.
+    // That defensive guard is a separate, tracked wasm2 follow-up.
+    "tests/bindings/test_double_free.ts" => [Jsi, Napi],
 }

--- a/runtimes/napi/fixtures/test_lib/src/lib.rs
+++ b/runtimes/napi/fixtures/test_lib/src/lib.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, Ordering};
 use std::sync::Mutex;
 
 #[repr(C)]
@@ -83,8 +83,23 @@ pub extern "C" fn uniffi_test_fn_i64_negate(x: i64, status: &mut RustCallStatus)
 
 // --- RustBuffer helpers ---
 
+/// Census of the `RustBuffer` allocations this fixture currently owns.
+///
+/// Every allocation goes through `alloc_rustbuffer` or `uniffi_test_rustbuffer_alloc`, and
+/// every release goes through `free_buffer`, so these counters are exact rather than
+/// approximate. Tests read them through `uniffi_test_live_buffer_count` /
+/// `uniffi_test_live_buffer_bytes` to assert buffer ownership directly.
+///
+/// This exists because RSS sampling cannot do the job: V8 moves its own heap reservation by
+/// megabytes, which swamps a few hundred leaked bytes per call and makes such a test both
+/// slow and flaky. A counter turns the same question into an exact equality.
+static LIVE_BUFFERS: AtomicI64 = AtomicI64::new(0);
+static LIVE_BUFFER_BYTES: AtomicI64 = AtomicI64::new(0);
+
 fn free_buffer(buf: RustBuffer) {
     if !buf.data.is_null() && buf.capacity > 0 {
+        LIVE_BUFFERS.fetch_sub(1, Ordering::Relaxed);
+        LIVE_BUFFER_BYTES.fetch_sub(buf.capacity as i64, Ordering::Relaxed);
         let layout = std::alloc::Layout::from_size_align(buf.capacity as usize, 1).unwrap();
         unsafe { std::alloc::dealloc(buf.data, layout) };
     }
@@ -105,6 +120,8 @@ fn alloc_rustbuffer(data: &[u8]) -> RustBuffer {
         ptr::copy_nonoverlapping(data.as_ptr(), ptr, len);
         ptr
     };
+    LIVE_BUFFERS.fetch_add(1, Ordering::Relaxed);
+    LIVE_BUFFER_BYTES.fetch_add(len as i64, Ordering::Relaxed);
     RustBuffer {
         capacity: len as u64,
         len: len as u64,
@@ -131,13 +148,36 @@ pub extern "C" fn uniffi_test_rustbuffer_alloc(
     status: &mut RustCallStatus,
 ) -> RustBuffer {
     status.code = 0;
+    if size == 0 {
+        return RustBuffer {
+            capacity: 0,
+            len: 0,
+            data: ptr::null_mut(),
+        };
+    }
     let layout = std::alloc::Layout::from_size_align(size as usize, 1).unwrap();
     let data = unsafe { std::alloc::alloc_zeroed(layout) };
+    LIVE_BUFFERS.fetch_add(1, Ordering::Relaxed);
+    LIVE_BUFFER_BYTES.fetch_add(size as i64, Ordering::Relaxed);
     RustBuffer {
         capacity: size,
         len: 0,
         data,
     }
+}
+
+/// Number of `RustBuffer` allocations the fixture currently owns. See [`LIVE_BUFFERS`].
+#[no_mangle]
+pub extern "C" fn uniffi_test_live_buffer_count(status: &mut RustCallStatus) -> i32 {
+    status.code = 0;
+    LIVE_BUFFERS.load(Ordering::Relaxed) as i32
+}
+
+/// Total bytes across the allocations the fixture currently owns. See [`LIVE_BUFFERS`].
+#[no_mangle]
+pub extern "C" fn uniffi_test_live_buffer_bytes(status: &mut RustCallStatus) -> i64 {
+    status.code = 0;
+    LIVE_BUFFER_BYTES.load(Ordering::Relaxed)
 }
 
 #[no_mangle]

--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -67,6 +67,7 @@ pub(crate) fn call_ffi_function(
                         env.raw(),
                         js_val,
                         module.rb_ops().from_bytes_ptr,
+                        Some(capacity_symbol),
                     )?
                 };
                 slot::write_rust_buffer(slot, rust_buffer);

--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -57,6 +57,11 @@ pub(crate) fn call_ffi_function(
 
     let mut call = module.prepare_call(fn_name).map_err(core_err)?;
 
+    // NOTE: arguments are lowered in order, and lowering a library-owned `RustBuffer` adopts its
+    // allocation (the callee frees it). If a *later* argument fails to lower we return early
+    // without invoking the callee, so any already-adopted buffer in this call is orphaned. This
+    // only happens on a misuse/error path — e.g. passing the same alloc'd view twice, which trips
+    // the "already consumed" guard — never on the happy path, which always reaches the call.
     for (i, desc) in arg_types.iter().enumerate() {
         let js_val: JsUnknown = ctx.get(i)?;
         let slot = call.arg_slot(i).map_err(core_err)?;

--- a/runtimes/napi/src/callback/marshal.rs
+++ b/runtimes/napi/src/callback/marshal.rs
@@ -142,8 +142,17 @@ fn marshal_field_to_bytes(
             slot::write_f64(slot, n.get_double()?);
         }
         FfiTypeDesc::RustBuffer => {
+            // No capacity symbol in scope on the callback path, so this keeps the copy
+            // behavior. Always memory-safe, but it means a `rustbuffer_alloc` view lowered
+            // as a callback argument is still orphaned. See the note in
+            // `js_uint8array_to_rust_buffer`.
             let rb = unsafe {
-                napi_utils::js_uint8array_to_rust_buffer(env.raw(), js_val, rb_from_bytes_ptr)?
+                napi_utils::js_uint8array_to_rust_buffer(
+                    env.raw(),
+                    js_val,
+                    rb_from_bytes_ptr,
+                    None,
+                )?
             };
             slot::write_rust_buffer(slot, rb);
         }
@@ -173,7 +182,12 @@ fn marshal_field_to_bytes(
             if has_error_buf && code != 0 {
                 let err_val: JsUnknown = status_obj.get_named_property("errorBuf")?;
                 let rb = unsafe {
-                    napi_utils::js_uint8array_to_rust_buffer(env.raw(), err_val, rb_from_bytes_ptr)?
+                    napi_utils::js_uint8array_to_rust_buffer(
+                        env.raw(),
+                        err_val,
+                        rb_from_bytes_ptr,
+                        None,
+                    )?
                 };
                 let u64_size = std::mem::size_of::<u64>();
                 let ptr_size = std::mem::size_of::<*mut u8>();
@@ -287,7 +301,12 @@ fn marshal_arg_to_bytes(
         FfiTypeDesc::RustBuffer => {
             let rb_from_bytes_ptr = module.rb_ops().from_bytes_ptr;
             let rb = unsafe {
-                napi_utils::js_uint8array_to_rust_buffer(env.raw(), js_val, rb_from_bytes_ptr)?
+                napi_utils::js_uint8array_to_rust_buffer(
+                    env.raw(),
+                    js_val,
+                    rb_from_bytes_ptr,
+                    None,
+                )?
             };
             // Transmute RustBufferC to its raw bytes.
             let rb_bytes: [u8; std::mem::size_of::<RustBufferC>()] =

--- a/runtimes/napi/src/callback/mod.rs
+++ b/runtimes/napi/src/callback/mod.rs
@@ -695,7 +695,8 @@ unsafe fn write_js_return_to_bytes(
             // Read Uint8Array -> rustbuffer_from_bytes -> write RustBufferC bytes.
             // Truncating copy: caller may pass a `ret_bytes` smaller than RustBufferC
             // when the return slot is a different shape; preserve historical behavior.
-            let rb = napi_utils::js_uint8array_to_rust_buffer(raw_env, js_val, rb_from_bytes_ptr)?;
+            let rb =
+                napi_utils::js_uint8array_to_rust_buffer(raw_env, js_val, rb_from_bytes_ptr, None)?;
             let rb_bytes = slot::rust_buffer_to_bytes(&rb);
             let copy_len = rb_bytes.len().min(ret_bytes.len());
             ret_bytes[..copy_len].copy_from_slice(&rb_bytes[..copy_len]);

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -32,12 +32,24 @@ use uniffi_runtime_core::ffi_c_types::{
 };
 
 /// A per-registration JS Symbol used as a hidden property key for stashing the
-/// underlying RustBuffer capacity on a lift-handoff `Uint8Array`. The view's
-/// `byteLength` is set to `len` so converters that decode the whole view
-/// (strings, raw byte arrays) see only the message bytes — but the global
-/// allocator needs `capacity` to free correctly when `capacity > len`. The
-/// symbol is created once when the module registers and lives as long as the
-/// JS-side module facade.
+/// underlying RustBuffer capacity on a `Uint8Array` that views library-owned memory.
+///
+/// Set on both kinds of library-owned view:
+///
+/// - **lift-handoff views** (a buffer Rust returned). The view's `byteLength` is `len` so
+///   converters that decode the whole view see only the message bytes, but the allocator
+///   needs `capacity` to free correctly when `capacity > len`.
+/// - **`rustbuffer_alloc` views**. Here `capacity == byteLength`, so the hint is redundant for
+///   freeing — but its *presence* is what marks the view as library-owned, which lets the
+///   argument-lowering path adopt the allocation instead of copying it.
+///
+/// Therefore the invariant is: **a hint is present if and only if the library owns the
+/// backing memory.** An ordinary V8-backed `Uint8Array` never carries one. A hint of `0`
+/// means the view was library-owned but has since been adopted by a callee, so the memory is
+/// gone and the view must not be used again.
+///
+/// The symbol is created once when the module registers and lives as long as the JS-side
+/// module facade.
 ///
 /// Mirrors wasm2's `CAPACITY_HINT` symbol in `runtimes/wasm/core/src/call.ts`.
 pub struct CapacitySymbol {
@@ -152,8 +164,9 @@ impl CapacitySymbol {
         Ok(())
     }
 
-    /// Read the capacity hint from `obj`. Returns `None` if no hint is set
-    /// (e.g., views from `rustbuffer_alloc(n)` where `byteLength == capacity`).
+    /// Read the capacity hint from `obj`. Returns `None` when no hint is set, which means
+    /// the memory is not the library's — an ordinary V8-backed `Uint8Array`. `Some(0)` means
+    /// a library-owned view whose allocation has already been adopted by a callee.
     ///
     /// # Safety
     ///
@@ -429,8 +442,26 @@ pub unsafe fn create_external_uint8array(
     Ok(typedarray)
 }
 
-/// Convert a JS `Uint8Array` to a [`RustBufferC`] by reading its data and calling
-/// [`rustbuffer_from_raw_bytes`].
+/// Convert a JS `Uint8Array` argument to a [`RustBufferC`] the callee can consume.
+///
+/// Two kinds of view arrive here, and they must be handled differently:
+///
+/// - **Library-owned views**, produced by `rustbuffer_alloc`. Codegen allocates one of these,
+///   fills it in place, and passes it straight through as the argument. It carries a capacity
+///   hint (see [`CapacitySymbol`]), and nothing else will ever free it: codegen frees returned
+///   buffers but never lowered arguments, and the view has a no-op finalizer. These are
+///   **adopted** — we hand the existing allocation to the callee, which frees it. Copying such
+///   a view instead would orphan the original and leak one whole payload per call.
+/// - **V8-owned arrays**, i.e. any ordinary `Uint8Array` from JS. These are not ours to give
+///   away, so they are **copied** into a fresh library allocation via `rustbuffer_from_bytes`.
+///
+/// The capacity hint is the discriminator: the runtime knows a buffer's capacity precisely
+/// when the library allocated it. On adoption the hint is reset to `0`, which makes any later
+/// `rustbuffer_free(view)` a no-op rather than a double free, since `free_rustbuffer` skips
+/// zero-capacity buffers.
+///
+/// Passing `None` for `capacity_symbol` forces the copy path. Call sites that have no symbol
+/// in scope use that, which is always memory-safe — it is the pre-adoption behavior.
 ///
 /// # Safety
 ///
@@ -441,10 +472,38 @@ pub unsafe fn js_uint8array_to_rust_buffer(
     raw_env: napi::sys::napi_env,
     js_val: JsUnknown,
     rb_from_bytes_ptr: *const c_void,
+    capacity_symbol: Option<&CapacitySymbol>,
 ) -> napi::Result<RustBufferC> {
-    let (data_ptr, length) = read_typedarray_data(raw_env, js_val.raw()).ok_or_else(|| {
+    let raw_val = js_val.raw();
+    let (data_ptr, length) = read_typedarray_data(raw_env, raw_val).ok_or_else(|| {
         napi::Error::from_reason("Expected a Uint8Array argument for RustBuffer".to_string())
     })?;
+
+    // An empty view owns no allocation, so there is nothing to adopt. `rustbuffer_alloc(0)`
+    // never sets a hint, and the copy path yields the correct empty `RustBufferC`.
+    if length == 0 {
+        return rustbuffer_from_raw_bytes(data_ptr, length, rb_from_bytes_ptr);
+    }
+
+    if let Some(symbol) = capacity_symbol {
+        if let Some(capacity) = symbol.get(raw_env, raw_val) {
+            if capacity == 0 {
+                // The hint exists but has been zeroed, so this view was already adopted and
+                // its memory has since been freed by the callee. Reading it would be a
+                // use-after-free, so refuse rather than hand the callee a dangling pointer.
+                return Err(napi::Error::from_reason(
+                    "RustBuffer argument was already consumed by a previous FFI call".to_string(),
+                ));
+            }
+            symbol.set(raw_env, raw_val, 0)?;
+            return Ok(RustBufferC {
+                capacity,
+                len: length as u64,
+                data: data_ptr as *mut u8,
+            });
+        }
+    }
+
     rustbuffer_from_raw_bytes(data_ptr, length, rb_from_bytes_ptr)
 }
 

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -110,6 +110,12 @@ pub fn register(
         // SAFETY: rb.data points to a valid allocation of `len` bytes that the Rust
         // library owns; the view is released either by `rustbuffer_free(view)` or by being
         // adopted when passed as an FFI argument, so no finalizer is required.
+        //
+        // CONTRACT: adoption frees the backing allocation but cannot detach this view, so the
+        // `Uint8Array` is left dangling over freed memory. A view must be treated as consumed
+        // once it has been passed as an FFI argument: reading it afterwards is a use-after-free,
+        // and passing it a second time fails with an "already consumed" error. Generated lowering
+        // code drops the view immediately, so this only bites hand-written callers.
         let typedarray =
             unsafe { napi_utils::create_external_uint8array(ctx.env.raw(), rb.data, len)? };
         // Stamp the capacity so the runtime can recognise this view as library-owned. Two

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -90,6 +90,7 @@ pub fn register(
     // library's `rustbuffer_free`. Together they let JS allocate buffers that the
     // codegen-emitted lowering path can fill in place and ship to Rust without copying.
     let alloc_module = Arc::clone(&module);
+    let cap_sym_for_alloc = Arc::clone(&capacity_symbol);
     let alloc_fn = env.create_function_from_closure("rustbuffer_alloc", move |ctx| {
         let size_arg: i32 = ctx.get(0)?;
         if size_arg < 0 {
@@ -107,10 +108,17 @@ pub fn register(
             napi::Error::from_reason("RustBuffer capacity exceeds addressable memory".to_string())
         })?;
         // SAFETY: rb.data points to a valid allocation of `len` bytes that the Rust
-        // library owns; codegen will hand the view back via `rustbuffer_free` before
-        // shipping the (ptr, len, cap) tuple to FFI, so no finalizer is required.
+        // library owns; the view is released either by `rustbuffer_free(view)` or by being
+        // adopted when passed as an FFI argument, so no finalizer is required.
         let typedarray =
             unsafe { napi_utils::create_external_uint8array(ctx.env.raw(), rb.data, len)? };
+        // Stamp the capacity so the runtime can recognise this view as library-owned. Two
+        // consumers rely on it: `rustbuffer_free` frees against the true capacity, and the
+        // argument-lowering path adopts the allocation instead of copying it. Without the
+        // stamp, a lowered argument gets copied and this allocation is orphaned.
+        if rb.capacity > 0 {
+            unsafe { cap_sym_for_alloc.set(ctx.env.raw(), typedarray, rb.capacity)? };
+        }
         unsafe { JsUnknown::from_raw(ctx.env.raw(), typedarray) }
     })?;
     result.set_named_property("rustbuffer_alloc", alloc_fn)?;
@@ -137,15 +145,15 @@ pub fn register(
         if length == 0 {
             return ctx.env.get_undefined().map(|u| u.into_unknown());
         }
-        // Capacity recovery. Two view origins to handle:
-        //   (a) `rustbuffer_alloc(n)` views: capacity == byteLength == n, no
-        //       hint set. Use byteLength.
-        //   (b) Lift-handoff views: byteLength == rb.len, capacity may be
-        //       larger and was stashed on the view at handoff time. Read
-        //       the stashed value via `CapacitySymbol::get`. When
-        //       `capacity == len` at handoff time we skip the property write,
-        //       so absence of a hint here is also a valid "use byteLength"
-        //       signal.
+        // Capacity recovery. Three cases, all keyed off the hint:
+        //   (a) `rustbuffer_alloc(n)` views: hint == byteLength == n.
+        //   (b) Lift-handoff views: byteLength == rb.len, and the hint carries the true
+        //       capacity, which may be larger. Set at handoff time when capacity != len.
+        //   (c) Hint == 0: the view was already adopted as an FFI argument, so the callee
+        //       has freed the memory. `free_rustbuffer` skips zero-capacity buffers, which
+        //       turns this into the no-op it must be rather than a double free.
+        // No hint at all means the memory is not the library's to free; fall back to
+        // byteLength to preserve the historical behaviour for such views.
         // SAFETY: raw_env / raw_val are valid for the current callback scope.
         let capacity = unsafe { cap_sym_for_free.get(raw_env, raw_val) }.unwrap_or(length as u64);
         let rb = RustBufferC {

--- a/runtimes/napi/tests/rust_buffer_ownership.test.mjs
+++ b/runtimes/napi/tests/rust_buffer_ownership.test.mjs
@@ -1,0 +1,213 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Ownership accounting for RustBuffers crossing the FFI boundary.
+//
+// These tests assert that every allocation the library makes is eventually released. They
+// read the fixture's exact live-allocation counters rather than sampling RSS: V8 moves its
+// own heap reservation by megabytes, which would swamp a few hundred leaked bytes per call
+// and make the test both slow and flaky.
+//
+// The regression they guard is a leak in the *argument* lowering path. Codegen lowers a
+// RustBuffer argument by calling `rustbuffer_alloc(n)`, filling the returned view in place,
+// and passing that view as the argument. If the runtime converts that view by copying it into
+// a second buffer, the first one is orphaned: codegen never frees a lowered argument, and the
+// view carries a no-op finalizer. One whole payload then leaks per call.
+import { test } from "node:test";
+import assert from "node:assert";
+import lib from "../lib.js";
+const { UniffiNativeModule, FfiType } = lib;
+import { libPath } from "./helpers/lib-path.mjs";
+
+const LIB_PATH = libPath("uniffi_napi_test_lib");
+
+const SYMBOLS = {
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+};
+
+const FUNCTIONS = {
+  uniffi_test_fn_echo_buffer: {
+    args: [FfiType.RustBuffer],
+    ret: FfiType.RustBuffer,
+    hasRustCallStatus: true,
+  },
+  uniffi_test_fn_buffer_len: {
+    args: [FfiType.RustBuffer],
+    ret: FfiType.UInt32,
+    hasRustCallStatus: true,
+  },
+  uniffi_test_fn_concat_buffers: {
+    args: [FfiType.RustBuffer, FfiType.RustBuffer],
+    ret: FfiType.RustBuffer,
+    hasRustCallStatus: true,
+  },
+  uniffi_test_live_buffer_count: {
+    args: [],
+    ret: FfiType.Int32,
+    hasRustCallStatus: true,
+  },
+  uniffi_test_live_buffer_bytes: {
+    args: [],
+    ret: FfiType.Int64,
+    hasRustCallStatus: true,
+  },
+};
+
+function openModule() {
+  const nm = UniffiNativeModule.open(LIB_PATH).register({
+    symbols: SYMBOLS,
+    structs: {},
+    callbacks: {},
+    functions: FUNCTIONS,
+  });
+  const live = () => ({
+    count: nm.uniffi_test_live_buffer_count({ code: 0 }),
+    bytes: Number(nm.uniffi_test_live_buffer_bytes({ code: 0 })),
+  });
+  return { nm, live };
+}
+
+// Sized so a leak is unmistakable: 64 iterations x 1024 bytes is 64 KB, and the assertion is
+// an exact equality rather than a threshold.
+const ITERATIONS = 64;
+const PAYLOAD_SIZE = 1024;
+
+test("lowered argument buffer is released (rustbuffer_alloc view as argument)", () => {
+  const { nm, live } = openModule();
+  const before = live();
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    // Exactly what codegen does: allocate through the library, fill in place, pass the view.
+    const view = nm.rustbuffer_alloc(PAYLOAD_SIZE);
+    view.fill(i & 0xff);
+    const status = { code: 0 };
+    const result = nm.uniffi_test_fn_echo_buffer(view, status);
+    assert.strictEqual(status.code, 0);
+    assert.strictEqual(result.byteLength, PAYLOAD_SIZE);
+    // Codegen's `finally` frees the returned buffer. It never frees the argument.
+    nm.rustbuffer_free(result);
+  }
+
+  const after = live();
+  assert.strictEqual(
+    after.count,
+    before.count,
+    `leaked ${after.count - before.count} buffers over ${ITERATIONS} calls`,
+  );
+  assert.strictEqual(
+    after.bytes,
+    before.bytes,
+    `leaked ${after.bytes - before.bytes} bytes over ${ITERATIONS} calls`,
+  );
+});
+
+test("lowered argument buffer is released for a void-returning call", () => {
+  // Isolates the argument direction: nothing comes back, so any growth must be the argument.
+  const { nm, live } = openModule();
+  const before = live();
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const view = nm.rustbuffer_alloc(PAYLOAD_SIZE);
+    const status = { code: 0 };
+    const len = nm.uniffi_test_fn_buffer_len(view, status);
+    assert.strictEqual(status.code, 0);
+    // `rustbuffer_alloc` reports len 0; the library sees the capacity as the length.
+    assert.strictEqual(typeof len, "number");
+  }
+
+  const after = live();
+  assert.strictEqual(after.count, before.count);
+  assert.strictEqual(after.bytes, before.bytes);
+});
+
+test("both lowered argument buffers are released for a two-argument call", () => {
+  const { nm, live } = openModule();
+  const before = live();
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const a = nm.rustbuffer_alloc(PAYLOAD_SIZE);
+    const b = nm.rustbuffer_alloc(PAYLOAD_SIZE);
+    const status = { code: 0 };
+    const result = nm.uniffi_test_fn_concat_buffers(a, b, status);
+    assert.strictEqual(status.code, 0);
+    nm.rustbuffer_free(result);
+  }
+
+  const after = live();
+  assert.strictEqual(after.count, before.count);
+  assert.strictEqual(after.bytes, before.bytes);
+});
+
+test("plain JS Uint8Array argument is copied, not adopted", () => {
+  // A V8-owned array is not the library's to take. The runtime must copy it, and the copy
+  // must be released. Adopting it would hand the library a pointer into the V8 heap.
+  const { nm, live } = openModule();
+  const before = live();
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const input = new Uint8Array(PAYLOAD_SIZE);
+    input.fill(i & 0xff);
+    const status = { code: 0 };
+    const result = nm.uniffi_test_fn_echo_buffer(input, status);
+    assert.strictEqual(status.code, 0);
+    // The echo must still be correct, which it would not be if the bytes were not copied.
+    assert.strictEqual(result[0], i & 0xff);
+    assert.strictEqual(result[PAYLOAD_SIZE - 1], i & 0xff);
+    nm.rustbuffer_free(result);
+  }
+
+  const after = live();
+  assert.strictEqual(after.count, before.count);
+  assert.strictEqual(after.bytes, before.bytes);
+});
+
+test("alloc/free round-trip without an FFI call is balanced", () => {
+  const { nm, live } = openModule();
+  const before = live();
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const view = nm.rustbuffer_alloc(PAYLOAD_SIZE);
+    nm.rustbuffer_free(view);
+  }
+
+  const after = live();
+  assert.strictEqual(after.count, before.count);
+  assert.strictEqual(after.bytes, before.bytes);
+});
+
+test("freeing an already-adopted argument view does not double free", () => {
+  // Defensive: codegen does not free lowered arguments today, but a caller that does must not
+  // corrupt the heap. Once the library has adopted the view, the second release is a no-op.
+  const { nm, live } = openModule();
+  const before = live();
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const view = nm.rustbuffer_alloc(PAYLOAD_SIZE);
+    const status = { code: 0 };
+    const result = nm.uniffi_test_fn_echo_buffer(view, status);
+    assert.strictEqual(status.code, 0);
+    nm.rustbuffer_free(view);
+    nm.rustbuffer_free(result);
+  }
+
+  const after = live();
+  assert.strictEqual(after.count, before.count);
+  assert.strictEqual(after.bytes, before.bytes);
+});
+
+test("empty rustbuffer_alloc view is accounted for", () => {
+  const { nm, live } = openModule();
+  const before = live();
+
+  const view = nm.rustbuffer_alloc(0);
+  assert.strictEqual(view.byteLength, 0);
+  nm.rustbuffer_free(view);
+
+  const after = live();
+  assert.strictEqual(after.count, before.count);
+  assert.strictEqual(after.bytes, before.bytes);
+});

--- a/runtimes/napi/tests/rust_buffer_ownership.test.mjs
+++ b/runtimes/napi/tests/rust_buffer_ownership.test.mjs
@@ -105,8 +105,9 @@ test("lowered argument buffer is released (rustbuffer_alloc view as argument)", 
   );
 });
 
-test("lowered argument buffer is released for a void-returning call", () => {
-  // Isolates the argument direction: nothing comes back, so any growth must be the argument.
+test("lowered argument buffer is released for a scalar-returning call", () => {
+  // Isolates the argument direction: the return is a scalar, not a buffer, so any growth in
+  // live allocations must come from the argument.
   const { nm, live } = openModule();
   const before = live();
 


### PR DESCRIPTION
### Problem

After some benchmarking, I have determined that the NAPI player runtime leaks memory for each FFI call that has a `RustBuffer` argument.

My use case: a 48 kHz audio plugin sends one 1924-byte buffer for each 10 ms frame. The plugin therefore leaks approximately 2.4 KB for each frame, which equals approximately 14.7 MB for each minute of audio - fairly signifigant.

### Cause

The runtime allocates each argument buffer two times. The runtime releases only one of the two buffers.

The generated code lowers a `RustBuffer` argument in three steps:

1. The generated code calls `rustbuffer_alloc(n)`. The library allocates buffer A, and the runtime gives JavaScript an external `Uint8Array` view of buffer A.
2. The generated code writes the value into buffer A.
3. The generated code sends the view as the argument.

The argument then goes to `js_uint8array_to_rust_buffer`. That function called `rustbuffer_from_bytes`, which allocated buffer B and copied buffer A into buffer B. The callee then released buffer B.

No code released buffer A. The generated code releases returned buffers, but it does not release lowered arguments. Also, the view has a no-op finalizer, therefore buffer A stayed in memory until the process stopped.

The `rustbuffer_alloc` and `rustbuffer_free` pair exists to prevent return direction already used the pair correctly. Only the argument direction did not.

### Solution

> [!WARNING]
> I'm not fully confident in this solution, and I used a fair bit of LLM help to get to it. In particular, using `capacity` as a hint like this to me seems like it could be quite fragile, but I also am not sure where this metadata would live otherwise other than adding a whole new level of abstraction around `RustBuffer`. Definitely open to suggestions and alternate approaches! 

The runtime now adopts library-owned buffers - The callee receives the existing allocation, and the runtime does not copy the buffer.

Two kinds of view come to this function. The runtime must treat them differently:

- Library-owned views come from rustbuffer_alloc. The runtime adopts these views.
- V8-owned views are ordinary `Uint8Array` objects from JavaScript. The runtime must copy these views and must not give V8 memory to the library.

The capacity hint symbol is the marker. The runtime knows a buffer's capacity only when the library allocated the buffer. Therefore, a capacity hint is present if and only if the library owns the memory.

To keep this invariant, `rustbuffer_alloc` now stamps the capacity on each view that it returns.

After adoption, the runtime sets the hint to 0. This prevents a double release. The `free_rustbuffer` function ignores buffers that have a capacity of 0. Therefore a later `rustbuffer_free(view)` call does nothing.

If a caller sends an adopted view a second time, the runtime returns an error, as the callee has already released it.

### Test

The new tests count the live allocations in the fixture. They do not sample RSS. V8 can change its own heap reservation by several megabytes, which hides a leak of a few hundred bytes for each call. A counter is used to give an exact equality instead.

List of test cases:

1. A lowered argument buffer is released.
2. A lowered argument buffer is released for a call that return
3. Both argument buffers are released for a call that has 2 arguments.
4. A plain JavaScript Uint8Array is copied and not adopted.
5. An alloc and free pair is balanced.
6. A release of an adopted view does not cause a double release
7. An empty view is correct.

Before the fix, tests 1, 2, and 3 failed. Test 1 reported leaked 64 buffers over 64 calls. This is one buffer for each call.

After the fix, all 7 tests pass.

### Limits of this change

Two items remain. Neither is a new problem, and neither is a result of this change.

1. The callback paths still copy. No capacity symbol is available in those paths. To adopt buffers there, a person must send the symbol through the callback user data and the vtable marshalling code. The copy is always safe, but a rustbuffer_alloc view that a callback lowers is still orphaned.
2. A second, independent leak remains. Each external `Uint8Array` view leaks approximately 193 bytes. This quantity does not change with the buffer size. The alloc/free test measures 194.6 bytes for each cycle both before and after this change. The cause is in `create_external_uint8array`, and not in buffer ownership. This item needs a separate investigation.