### PR TITLE
fix(napi): answer is_js_thread per callback, not per process

### DIFF
--- a/runtimes/napi/src/callback/mod.rs
+++ b/runtimes/napi/src/callback/mod.rs
@@ -74,6 +74,9 @@ struct RustCallStatusForVTable {
 /// invocation and passes it through to `on_js_thread`, `dispatch_to_js_thread`,
 /// and `is_js_thread`.
 struct CallbackUserData {
+    /// State of the environment this callback belongs to, held here so an invocation can check for
+    /// shutdown without taking a lock.
+    env_state: Arc<crate::EnvState>,
     /// Raw napi environment handle. Only valid on the main thread.
     raw_env: napi::sys::napi_env,
     /// GC-preventing reference to the JS callback function. Only valid on the main thread.
@@ -148,7 +151,7 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
     // SAFETY: `user_data` was created via `Box::into_raw` and leaked.
     let ud = unsafe { &*(user_data as *const CallbackUserData) };
 
-    if crate::is_shutting_down() {
+    if ud.env_state.is_shutting_down() {
         // Zero out the return buffer so the caller gets a deterministic value.
         if !ret.is_null() {
             let ret_size = ud.ret_size;
@@ -347,7 +350,7 @@ pub extern "C" fn dispatch_to_js_thread(
     // SAFETY: `user_data` was created via `Box::into_raw` and leaked.
     let ud = unsafe { &*(user_data as *const CallbackUserData) };
 
-    if crate::is_shutting_down() {
+    if ud.env_state.is_shutting_down() {
         return;
     }
 
@@ -472,6 +475,7 @@ pub fn create_callback_user_data(
 
     // Allocate the userdata and leak it to a stable address.
     let userdata = Box::new(CallbackUserData {
+        env_state: crate::env_state(env.raw()),
         raw_env: env.raw(),
         fn_ref,
         arg_layout,
@@ -512,7 +516,8 @@ pub fn create_callback_user_data(
     let mut tsfn = tsfn;
 
     // Register the raw TSFN handle so the env cleanup hook can abort it at shutdown.
-    crate::register_tsfn(tsfn.raw());
+    // SAFETY: `userdata_ptr` is valid and uniquely owned here.
+    unsafe { (*userdata_ptr).env_state.register_tsfn(tsfn.raw()) };
 
     // Unref the TSFN so it does not prevent the Node.js event loop from exiting.
     tsfn.unref(env)?;

--- a/runtimes/napi/src/callback/mod.rs
+++ b/runtimes/napi/src/callback/mod.rs
@@ -13,7 +13,8 @@
 //! - [`dispatch_to_js_thread`]: runs off the JS thread, copies the arg buffer,
 //!   sends it to the JS thread via a ThreadsafeFunction, and blocks on a
 //!   sync_channel for the return value.
-//! - [`is_js_thread`]: returns whether the current thread is the JS main thread.
+//! - [`is_js_thread`]: returns whether the current thread is the one that registered the
+//!   callback, and so may touch its napi values directly.
 //!
 //! Each callback closure is associated with a [`CallbackUserData`] struct that is
 //! leaked to a stable address and passed as `user_data: *const c_void` through the
@@ -37,6 +38,7 @@
 use std::ffi::c_void;
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::{Arc, Mutex};
+use std::thread::ThreadId;
 
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, NapiRaw, NapiValue};
@@ -74,12 +76,15 @@ struct RustCallStatusForVTable {
 /// invocation and passes it through to `on_js_thread`, `dispatch_to_js_thread`,
 /// and `is_js_thread`.
 struct CallbackUserData {
+    /// The JS thread this callback was registered on: the only thread whose napi values
+    /// (`raw_env`, `fn_ref`) may be touched directly, and the one `tsfn` dispatches to.
+    owner_thread: ThreadId,
     /// State of the environment this callback belongs to, held here so an invocation can check for
     /// shutdown without taking a lock.
     env_state: Arc<crate::EnvState>,
-    /// Raw napi environment handle. Only valid on the main thread.
+    /// Raw napi environment handle. Only valid on `owner_thread`.
     raw_env: napi::sys::napi_env,
-    /// GC-preventing reference to the JS callback function. Only valid on the main thread.
+    /// GC-preventing reference to the JS callback function. Only valid on `owner_thread`.
     fn_ref: napi::sys::napi_ref,
     /// Precomputed layout for the arg byte buffer produced by core's trampoline.
     arg_layout: ArgLayout,
@@ -94,15 +99,15 @@ struct CallbackUserData {
     out_return: bool,
     /// Precomputed size of the return value in bytes (0 for void or out_return).
     ret_size: usize,
-    /// Thread-safe function for dispatching to the main thread.
+    /// Thread-safe function for dispatching to `owner_thread`.
     tsfn: Mutex<Option<ThreadsafeFunction<DispatchPayload, ErrorStrategy::Fatal>>>,
     /// Reference to the Module, needed for fn_pointer wrapping (Callback-typed args).
     module: Arc<Module>,
 }
 
 // SAFETY: `CallbackUserData` is shared across threads. This is sound because:
-// - `raw_env` and `fn_ref` are only dereferenced on the main thread (the
-//   same-thread path checks `is_main_thread()` before touching them).
+// - `raw_env` and `fn_ref` are only dereferenced on `owner_thread` (the
+//   same-thread path checks `is_js_thread()` before touching them).
 // - `tsfn` is designed for cross-thread use and protected by a Mutex.
 // - `arg_types`, `ret_type`, `arg_layout`, `ret_size` are immutable after construction.
 // - `module` is an `Arc<Module>` which is Send+Sync.
@@ -140,7 +145,7 @@ unsafe impl Send for DispatchPayload {}
 ///
 /// # Safety
 ///
-/// - Must be called on the main Node.js thread.
+/// - Must be called on the JS thread that registered this callback.
 /// - `args` must point to a valid byte buffer laid out according to the
 ///   `CallbackUserData::arg_layout`.
 /// - `ret` must point to a buffer of at least `ret_size` bytes (as computed by
@@ -162,7 +167,7 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
         return;
     }
 
-    // SAFETY: We are on the main thread, so raw_env is valid.
+    // SAFETY: We are on the owning thread, so raw_env is valid.
     let env = unsafe { Env::from_raw(ud.raw_env) };
 
     // Resolve the JS function from the persistent reference.
@@ -338,7 +343,8 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
 ///
 /// # Safety
 ///
-/// - Must NOT be called on the main thread (the blocking recv would deadlock).
+/// - Must NOT be called on `owner_thread`: that thread is the only one that can drain its own
+///   event loop to produce the reply, so the blocking recv would deadlock.
 /// - `on_js_thread_fn` must be a valid function pointer.
 /// - `args`, `ret`, and `user_data` follow the same contracts as `on_js_thread`.
 pub extern "C" fn dispatch_to_js_thread(
@@ -407,14 +413,20 @@ pub extern "C" fn dispatch_to_js_thread(
     }
 }
 
-/// Returns whether the current thread is the main JS thread.
+/// Returns whether the current thread is the JS thread that registered this callback.
+///
+/// Per callback, not per process. Each JS thread (a Node worker, say) owns napi values only for
+/// itself, so a single process-wide answer is wrong for every thread but one: it sends a JS thread
+/// down the cross-thread path, where it blocks on a reply only it could have produced.
 ///
 /// # Safety
 ///
-/// `user_data` is unused by this implementation (the check is global), but must
-/// be a valid pointer per the core trampoline protocol.
-pub extern "C" fn is_js_thread(_user_data: *const c_void) -> bool {
-    crate::is_main_thread()
+/// `user_data` must be a valid `*const CallbackUserData` obtained from `Box::into_raw`, per the
+/// core trampoline protocol.
+pub extern "C" fn is_js_thread(user_data: *const c_void) -> bool {
+    // SAFETY: `user_data` was created via `Box::into_raw` and leaked.
+    let ud = unsafe { &*(user_data as *const CallbackUserData) };
+    ud.owner_thread == std::thread::current().id()
 }
 
 // ---------------------------------------------------------------------------
@@ -475,6 +487,7 @@ pub fn create_callback_user_data(
 
     // Allocate the userdata and leak it to a stable address.
     let userdata = Box::new(CallbackUserData {
+        owner_thread: std::thread::current().id(),
         env_state: crate::env_state(env.raw()),
         raw_env: env.raw(),
         fn_ref,
@@ -523,8 +536,8 @@ pub fn create_callback_user_data(
     tsfn.unref(env)?;
 
     // Store the TSFN in the userdata.
-    // SAFETY: `userdata_ptr` is valid and uniquely owned. We are still on the main
-    // thread; no concurrent access is possible yet.
+    // SAFETY: `userdata_ptr` is valid and uniquely owned. We are still on the
+    // registering thread; no concurrent access is possible yet.
     unsafe {
         let tsfn_slot = &mut (*userdata_ptr).tsfn;
         *tsfn_slot.get_mut().expect("mutex not poisoned") = Some(tsfn);

--- a/runtimes/napi/src/lib.rs
+++ b/runtimes/napi/src/lib.rs
@@ -43,8 +43,9 @@
 //! initialization time, and [`is_main_thread`] is the single predicate that every
 //! callback path consults to choose between these two strategies.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
 use std::thread::ThreadId;
 
 use napi::bindgen_prelude::*;
@@ -70,91 +71,178 @@ pub(crate) fn core_err(e: uniffi_runtime_core::Error) -> napi::Error {
 /// values directly or must dispatch through a threadsafe function.
 static MAIN_THREAD_ID: OnceLock<ThreadId> = OnceLock::new();
 
-/// Global module state for coordinating shutdown and tracking VTable TSFNs.
+/// Per-environment state for coordinating shutdown and tracking VTable TSFNs.
 ///
-/// During env cleanup (triggered when Node.js is shutting down), the cleanup hook
-/// sets `shutdown` to `true` and aborts all tracked TSFNs. Aborting drops pending
-/// calls and their `SyncSender`s, which unblocks any Rust worker threads that are
-/// waiting on `rx.recv()`. This prevents SIGSEGV crashes on Linux where the shared
-/// library would otherwise be `dlclose()`'d while Rust threads still hold function
-/// pointers into it.
-struct ModuleState {
-    /// Set to `true` when the env cleanup hook fires.
+/// During env cleanup (triggered when that environment is torn down, which for a worker happens
+/// long before the process exits), the hook sets `shutdown` to `true` and aborts that
+/// environment's TSFNs. Aborting drops pending calls and their `SyncSender`s, which unblocks any
+/// Rust worker threads that are waiting on `rx.recv()`. This prevents SIGSEGV crashes on Linux
+/// where the shared library would otherwise be `dlclose()`'d while Rust threads still hold
+/// function pointers into it.
+///
+/// Per environment rather than per process: a TSFN is bound to the event loop of the environment
+/// that created it, so one environment's teardown must neither abort another's handles nor mark
+/// another's callbacks as shutting down.
+pub struct EnvState {
+    /// A hint, read on every callback invocation so the hot path takes no lock. The list below is
+    /// the authority: a registration racing teardown is refused by `register_tsfn`, not by this.
     shutdown: AtomicBool,
-    /// Raw handles of VTable TSFNs, so the cleanup hook can abort them all.
-    tsfn_handles: Mutex<Vec<napi::sys::napi_threadsafe_function>>,
+    /// This environment's VTable TSFN handles while it lives, and `None` once it is torn down.
+    ///
+    /// One `Option` rather than a separate flag and list, because registering and sweeping have to
+    /// be the same decision under the same lock. As two pieces of state, a handle could be pushed
+    /// after the sweep had already passed it, leaving it bound to an event loop that no longer
+    /// exists with nothing left to abort it.
+    tsfns: Mutex<Option<Vec<TsfnHandle>>>,
 }
 
-// SAFETY: `napi_threadsafe_function` (a raw pointer) is designed to be used
-// across threads—napi's threadsafe function APIs are explicitly thread-safe.
-// The `Mutex` synchronizes access to the `Vec`.
-unsafe impl Send for ModuleState {}
-unsafe impl Sync for ModuleState {}
-
-static MODULE_STATE: OnceLock<ModuleState> = OnceLock::new();
-
-/// Returns `true` if the Node.js environment is shutting down.
+/// A `napi_threadsafe_function`, as a value that may cross threads.
 ///
-/// Callback trampolines check this before attempting any work, so they can
-/// bail out early rather than touching a half-torn-down JS environment.
-pub fn is_shutting_down() -> bool {
-    MODULE_STATE
-        .get()
-        .is_some_and(|s| s.shutdown.load(Ordering::Acquire))
-}
+/// The newtype exists for the two impls below. They are the only `unsafe` this needs, and putting
+/// them here rather than on [`EnvState`] keeps them off the fields that never wanted them.
+#[derive(Clone, Copy)]
+struct TsfnHandle(napi::sys::napi_threadsafe_function);
 
-/// Register a VTable TSFN raw handle so the env cleanup hook can abort it.
-pub fn register_tsfn(raw: napi::sys::napi_threadsafe_function) {
-    if let Some(state) = MODULE_STATE.get() {
-        state
-            .tsfn_handles
-            .lock()
-            .expect("tsfn_handles lock poisoned")
-            .push(raw);
+// SAFETY: napi's threadsafe function APIs are explicitly callable from any thread, which is the
+// whole purpose of the type. This is an opaque handle that is never dereferenced here, only handed
+// back to `napi_release_threadsafe_function`.
+unsafe impl Send for TsfnHandle {}
+unsafe impl Sync for TsfnHandle {}
+
+impl EnvState {
+    fn new() -> Self {
+        Self {
+            shutdown: AtomicBool::new(false),
+            tsfns: Mutex::new(Some(Vec::new())),
+        }
     }
-}
 
-/// Env cleanup hook called by Node.js during shutdown.
-///
-/// # Safety
-/// Called by the napi runtime with the `data` pointer we registered (null in our case).
-unsafe extern "C" fn env_cleanup_hook(_data: *mut std::ffi::c_void) {
-    if let Some(state) = MODULE_STATE.get() {
-        // Signal all trampoline code to stop processing.
-        state.shutdown.store(true, Ordering::Release);
+    /// Returns `true` if the owning Node.js environment is shutting down.
+    ///
+    /// Callback trampolines check this before attempting any work, so they can
+    /// bail out early rather than touching a half-torn-down JS environment.
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutdown.load(Ordering::Acquire)
+    }
 
-        // Abort every tracked VTable TSFN. This drops any pending calls
-        // (and their SyncSenders), which unblocks Rust worker threads
-        // waiting on `rx.recv()`.
-        let handles = state
-            .tsfn_handles
-            .lock()
-            .expect("tsfn_handles lock poisoned");
-        for &handle in handles.iter() {
+    /// Register a VTable TSFN raw handle so this environment's cleanup hook can abort it.
+    ///
+    /// A handle arriving after the environment has been torn down is aborted here instead: its
+    /// sweep has already passed, so nothing else ever would. Callers get one rule rather than a
+    /// result to remember, and the decision stays with the state that knows the answer.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a live threadsafe function this environment owns, and ownership of it passes
+    /// here: the caller must not release it, because this either stores it for the teardown sweep
+    /// or aborts it on the spot.
+    pub unsafe fn register_tsfn(&self, raw: napi::sys::napi_threadsafe_function) {
+        let orphaned = match &mut *self.tsfns() {
+            Some(live) => {
+                live.push(TsfnHandle(raw));
+                false
+            }
+            None => true,
+        };
+        // Outside the guard, for the reason `close` gives: aborting is a call into napi that
+        // unblocks other threads, and it has no business happening under this lock.
+        if orphaned {
+            // SAFETY: an opaque handle the caller just created and never dereferences. `abort`
+            // drops pending calls, which is what releases anything already waiting on it.
             unsafe {
                 napi::sys::napi_release_threadsafe_function(
-                    handle,
+                    raw,
                     napi::sys::ThreadsafeFunctionReleaseMode::abort,
                 );
             }
         }
     }
+
+    /// Close this environment to new handles and take the ones it holds.
+    ///
+    /// The guard is released with the returned value, so the caller aborts without holding the
+    /// lock. That matters: aborting unblocks Rust worker threads, and one of those may re-enter
+    /// through a callback before the sweep has finished.
+    fn close(&self) -> Vec<TsfnHandle> {
+        self.shutdown.store(true, Ordering::Release);
+        self.tsfns().take().unwrap_or_default()
+    }
+
+    /// A poisoned lock means a panic while the list was held. It guards a list of opaque handles
+    /// with no cross-field invariant a panic could break, and a panic raised from here would cross
+    /// the napi boundary as an abort, so recovering beats taking the host process down.
+    fn tsfns(&self) -> MutexGuard<'_, Option<Vec<TsfnHandle>>> {
+        self.tsfns.lock().unwrap_or_else(PoisonError::into_inner)
+    }
 }
 
-/// Install the env cleanup hook (idempotent—only the first call has effect).
-fn install_env_cleanup_hook(env: &Env) {
-    static INSTALLED: AtomicBool = AtomicBool::new(false);
-    if INSTALLED
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_ok()
-    {
+/// Every environment that has registered a module, keyed by its raw `napi_env`.
+///
+/// Touched when a callback is created and when an environment is torn down, both cold paths. A
+/// callback invocation reads its own `Arc<EnvState>` out of its user data, so the hot path takes
+/// no lock.
+static ENV_STATES: OnceLock<Mutex<HashMap<usize, Arc<EnvState>>>> = OnceLock::new();
+
+/// Recovered rather than propagated, for the reason [`EnvState::tsfns`] gives: a panic raised from
+/// here would cross the napi boundary as an abort.
+fn env_states() -> MutexGuard<'static, HashMap<usize, Arc<EnvState>>> {
+    ENV_STATES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+/// The state for `raw_env`, created on first use.
+pub fn env_state(raw_env: napi::sys::napi_env) -> Arc<EnvState> {
+    Arc::clone(
+        env_states()
+            .entry(raw_env as usize)
+            .or_insert_with(|| Arc::new(EnvState::new())),
+    )
+}
+
+/// Env cleanup hook, called by Node.js when an environment is torn down.
+///
+/// # Safety
+/// Called by the napi runtime with the `data` pointer we registered, which is the raw `napi_env`
+/// this hook was installed for.
+unsafe extern "C" fn env_cleanup_hook(data: *mut std::ffi::c_void) {
+    // Removed in a statement of its own, so the table's lock is released before anything below.
+    let removed = env_states().remove(&(data as usize));
+    let Some(state) = removed else {
+        return;
+    };
+
+    // `close` marks the environment shut, takes its handles, and releases its own lock before
+    // handing them back. Aborting drops pending calls (and their SyncSenders), which unblocks Rust
+    // worker threads waiting on `rx.recv()` — and one of those may come straight back through a
+    // callback, so it must not find this sweep still holding the lock it needs.
+    for handle in state.close() {
         unsafe {
-            napi::sys::napi_add_env_cleanup_hook(
-                env.raw(),
-                Some(env_cleanup_hook),
-                std::ptr::null_mut(),
+            napi::sys::napi_release_threadsafe_function(
+                handle.0,
+                napi::sys::ThreadsafeFunctionReleaseMode::abort,
             );
         }
+    }
+}
+
+/// Install the cleanup hook for `env`, once per environment.
+///
+/// Every environment needs its own: a worker's TSFNs are bound to the worker's event loop, and are
+/// only safe for that environment's teardown to abort.
+fn install_env_cleanup_hook(env: &Env) {
+    let raw = env.raw();
+    let key = raw as usize;
+    {
+        let mut states = env_states();
+        if states.contains_key(&key) {
+            return;
+        }
+        states.insert(key, Arc::new(EnvState::new()));
+    }
+    unsafe {
+        napi::sys::napi_add_env_cleanup_hook(raw, Some(env_cleanup_hook), raw.cast());
     }
 }
 
@@ -163,10 +251,6 @@ fn init() {
     MAIN_THREAD_ID
         .set(std::thread::current().id())
         .expect("module_init called twice");
-    let _ = MODULE_STATE.set(ModuleState {
-        shutdown: AtomicBool::new(false),
-        tsfn_handles: Mutex::new(Vec::new()),
-    });
 }
 
 /// Returns `true` if the calling thread is the main Node.js event-loop thread.

--- a/runtimes/napi/src/lib.rs
+++ b/runtimes/napi/src/lib.rs
@@ -26,30 +26,29 @@
 //! 4. At call time, Rust marshals JS values into C-compatible argument buffers, invokes
 //!    the foreign function via core, and unmarshals the result back to JS.
 //!
-//! ## Main-thread detection and the two-path callback design
+//! ## Owning-thread detection and the two-path callback design
 //!
-//! Node.js's N-API values can only be created and accessed on the **main thread** (the
-//! thread running the event loop). However, Rust libraries may invoke callbacks from
-//! arbitrary worker threads. This fundamental tension drives the two-path design that
-//! pervades the callback system:
+//! Node.js's N-API values can only be created and accessed on the JS thread that owns
+//! them. However, Rust libraries may invoke callbacks from arbitrary worker threads.
+//! This fundamental tension drives the two-path design that pervades the callback
+//! system:
 //!
-//! - **Same-thread path**: When a callback fires on the main thread, we can directly
-//!   construct napi values and call into JS synchronously.
-//! - **Cross-thread path**: When a callback fires on a worker thread, we must use a
-//!   threadsafe function to schedule the call back onto the main thread's event
-//!   loop, then block the worker until the result is available.
+//! - **Same-thread path**: When a callback fires on the JS thread that registered it, we
+//!   can directly construct napi values and call into JS synchronously.
+//! - **Cross-thread path**: When a callback fires on any other thread, we must use a
+//!   threadsafe function to schedule the call back onto the owning thread's event
+//!   loop, then block the calling thread until the result is available.
 //!
-//! The [`MAIN_THREAD_ID`] static captures the main thread's identity at module
-//! initialization time, and [`is_main_thread`] is the single predicate that every
-//! callback path consults to choose between these two strategies.
+//! [`callback::is_js_thread`] is the single predicate every callback path consults to choose
+//! between these two strategies, and it answers per callback: each callback records the thread
+//! that registered it, alongside the `napi_env` and `ThreadsafeFunction` it already held for that
+//! same thread.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
-use std::thread::ThreadId;
 
 use napi::bindgen_prelude::*;
-use napi::module_init;
 use napi::JsObject;
 use napi_derive::napi;
 
@@ -65,11 +64,6 @@ use uniffi_runtime_core::Module;
 pub(crate) fn core_err(e: uniffi_runtime_core::Error) -> napi::Error {
     napi::Error::from_reason(e.to_string())
 }
-
-/// The identity of the main Node.js thread, captured once at module initialization.
-/// Used by [`is_main_thread`] to determine whether callback code can access napi
-/// values directly or must dispatch through a threadsafe function.
-static MAIN_THREAD_ID: OnceLock<ThreadId> = OnceLock::new();
 
 /// Per-environment state for coordinating shutdown and tracking VTable TSFNs.
 ///
@@ -244,24 +238,6 @@ fn install_env_cleanup_hook(env: &Env) {
     unsafe {
         napi::sys::napi_add_env_cleanup_hook(raw, Some(env_cleanup_hook), raw.cast());
     }
-}
-
-#[module_init]
-fn init() {
-    MAIN_THREAD_ID
-        .set(std::thread::current().id())
-        .expect("module_init called twice");
-}
-
-/// Returns `true` if the calling thread is the main Node.js event-loop thread.
-///
-/// This is the single decision point for the callback system's two-path design:
-/// when `true`, napi values can be manipulated directly; when `false`, work must
-/// be dispatched to the main thread via a threadsafe function.
-pub fn is_main_thread() -> bool {
-    MAIN_THREAD_ID
-        .get()
-        .is_some_and(|id| *id == std::thread::current().id())
 }
 
 /// The top-level napi class exposed to JavaScript.

--- a/runtimes/napi/tests/helpers/env-teardown.mjs
+++ b/runtimes/napi/tests/helpers/env-teardown.mjs
@@ -1,0 +1,60 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// A worker registers and is torn down, then the main thread registers and invokes a callback.
+// Run as a script by threading.test.mjs; see there for what it is guarding.
+import { Worker, isMainThread } from "node:worker_threads";
+
+import lib from "../../lib.js";
+import { libPath } from "./lib-path.mjs";
+
+const { UniffiNativeModule, FfiType } = lib;
+
+const DEFINITIONS = {
+  symbols: {
+    rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+    rustbuffer_free: "uniffi_test_rustbuffer_free",
+    rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+  },
+  structs: {},
+  callbacks: {
+    simple_callback: {
+      args: [FfiType.UInt64, FfiType.Int8],
+      ret: FfiType.Void,
+      hasRustCallStatus: false,
+    },
+  },
+  functions: {
+    uniffi_test_fn_call_callback: {
+      args: [FfiType.Callback("simple_callback"), FfiType.UInt64, FfiType.Int8],
+      ret: FfiType.Void,
+      hasRustCallStatus: true,
+    },
+  },
+};
+
+const open = () =>
+  UniffiNativeModule.open(libPath("uniffi_napi_test_lib")).register(
+    DEFINITIONS,
+  );
+
+// The worker registers before the main thread does, so it is the one that installs a cleanup hook
+// when only the first environment gets one. Its teardown is what must not affect the main thread.
+if (!isMainThread) {
+  open();
+} else {
+  const worker = new Worker(new URL(import.meta.url));
+  await new Promise((resolve) => worker.on("exit", resolve));
+
+  const nm = open();
+  const status = { code: 0 };
+  nm.uniffi_test_fn_call_callback(
+    (handle, value) => console.log(`CALLED ${handle} ${value}`),
+    7n,
+    42,
+    status,
+  );
+  if (status.code !== 0) throw new Error(`call status ${status.code}`);
+}

--- a/runtimes/napi/tests/helpers/second-thread-callback.mjs
+++ b/runtimes/napi/tests/helpers/second-thread-callback.mjs
@@ -1,0 +1,55 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Registers on the main thread, then invokes a callback from a worker, printing what it received.
+// Run as a script by threading.test.mjs; see there for why it is a separate process.
+import { Worker, isMainThread } from "node:worker_threads";
+
+import lib from "../../lib.js";
+import { libPath } from "./lib-path.mjs";
+
+const { UniffiNativeModule, FfiType } = lib;
+
+const DEFINITIONS = {
+  symbols: {
+    rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+    rustbuffer_free: "uniffi_test_rustbuffer_free",
+    rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+  },
+  structs: {},
+  callbacks: {
+    simple_callback: {
+      args: [FfiType.UInt64, FfiType.Int8],
+      ret: FfiType.Void,
+      hasRustCallStatus: false,
+    },
+  },
+  functions: {
+    uniffi_test_fn_call_callback: {
+      args: [FfiType.Callback("simple_callback"), FfiType.UInt64, FfiType.Int8],
+      ret: FfiType.Void,
+      hasRustCallStatus: true,
+    },
+  },
+};
+
+const nm = UniffiNativeModule.open(libPath("uniffi_napi_test_lib")).register(
+  DEFINITIONS,
+);
+
+// The main thread registers first: whichever thread loads the addon first is the one the old code
+// treated as "the" JS thread, so a worker that got there first would prove nothing.
+if (isMainThread) {
+  new Worker(new URL(import.meta.url));
+} else {
+  const status = { code: 0 };
+  nm.uniffi_test_fn_call_callback(
+    (handle, value) => console.log(`CALLED ${handle} ${value}`),
+    7n,
+    42,
+    status,
+  );
+  if (status.code !== 0) throw new Error(`call status ${status.code}`);
+}

--- a/runtimes/napi/tests/threading.test.mjs
+++ b/runtimes/napi/tests/threading.test.mjs
@@ -103,6 +103,41 @@ test("callback: receives RustBuffer arg from another thread", async () => {
   assert.deepStrictEqual(result.data, new Uint8Array([0xca, 0xfe, 0xba, 0xbe]));
 });
 
+// A second JS thread can use the runtime: it registers a callback and Rust invokes it.
+//
+// Run in a child process on purpose. A regression parks a JS thread inside native code, where
+// `worker.terminate()` never resolves and `process.exit()` never takes effect, so an in-process
+// version would wedge the suite instead of failing it.
+test("threads: a second JS thread can invoke a callback", async () => {
+  const script = join(
+    import.meta.dirname,
+    "helpers",
+    "second-thread-callback.mjs",
+  );
+  const child = spawn(process.execPath, [script], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  let out = "";
+  child.stdout.on("data", (chunk) => {
+    out += String(chunk);
+  });
+
+  const exitCode = await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve(null);
+    }, 30_000);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+  assert.match(out, /^CALLED 7 42$/m, "the worker's callback did not run");
+  assert.strictEqual(exitCode, 0, "the child did not exit on its own");
+});
+
 // One environment's teardown does not disturb another's.
 //
 // The worker registers first, so under a single process-wide cleanup hook it is the environment

--- a/runtimes/napi/tests/threading.test.mjs
+++ b/runtimes/napi/tests/threading.test.mjs
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 import { test } from "node:test";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
 import assert from "node:assert";
 import lib from "../lib.js";
 const { UniffiNativeModule, FfiType } = lib;
@@ -99,4 +101,36 @@ test("callback: receives RustBuffer arg from another thread", async () => {
   assert.strictEqual(result.handle, 99n);
   assert.ok(result.data instanceof Uint8Array);
   assert.deepStrictEqual(result.data, new Uint8Array([0xca, 0xfe, 0xba, 0xbe]));
+});
+
+// One environment's teardown does not disturb another's.
+//
+// The worker registers first, so under a single process-wide cleanup hook it is the environment
+// that installs it, and its teardown aborts every environment's ThreadsafeFunctions and marks
+// every environment as shutting down. The main thread's callbacks then bail out early and zero
+// their return buffers, which looks like a callback that silently never ran.
+test("threads: one environment's teardown leaves another's callbacks working", async () => {
+  const script = join(import.meta.dirname, "helpers", "env-teardown.mjs");
+  const child = spawn(process.execPath, [script], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  let out = "";
+  child.stdout.on("data", (chunk) => {
+    out += String(chunk);
+  });
+
+  const exitCode = await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve(null);
+    }, 30_000);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+  assert.match(out, /^CALLED 7 42$/m, "the main thread's callback did not run");
+  assert.strictEqual(exitCode, 0, "the child did not exit on its own");
 });


### PR DESCRIPTION
Fixes #436. Stacked on #435: the first commit here is that PR's, so review or land this one second. It has to be underneath rather than alongside — see **Ordering** below.

**What I was doing**

Calling a uniffi library from a Node `worker_threads` worker. Vitest and Jest both default to a worker pool, so this also happens to people who never asked for threads.

**What happens**

The first call from that worker never returns. The thread is parked in native code, so `worker.terminate()` never resolves and `process.exit()` never takes effect; the process has to be killed from outside.

It isn't limited to calls with a callback of your own. A uniffi future's continuation is passed as an `FfiType.Callback` argument, so *every* async call from a second JS thread hangs.

**Why**

```mermaid
sequenceDiagram
    participant Main as Main thread
    participant Worker as Worker thread
    participant Rust

    Main->>Rust: loads the addon
    Note over Rust: module_init runs once per library load<br/>MAIN_THREAD_ID = Main thread

    Worker->>Rust: calls a function with a callback
    Rust->>Rust: is_js_thread()
    Note over Rust: current is Worker,<br/>MAIN_THREAD_ID is Main,<br/>so: not a JS thread
    Rust-->>Worker: queues the callback on the Worker's own event loop
    Rust->>Worker: blocks the Worker until that callback replies
    Note over Worker: blocked, so it never runs its own queue,<br/>so the callback never replies
```

The check is process-wide, but what it decides is per callback. Every JS thread except the first is told it is not a JS thread, and is then made to wait for itself.

**The fix**

`CallbackUserData` already stores the registering thread's `napi_env`, its `napi_ref` and a `ThreadsafeFunction` bound to that thread's loop. Only the `ThreadId` was missing:

```diff
  is_js_thread(user_data)
-     current == MAIN_THREAD_ID           // process-wide
+     current == user_data.owner_thread   // per callback
```

`runtimes/core` already passes `user_data` into `is_js_thread`, and this implementation was discarding it, so nothing outside `runtimes/napi` changes. `MAIN_THREAD_ID` and `is_main_thread` become unused, and with them gone `#[module_init]` has nothing left to set: the source is a net eleven lines shorter.

**Test**

Registers on the main thread, then invokes a callback from a worker. It runs in a child process on purpose, because a regression parks a JS thread and would wedge the suite rather than fail it.

Checked both ways by rebuilding the addon from the parent commit: 30s deadlock without the change, 48ms with it. Suite is 91/91.

**Ordering**

This test is the first thing in the suite to create a `ThreadsafeFunction` on a second environment, which is precisely the case #434 gets wrong: only the first environment installs a cleanup hook, but every environment's handles go into one shared list. The worker's teardown destroys its TSFN, and at process exit the main environment's hook aborts the freed handle. The child dies with SIGABRT and prints nothing, so the test reports `exitCode` `null` rather than a failed assertion — deterministic on Linux, invisible on macOS.

So this PR is stacked on #435 rather than the other way round. The two bugs are independent; only the order is.

**Not in this PR**

* This is not the Channel work in #412, and does not overlap it. That proxies a player from one JS context so a long call can leave the UI thread; this makes the NAPI player itself correct when several contexts use it directly. A Node server has no UI thread to get off, and reaches for a worker pool for throughput, so being directly usable from several threads is what that case needs.
* This does not make a cdylib safe across several JS realms in general: UniFFI registers one foreign-callback vtable per cdylib (mozilla/uniffi-rs#2295). This fixes the hang; that is what remains.
