### PR TITLE
fix(napi): cache callback trampolines instead of rebuilding per call

### DIFF
--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -51,7 +51,7 @@ pub(crate) fn call_ffi_function(
     module: &Arc<Module>,
     arg_types: &[FfiTypeDesc],
     has_rust_call_status: bool,
-    capacity_symbol: &CapacitySymbol,
+    registration: &crate::register::Registration,
 ) -> Result<JsUnknown> {
     let declared_arg_count = arg_types.len();
 
@@ -72,7 +72,7 @@ pub(crate) fn call_ffi_function(
                         env.raw(),
                         js_val,
                         module.rb_ops().from_bytes_ptr,
-                        Some(capacity_symbol),
+                        Some(&registration.capacity_symbol),
                     )?
                 };
                 slot::write_rust_buffer(slot, rust_buffer);
@@ -86,17 +86,58 @@ pub(crate) fn call_ffi_function(
                 slot::write_pointer(slot, struct_ptr);
             }
             FfiTypeDesc::Callback(cb_name) => {
-                let js_fn = unsafe { napi::JsFunction::from_raw(env.raw(), js_val.raw())? };
-                let user_data = callback::create_callback_user_data(env, js_fn, cb_name, module)?;
-                let fn_ptr = module
-                    .make_callback_trampoline(
-                        cb_name,
-                        callback::on_js_thread,
-                        callback::dispatch_to_js_thread,
-                        callback::is_js_thread,
-                        user_data,
-                    )
-                    .map_err(core_err)?;
+                // Reuse this function's trampoline if it already has one. Building one is
+                // permanently leaked by design — the library may invoke the pointer from any
+                // thread later — so the intended bound is one per callback type, and building
+                // one per call turns that into unbounded growth.
+                //
+                // Keying on the function object is what makes reuse correct: the Symbols
+                // belong to this `register()` call and so to this env, and a trampoline holds
+                // no per-call state, since callbacks receive their handle as an ordinary
+                // argument.
+                //
+                // A hit costs only the lookup — nothing below runs until a miss.
+                //
+                // SAFETY: `js_val` is a value from the current callback scope, so `raw()`
+                // yields a `napi_value` valid for that scope without transferring ownership.
+                let raw_fn_val = unsafe { js_val.raw() };
+                // SAFETY: `env` is the active env for this call and `raw_fn_val` is the value
+                // read above; a lookup miss is reported as `Ok(None)`, so a JS function
+                // carrying no marker is simply built below rather than misread.
+                let cached = unsafe {
+                    registration
+                        .trampolines
+                        .get(env.raw(), raw_fn_val, cb_name)?
+                };
+                let fn_ptr = match cached {
+                    Some(fn_ptr) => fn_ptr,
+                    None => {
+                        // SAFETY: `raw_fn_val` is a `napi_value` from this callback scope.
+                        // `from_raw` errors rather than aborting if it is not a function, and
+                        // the declared arg type is `Callback`, so a non-function here is a
+                        // caller error surfaced as a JS exception.
+                        let js_fn = unsafe { napi::JsFunction::from_raw(env.raw(), raw_fn_val)? };
+                        let user_data =
+                            callback::create_callback_user_data(env, js_fn, cb_name, module)?;
+                        let fn_ptr = module
+                            .make_callback_trampoline(
+                                cb_name,
+                                callback::on_js_thread,
+                                callback::dispatch_to_js_thread,
+                                callback::is_js_thread,
+                                user_data,
+                            )
+                            .map_err(core_err)?;
+                        // SAFETY: as for the lookup above — same env, same value. The
+                        // pointer stored is the trampoline just built for `cb_name`.
+                        unsafe {
+                            registration
+                                .trampolines
+                                .set(env.raw(), raw_fn_val, cb_name, fn_ptr)?
+                        };
+                        fn_ptr
+                    }
+                };
                 slot::write_pointer(slot, fn_ptr);
             }
             _ => {
@@ -179,7 +220,7 @@ pub(crate) fn call_ffi_function(
 
     match &call_ret {
         CallReturn::RustBuffer(rb) => {
-            rust_buffer_to_js_uint8array_handoff(env, *rb, capacity_symbol)
+            rust_buffer_to_js_uint8array_handoff(env, *rb, &registration.capacity_symbol)
         }
         _ => marshal::read_return_to_js(env, &call_ret),
     }

--- a/runtimes/napi/src/callback/cache.rs
+++ b/runtimes/napi/src/callback/cache.rs
@@ -1,0 +1,227 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+//! Trampoline cache: one libffi trampoline per (callback name, JS function).
+//!
+//! Building a trampoline for a callback argument is expensive and **permanently
+//! leaked**, by design: the library may invoke the function pointer from any thread
+//! at any later time, so nothing can safely reclaim it. Each one costs
+//!
+//! - a strong `napi_ref` pinning the JS function,
+//! - a leaked `CallbackUserData` (arg layout, cloned type descriptors, `Arc<Module>`),
+//! - a fresh JS function plus a fresh `ThreadsafeFunction` (a libuv async handle),
+//!   and an entry appended to the env's TSFN registry,
+//! - a leaked `TrampolineUserdata`, and
+//! - a libffi `Closure`, which owns an executable page.
+//!
+//! Dispatch used to build one on *every* call that passed a callback, so the cost
+//! became a ~3 KB per-call leak. That is reached from ordinary generated code: the
+//! async poll loop passes its continuation callback on every poll, so every `await`
+//! leaked ~3.2 KB regardless of argument types.
+//!
+//! Caching removes the per-call part without changing any lifetime: trampolines are
+//! still never freed, there is just one per distinct (callback name, function) pair
+//! instead of one per call. The async continuation is a module-level `const`, so it
+//! is built once and reused for the life of the registration.
+//!
+//! The cached pointer lives on the JS function object under a hidden per-callback
+//! Symbol, mirroring how [`crate::napi_utils::CapacitySymbol`] records RustBuffer
+//! ownership on a view. Keying on the function object is what makes reuse safe:
+//!
+//! - The Symbols belong to one `register()` call, hence one `napi_env`, and a JS
+//!   function object cannot cross realms. So a cached trampoline is never handed to
+//!   a different env than the `raw_env`/`owner_thread` its userdata captured.
+//! - A trampoline carries no per-call state. Callbacks receive their handle as an
+//!   ordinary argument, so reusing one across calls cannot mix up call state.
+//!
+//! A caller that passes a freshly created closure on every call gets no benefit and
+//! behaves exactly as before — there is nothing stable to key on.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+/// Per-registration hidden Symbols keyed by callback name, used to stash a built
+/// trampoline pointer on the JS function it was built for.
+pub struct TrampolineCache {
+    /// One `napi_ref`'d Symbol per callback name in the module spec. Symbols are
+    /// GC-managed; the strong reference keeps them alive for as long as the JS-side
+    /// module facade, which is what makes the cache last as long as the registration.
+    symbols: HashMap<String, napi::sys::napi_ref>,
+    /// Captured so `Drop` releases each reference against the env that owns it.
+    raw_env: napi::sys::napi_env,
+}
+
+// SAFETY: mirrors `CapacitySymbol`. These raw handles are only ever dereferenced on
+// the JS thread that created them; `Send`/`Sync` is required because the cache is
+// parked in an `Arc` captured by closures that napi-rs requires to be `Send`.
+unsafe impl Send for TrampolineCache {}
+unsafe impl Sync for TrampolineCache {}
+
+impl TrampolineCache {
+    /// Create one Symbol per callback name.
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must be a valid `napi_env` for the current callback scope.
+    pub unsafe fn new<'a>(
+        raw_env: napi::sys::napi_env,
+        names: impl Iterator<Item = &'a String>,
+    ) -> napi::Result<Self> {
+        let mut symbols = HashMap::new();
+        for name in names {
+            let description = format!("uniffi.trampoline.{name}\0");
+            let mut desc_val: napi::sys::napi_value = std::ptr::null_mut();
+            let status = napi::sys::napi_create_string_utf8(
+                raw_env,
+                description.as_ptr() as *const _,
+                description.len() - 1,
+                &mut desc_val,
+            );
+            if status != napi::sys::Status::napi_ok {
+                return Err(napi::Error::from_reason(
+                    "Failed to create trampoline symbol description".to_string(),
+                ));
+            }
+
+            let mut sym_val: napi::sys::napi_value = std::ptr::null_mut();
+            let status = napi::sys::napi_create_symbol(raw_env, desc_val, &mut sym_val);
+            if status != napi::sys::Status::napi_ok {
+                return Err(napi::Error::from_reason(
+                    "Failed to create trampoline Symbol".to_string(),
+                ));
+            }
+
+            let mut sym_ref: napi::sys::napi_ref = std::ptr::null_mut();
+            let status = napi::sys::napi_create_reference(raw_env, sym_val, 1, &mut sym_ref);
+            if status != napi::sys::Status::napi_ok {
+                return Err(napi::Error::from_reason(
+                    "Failed to reference trampoline Symbol".to_string(),
+                ));
+            }
+            symbols.insert(name.clone(), sym_ref);
+        }
+        Ok(Self { symbols, raw_env })
+    }
+
+    /// Resolve the Symbol for `callback_name`, if the module declares it.
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must match the env this cache was created in.
+    unsafe fn symbol(
+        &self,
+        raw_env: napi::sys::napi_env,
+        callback_name: &str,
+    ) -> Option<napi::sys::napi_value> {
+        let sym_ref = self.symbols.get(callback_name)?;
+        let mut sym_val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_get_reference_value(raw_env, *sym_ref, &mut sym_val);
+        if status != napi::sys::Status::napi_ok || sym_val.is_null() {
+            return None;
+        }
+        Some(sym_val)
+    }
+
+    /// Read the trampoline cached on `js_fn` for `callback_name`.
+    ///
+    /// Returns `Ok(None)` when nothing is cached yet. A lookup failure is also
+    /// reported as `Ok(None)` rather than an error: the only cost of a miss is
+    /// rebuilding the trampoline, which is exactly the pre-cache behaviour, so a
+    /// transient napi hiccup must not fail an otherwise valid FFI call.
+    ///
+    /// # Safety
+    ///
+    /// `raw_env` must be valid for the current callback scope; `obj` must be a JS
+    /// function value from that scope.
+    pub unsafe fn get(
+        &self,
+        raw_env: napi::sys::napi_env,
+        obj: napi::sys::napi_value,
+        callback_name: &str,
+    ) -> napi::Result<Option<*const c_void>> {
+        let Some(sym_val) = self.symbol(raw_env, callback_name) else {
+            return Ok(None);
+        };
+
+        let mut has = false;
+        let status = napi::sys::napi_has_own_property(raw_env, obj, sym_val, &mut has);
+        if status != napi::sys::Status::napi_ok || !has {
+            return Ok(None);
+        }
+
+        let mut val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_get_property(raw_env, obj, sym_val, &mut val);
+        if status != napi::sys::Status::napi_ok || val.is_null() {
+            return Ok(None);
+        }
+
+        let mut ptr: u64 = 0;
+        let mut lossless = false;
+        let status = napi::sys::napi_get_value_bigint_uint64(raw_env, val, &mut ptr, &mut lossless);
+        if status != napi::sys::Status::napi_ok || !lossless || ptr == 0 {
+            return Ok(None);
+        }
+        Ok(Some(ptr as *const c_void))
+    }
+
+    /// Cache `fn_ptr` on `js_fn` for `callback_name`.
+    ///
+    /// Defined non-enumerable so the marker cannot show up in property enumeration
+    /// or structural comparison of a user-supplied function.
+    ///
+    /// # Safety
+    ///
+    /// As [`Self::get`].
+    pub unsafe fn set(
+        &self,
+        raw_env: napi::sys::napi_env,
+        obj: napi::sys::napi_value,
+        callback_name: &str,
+        fn_ptr: *const c_void,
+    ) -> napi::Result<()> {
+        let Some(sym_val) = self.symbol(raw_env, callback_name) else {
+            return Ok(());
+        };
+
+        let mut val: napi::sys::napi_value = std::ptr::null_mut();
+        let status = napi::sys::napi_create_bigint_uint64(raw_env, fn_ptr as u64, &mut val);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to create BigInt for trampoline pointer".to_string(),
+            ));
+        }
+
+        let descriptor = napi::sys::napi_property_descriptor {
+            utf8name: std::ptr::null(),
+            name: sym_val,
+            method: None,
+            getter: None,
+            setter: None,
+            value: val,
+            attributes: napi::sys::PropertyAttributes::writable,
+            data: std::ptr::null_mut(),
+        };
+        let status = napi::sys::napi_define_properties(raw_env, obj, 1, &descriptor);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to cache trampoline pointer".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TrampolineCache {
+    fn drop(&mut self) {
+        for sym_ref in self.symbols.values() {
+            // SAFETY: each ref was created against `self.raw_env` with refcount 1 and
+            // has not been deleted. The trampolines the Symbols pointed at stay leaked
+            // on purpose — see the module docs.
+            unsafe {
+                napi::sys::napi_delete_reference(self.raw_env, *sym_ref);
+            }
+        }
+    }
+}

--- a/runtimes/napi/src/callback/mod.rs
+++ b/runtimes/napi/src/callback/mod.rs
@@ -43,6 +43,7 @@ use std::thread::ThreadId;
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, NapiRaw, NapiValue};
 
+pub(crate) mod cache;
 mod marshal;
 pub(crate) mod vtable;
 

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -23,6 +23,24 @@ use crate::napi_utils::CapacitySymbol;
 use uniffi_runtime_core::ffi_c_types::RustBufferC;
 use uniffi_runtime_core::{FfiTypeDesc, Module};
 
+/// State created once per `register()` call and shared by every function closure the
+/// resulting facade exposes.
+///
+/// Both members are per-registration JS Symbols, and both are keyed to the `napi_env`
+/// that `register()` ran on — which is what makes their contents safe to reuse across
+/// calls. Bundling them keeps the dispatch signature manageable as more per-registration
+/// state accrues.
+pub(crate) struct Registration {
+    /// Hidden capacity-hint key on lift-handoff `Uint8Array` views. A handed-off view's
+    /// `byteLength` is `rb.len`, but Rust may have allocated `rb.capacity > rb.len`, so
+    /// the capacity is stashed here for `rustbuffer_free(view)` to read back.
+    pub(crate) capacity_symbol: CapacitySymbol,
+    /// Hidden keys caching a built callback trampoline on the JS function it was built
+    /// for. Without this, dispatch rebuilds one per call — a permanent ~3 KB leak, and
+    /// the async poll loop passes its continuation on every poll. See `callback::cache`.
+    pub(crate) trampolines: crate::callback::cache::TrampolineCache,
+}
+
 /// Build a JS object whose methods call into the native library described by `definitions`.
 pub fn register(
     env: Env,
@@ -38,17 +56,15 @@ pub fn register(
     let functions: JsObject = definitions.get_named_property("functions")?;
     let mut result = env.create_object()?;
 
-    // Per-registration Symbol used as a hidden capacity-hint key on lift-
-    // handoff `Uint8Array` views. The view-handoff path returns a view whose
-    // `byteLength` is `rb.len`, but Rust may have allocated
-    // `rb.capacity > rb.len`. We stash `capacity` on the view via this
-    // symbol; `rustbuffer_free(view)` reads it back when releasing the
-    // allocation.
-    //
-    // SAFETY: env is the active napi env supplied by node for this register
-    // call. The `Arc<CapacitySymbol>` keeps the Symbol alive across the
-    // module facade's lifetime (closures captured below outlive the call).
-    let capacity_symbol = Arc::new(unsafe { CapacitySymbol::new(env.raw())? });
+    // SAFETY: env is the active napi env supplied by node for this register call. The
+    // `Arc<Registration>` keeps both Symbols alive across the module facade's lifetime
+    // (the closures captured below outlive this call).
+    let registration = Arc::new(Registration {
+        capacity_symbol: unsafe { CapacitySymbol::new(env.raw())? },
+        trampolines: unsafe {
+            crate::callback::cache::TrampolineCache::new(env.raw(), module.spec_callbacks().keys())?
+        },
+    });
 
     let names = functions.get_property_names()?;
     let len = names.get_array_length()?;
@@ -68,7 +84,7 @@ pub fn register(
         })?;
         let arg_types: Rc<Vec<FfiTypeDesc>> = Rc::new(func_def.args.clone());
         let has_rust_call_status = func_def.has_rust_call_status;
-        let cap_sym_for_call = Arc::clone(&capacity_symbol);
+        let reg_for_call = Arc::clone(&registration);
 
         let js_func = env.create_function_from_closure(&name, move |ctx| {
             call_ffi_function(
@@ -78,7 +94,7 @@ pub fn register(
                 &module_ref,
                 &arg_types,
                 has_rust_call_status,
-                &cap_sym_for_call,
+                &reg_for_call,
             )
         })?;
 
@@ -90,7 +106,7 @@ pub fn register(
     // library's `rustbuffer_free`. Together they let JS allocate buffers that the
     // codegen-emitted lowering path can fill in place and ship to Rust without copying.
     let alloc_module = Arc::clone(&module);
-    let cap_sym_for_alloc = Arc::clone(&capacity_symbol);
+    let reg_for_alloc = Arc::clone(&registration);
     let alloc_fn = env.create_function_from_closure("rustbuffer_alloc", move |ctx| {
         let size_arg: i32 = ctx.get(0)?;
         if size_arg < 0 {
@@ -123,14 +139,18 @@ pub fn register(
         // argument-lowering path adopts the allocation instead of copying it. Without the
         // stamp, a lowered argument gets copied and this allocation is orphaned.
         if rb.capacity > 0 {
-            unsafe { cap_sym_for_alloc.set(ctx.env.raw(), typedarray, rb.capacity)? };
+            unsafe {
+                reg_for_alloc
+                    .capacity_symbol
+                    .set(ctx.env.raw(), typedarray, rb.capacity)?
+            };
         }
         unsafe { JsUnknown::from_raw(ctx.env.raw(), typedarray) }
     })?;
     result.set_named_property("rustbuffer_alloc", alloc_fn)?;
 
     let free_module = Arc::clone(&module);
-    let cap_sym_for_free = Arc::clone(&capacity_symbol);
+    let reg_for_free = Arc::clone(&registration);
     let free_fn = env.create_function_from_closure("rustbuffer_free", move |ctx| {
         let js_val: JsUnknown = ctx.get(0)?;
         let raw_env = ctx.env.raw();
@@ -161,7 +181,8 @@ pub fn register(
         // No hint at all means the memory is not the library's to free; fall back to
         // byteLength to preserve the historical behaviour for such views.
         // SAFETY: raw_env / raw_val are valid for the current callback scope.
-        let capacity = unsafe { cap_sym_for_free.get(raw_env, raw_val) }.unwrap_or(length as u64);
+        let capacity =
+            unsafe { reg_for_free.capacity_symbol.get(raw_env, raw_val) }.unwrap_or(length as u64);
         let rb = RustBufferC {
             capacity,
             len: 0,

--- a/runtimes/napi/tests/callback_trampoline_cache.test.mjs
+++ b/runtimes/napi/tests/callback_trampoline_cache.test.mjs
@@ -1,0 +1,139 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// Passing a callback as an FFI argument must not rebuild its trampoline every call.
+//
+// Building one costs a leaked `napi_ref` to the function, a leaked userdata box, a
+// fresh JS function, a fresh ThreadsafeFunction (plus an entry on the env's TSFN
+// registry), a leaked TrampolineUserdata, and a libffi closure holding an
+// executable page. None of it is ever freed — deliberately, because the library
+// may invoke a trampoline from any thread at any later time — so building one per
+// call leaks ~3 KB per call. Measured against the generated API before this cache,
+// every `await` of an async uniffi function leaked ~3.2 KB, because the poll loop
+// passes its continuation callback on every poll.
+//
+// The assertion is deliberately NOT an RSS measurement. V8 moves its heap
+// reservation by megabytes, which makes per-call byte accounting at this scale
+// noisy enough to be useless (a 16 KB payload loop measured 0.9 MB, 9.0 MB and
+// 0.1 MB of "growth" at increasing iteration counts). Instead we assert the
+// invariant that actually matters and is exact: the same function object reuses
+// the same trampoline, and a different function object gets its own.
+import { test } from "node:test";
+import assert from "node:assert";
+import lib from "../lib.js";
+const { UniffiNativeModule, FfiType } = lib;
+import { libPath } from "./helpers/lib-path.mjs";
+
+const SYMBOLS = {
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+};
+
+function openModule() {
+  return UniffiNativeModule.open(libPath("uniffi_napi_test_lib")).register({
+    symbols: SYMBOLS,
+    structs: {},
+    callbacks: {
+      simple_cb: {
+        args: [FfiType.UInt64, FfiType.Int8],
+        ret: FfiType.Void,
+        hasRustCallStatus: false,
+      },
+    },
+    functions: {
+      uniffi_test_fn_call_callback: {
+        args: [FfiType.Callback("simple_cb"), FfiType.UInt64, FfiType.Int8],
+        ret: FfiType.Void,
+        hasRustCallStatus: true,
+      },
+    },
+  });
+}
+
+// The runtime records a cached trampoline on the function object under a hidden
+// per-registration Symbol, the same way it records RustBuffer ownership on a view.
+// Reading it back is white-box, but it is the only exact signal available: the
+// trampoline pointer is not otherwise observable from JS.
+function trampolineMarkers(fn) {
+  return Object.getOwnPropertySymbols(fn).map((s) => fn[s]);
+}
+
+test("the same callback function reuses one trampoline across calls", () => {
+  const nm = openModule();
+  let hits = 0;
+  const cb = (_handle, value) => {
+    hits += value;
+  };
+
+  const status = { code: 0 };
+  nm.uniffi_test_fn_call_callback(cb, 1n, 1, status);
+  assert.strictEqual(status.code, 0);
+
+  const afterFirst = trampolineMarkers(cb);
+  assert.strictEqual(
+    afterFirst.length,
+    1,
+    "expected exactly one cached trampoline marker after the first call",
+  );
+  assert.ok(afterFirst[0], "cached trampoline pointer must be non-zero");
+
+  for (let i = 0; i < 50; i++) {
+    nm.uniffi_test_fn_call_callback(cb, 1n, 1, status);
+    assert.strictEqual(status.code, 0);
+  }
+
+  assert.strictEqual(hits, 51, "the callback must still be invoked every call");
+  assert.deepStrictEqual(
+    trampolineMarkers(cb),
+    afterFirst,
+    "the trampoline must be reused, not rebuilt, on later calls",
+  );
+});
+
+test("distinct callback functions get distinct trampolines", () => {
+  const nm = openModule();
+  const status = { code: 0 };
+  const a = () => {};
+  const b = () => {};
+
+  nm.uniffi_test_fn_call_callback(a, 1n, 1, status);
+  nm.uniffi_test_fn_call_callback(b, 1n, 1, status);
+
+  const [ptrA] = trampolineMarkers(a);
+  const [ptrB] = trampolineMarkers(b);
+  assert.ok(ptrA && ptrB, "both functions must carry a cached trampoline");
+  assert.notStrictEqual(
+    ptrA,
+    ptrB,
+    "two different JS functions must not share a trampoline",
+  );
+});
+
+test("a cached callback still dispatches correctly after many calls", () => {
+  const nm = openModule();
+  const seen = [];
+  const cb = (handle, value) => {
+    seen.push([handle, value]);
+  };
+
+  const status = { code: 0 };
+  for (let i = 0; i < 5; i++) {
+    nm.uniffi_test_fn_call_callback(cb, BigInt(i), i, status);
+    assert.strictEqual(status.code, 0);
+  }
+
+  assert.deepStrictEqual(
+    seen,
+    [
+      [0n, 0],
+      [1n, 1],
+      [2n, 2],
+      [3n, 3],
+      [4n, 4],
+    ],
+    "arguments must be marshalled correctly on every call, cached or not",
+  );
+});


### PR DESCRIPTION
### Reachability

**Reachable through the generated wrappers — affects every consumer of an async API.**

`async-rust-call.ts` marshals its continuation callback to `rust_future_poll` on every
poll, so ordinary `await` grew RSS without anyone touching the native module directly. No
opt-in, no unusual usage: any app awaiting a uniffi async function paid this.

(For contrast, the vtable path also builds a trampoline per call, but generated code
registers a vtable once at module init, so it is not reached through the wrappers.)

### The intended design

Callback trampolines are **deliberately never reclaimed**. The library may invoke the
function pointer from any thread at any later time, so nothing can safely free one. That
is fine, because the intended bound is **one trampoline per callback type**: a fixed
startup cost, paid once, proportional to how many callback signatures a module declares.

`callback.rs` says as much — it describes trampolines as leaked "per registration".

### The bug

Dispatch built a fresh trampoline on **every call that marshalled a Callback argument**, so
that bounded startup cost became unbounded growth.

Note the unit: the cost is per *construction* — JS→Rust, at call time — not per callback
*invocation*. One trampoline services any number of Rust→JS crossings for free. Each
construction costs:

- a strong `napi_ref` pinning the JS function,
- a leaked `CallbackUserData` (arg layout, cloned type descriptors, `Arc<Module>`),
- a fresh JS function **and** a fresh `ThreadsafeFunction` (a libuv async handle), plus an
  entry appended to the env's TSFN registry — itself unbounded,
- a leaked `TrampolineUserdata`, and
- a libffi `Closure`, which owns an executable page.

Measured in isolation, one construction costs **~2869 B** (fresh closures defeat the cache;
a cache hit measures 1 B/call and a callback-free call 0 B/call, both at n=30k).

It is reached from ordinary generated code, not just hand-written FFI:
`typescript/src/async-rust-call.ts` marshals its continuation callback to
`rust_future_poll` on **every poll**. `noopAsync` polls once per await, so there one await
is one construction — which is why the per-await figures below track the per-construction
cost.

### Measurements

Through the generated API of `fixtures/benchmark`, RSS growth per call after a forced
`global.gc()`. `noopAsync()` touches no buffers at all, so this isolates trampoline cost
from anything RustBuffer-related:

| | before | after |
|---|---|---|
| `noopAsync()` | **3455 B/await** | **7 B/await** |

Of that 3455 B, ~2869 B is the trampoline construction; the remainder is the rest of the
async protocol per await (the promise, the resolver-map entry, and the other three FFI
calls), which the cache also removes because those costs were incurred alongside it.

The shapes differ, which is the actual evidence. Before: flat at ~3.2 KB across 1k/5k/20k
iterations — unbounded. After: 139 → 121 → 7 B/await as n rises to 200k, with
non-monotonic totals (2.7 / 9.2 / 1.3 MB) — bounded V8 heap-reservation noise.

Worth being explicit, because not all RSS growth in this runtime is equal: the *per-call*
growth here was genuine and irreducible. It is `Box::leak` plus `mem::forget` — nothing
frees it, and it survives event-loop turns. (The measurement above is a loop of `await`s,
which yield on every iteration.)

### The fix

Cache one trampoline per **(callback name, JS function)**, stored on the function object
under a hidden per-callback `Symbol` — the same mechanism `CapacitySymbol` already uses to
record RustBuffer ownership on a view, so no new abstraction.

Nothing about lifetimes changes: trampolines are still never freed. There is simply one
per distinct function instead of one per call.

**Why that restores the per-type bound.** Generated code passes per-type functions, created
once:

- a callback interface's vtable is a module-level `const` whose field closures are built at
  module load, handed to `init_callback_vtable` a single time;
- `uniffiFutureContinuationCallback` is likewise a module-level `const`, reused for every
  poll of every future.

So for generated bindings, the set of distinct `(callback name, JS function)` pairs *is*
the set of callback types. Measured with the fixture:

| | distinct trampolines |
|---|---|
| one stable function, 500 calls | **1** |
| 20 freshly-created closures | **20** |

### Why keying on the function object is safe

- The Symbols belong to a single `register()` call, hence a single `napi_env`, and a JS
  function object cannot cross realms — so a cached trampoline is never handed to a
  different env than the `raw_env`/`owner_thread` its userdata captured.
- A trampoline carries no per-call state. Callbacks receive their handle as an ordinary
  argument, so reuse cannot mix up call state.

A cache hit costs only the lookup; `JsFunction::from_raw` and everything else runs only on
a miss.

### Limits

The bound is per `(type, function)`, not per type unconditionally — the second row of the
table above is the honest boundary. A hand-written caller passing a freshly created closure
on every call still gets one trampoline per call, exactly as before.

Making it per-type in all cases would mean not baking a specific JS function into the
userdata at all, and instead dispatching via the handle argument through a registry — which
is how uniffi's own model works, since each vtable method already receives a handle and the
JS side already keeps a handle map. That is a much larger change and unnecessary while
generated code passes stable per-type functions.

**Also out of scope:** vtable-struct arguments build trampolines per call too, but
generated code registers a vtable once at module init, so client code does not reach that
path.

### Note on the `Registration` struct

Adding the cache pushed `call_ffi_function` to 8 parameters, tripping
`clippy::too_many_arguments`. Since the repo has no `#[allow(clippy::…)]` anywhere, the fix
is to bundle the two per-registration Symbols into a `Registration` struct rather than add
the first suppression. That accounts for the churn in `register/mod.rs` and the signature
change — both members are keyed to the `napi_env` that `register()` ran on, so they belong
together anyway.

### Tests

Three new tests in `callback_trampoline_cache.test.mjs` assert the *invariant* — the same
function reuses one trampoline, distinct functions get distinct ones, and dispatch stays
correct across many calls — rather than sampling RSS. Per-call byte accounting is unusable
at this scale: V8 moves its heap reservation by megabytes, and a 16 KB-payload loop
measured 0.9 MB, 9.0 MB and 0.1 MB of "growth" at increasing iteration counts. Reading the
cached pointer back through the marker Symbol is white-box, but it is the only exact signal
available — the trampoline pointer is not otherwise observable from JS.

All three fail before this change; the third (correct dispatch) passes before and after, as
it should.

### Verification

macOS/arm64, Node 26: **101/101** runtime tests, **48/48** napi fixture tests,
`cargo clippy` clean, `cargo fmt --check` clean. CI green on Linux, including
`Integration tests (N-API runtime and bindings)`.
