### PR TITLE
fix(napi): never free a buffer the library does not own

### DIFF
--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -219,9 +219,12 @@ pub(crate) fn call_ffi_function(
     }
 
     match &call_ret {
-        CallReturn::RustBuffer(rb) => {
-            rust_buffer_to_js_uint8array_handoff(env, *rb, &registration.capacity_symbol)
-        }
+        CallReturn::RustBuffer(rb) => rust_buffer_to_js_uint8array_handoff(
+            env,
+            *rb,
+            module.rb_ops().free_ptr,
+            &registration.capacity_symbol,
+        ),
         _ => marshal::read_return_to_js(env, &call_ret),
     }
 }
@@ -244,23 +247,44 @@ pub(crate) fn call_ffi_function(
 fn rust_buffer_to_js_uint8array_handoff(
     env: &napi::Env,
     rb: RustBufferC,
+    rb_free_ptr: *const c_void,
     capacity_symbol: &CapacitySymbol,
 ) -> Result<JsUnknown> {
     let raw_env = env.raw();
+    // Until this function hands `rb` to JS, it is the buffer's sole owner: every early
+    // return has to release it or the allocation is unreachable.
+    //
+    // SAFETY (each `free_rustbuffer` below): `rb_free_ptr` was resolved by dlsym at
+    // registration time, and `rb` is the buffer the callee just returned, which no other
+    // owner holds.
     let len = match usize::try_from(rb.len) {
         Ok(n) => n,
         Err(_) => {
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
             return Err(napi::Error::from_reason(
                 "RustBuffer len exceeds addressable memory",
             ));
         }
     };
 
-    // Empty RustBuffer (capacity == 0 or null data): no allocation to alias,
-    // and no capacity hint needed — the runtime's `rustbuffer_free` short-
-    // circuits on empty views without a hint.
-    if rb.capacity == 0 || rb.data.is_null() {
-        let typedarray = unsafe { napi_utils::create_uint8array(raw_env, std::ptr::null(), 0)? };
+    // Nothing to alias, so any spare capacity has to be released here: a zero-length
+    // typed array cannot carry the data pointer forward, leaving `rustbuffer_free`
+    // nothing to work from.
+    if rb.len == 0 || rb.capacity == 0 || rb.data.is_null() {
+        // SAFETY: `raw_env` is valid for this callback scope; a null `data` with length 0
+        // allocates an empty buffer without reading anything.
+        let typedarray =
+            match unsafe { napi_utils::create_uint8array(raw_env, std::ptr::null(), 0) } {
+                Ok(typedarray) => typedarray,
+                Err(error) => {
+                    unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+                    return Err(error);
+                }
+            };
+        unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+        // SAFETY: `raw_env` is valid for this callback scope, and `typedarray` is the
+        // object created just above.
+        unsafe { capacity_symbol.set(raw_env, typedarray, 0)? };
         return Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? });
     }
 
@@ -268,14 +292,25 @@ fn rust_buffer_to_js_uint8array_handoff(
     // bytes. We expose it to JS without a finalizer; the codegen-emitted
     // try/finally calls `rustbuffer_free(view)` which will hand the (ptr,
     // capacity) tuple back to the library's `rustbuffer_free`.
-    let typedarray = unsafe { napi_utils::create_external_uint8array(raw_env, rb.data, len)? };
+    let typedarray = match unsafe { napi_utils::create_external_uint8array(raw_env, rb.data, len) }
+    {
+        Ok(typedarray) => typedarray,
+        Err(error) => {
+            unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+            return Err(error);
+        }
+    };
 
-    // If `capacity > len`, the view's `byteLength` (== len) under-reports the
-    // allocation size. Stash the true capacity so `rustbuffer_free(view)` can
-    // free against the original `Layout`. When `capacity == len`, the runtime
-    // can recover capacity from `byteLength`, so we skip the property write.
-    if rb.capacity != rb.len {
-        unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity)? };
+    // Mark every handed-off view, including when `capacity == byteLength`: an absent
+    // marker means "not the library's, do not free", so an unmarked view leaks. The value
+    // is the true capacity, which may exceed `byteLength` — that is `rb.len`, so
+    // converters decoding the whole view see only the message bytes.
+    //
+    // SAFETY: `raw_env` is valid for this callback scope, and `typedarray` is the view
+    // created just above.
+    if let Err(error) = unsafe { capacity_symbol.set(raw_env, typedarray, rb.capacity) } {
+        unsafe { napi_utils::free_rustbuffer(rb, rb_free_ptr) };
+        return Err(error);
     }
 
     Ok(unsafe { JsUnknown::from_raw(raw_env, typedarray)? })

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -155,10 +155,41 @@ impl CapacitySymbol {
                 "Failed to create BigInt for capacity hint".to_string(),
             ));
         }
-        let status = napi::sys::napi_set_property(raw_env, obj, sym_val, cap_val);
+        // Own property, not inherited: the marker only ever lives on instances, and a
+        // prototype-chain hit would send us down the `napi_set_property` branch, silently
+        // creating an enumerable own property that shadows it.
+        let mut has = false;
+        let status = napi::sys::napi_has_own_property(raw_env, obj, sym_val, &mut has);
         if status != napi::sys::Status::napi_ok {
             return Err(napi::Error::from_reason(
-                "Failed to set capacity-hint property".to_string(),
+                "Failed to inspect RustBuffer ownership metadata",
+            ));
+        }
+
+        let status = if has {
+            // Already defined non-enumerable below; a plain set keeps that descriptor.
+            napi::sys::napi_set_property(raw_env, obj, sym_val, cap_val)
+        } else {
+            // `writable` only, so the marker is non-enumerable. That is load-bearing:
+            // lift now marks every handed-off view, and
+            // `assert.deepStrictEqual(view, new Uint8Array([...]))` compares enumerable
+            // own symbol properties — an enumerable marker would break every caller that
+            // compares a returned buffer against a plain Uint8Array.
+            let descriptor = napi::sys::napi_property_descriptor {
+                utf8name: std::ptr::null(),
+                name: sym_val,
+                method: None,
+                getter: None,
+                setter: None,
+                value: cap_val,
+                attributes: napi::sys::PropertyAttributes::writable,
+                data: std::ptr::null_mut(),
+            };
+            napi::sys::napi_define_properties(raw_env, obj, 1, &descriptor)
+        };
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to set RustBuffer ownership metadata",
             ));
         }
         Ok(())
@@ -175,26 +206,37 @@ impl CapacitySymbol {
         &self,
         raw_env: napi::sys::napi_env,
         obj: napi::sys::napi_value,
-    ) -> Option<u64> {
-        let sym_val = self.value(raw_env).ok()?;
+    ) -> napi::Result<Option<u64>> {
+        let sym_val = self.value(raw_env)?;
         let mut has = false;
-        let status = napi::sys::napi_has_property(raw_env, obj, sym_val, &mut has);
-        if status != napi::sys::Status::napi_ok || !has {
-            return None;
+        let status = napi::sys::napi_has_own_property(raw_env, obj, sym_val, &mut has);
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "Failed to inspect RustBuffer ownership metadata",
+            ));
         }
+        if !has {
+            return Ok(None);
+        }
+
         let mut cap_val: napi::sys::napi_value = std::ptr::null_mut();
         let status = napi::sys::napi_get_property(raw_env, obj, sym_val, &mut cap_val);
         if status != napi::sys::Status::napi_ok || cap_val.is_null() {
-            return None;
+            return Err(napi::Error::from_reason(
+                "Failed to read RustBuffer ownership metadata",
+            ));
         }
+
         let mut value: u64 = 0;
         let mut lossless = false;
         let status =
             napi::sys::napi_get_value_bigint_uint64(raw_env, cap_val, &mut value, &mut lossless);
-        if status != napi::sys::Status::napi_ok {
-            return None;
+        if status != napi::sys::Status::napi_ok || !lossless {
+            return Err(napi::Error::from_reason(
+                "Invalid RustBuffer ownership metadata",
+            ));
         }
-        Some(value)
+        Ok(Some(value))
     }
 }
 
@@ -486,7 +528,7 @@ pub unsafe fn js_uint8array_to_rust_buffer(
     }
 
     if let Some(symbol) = capacity_symbol {
-        if let Some(capacity) = symbol.get(raw_env, raw_val) {
+        if let Some(capacity) = symbol.get(raw_env, raw_val)? {
             if capacity == 0 {
                 // The hint exists but has been zeroed, so this view was already adopted and
                 // its memory has since been freed by the callee. Reading it would be a

--- a/runtimes/napi/src/register/mod.rs
+++ b/runtimes/napi/src/register/mod.rs
@@ -138,13 +138,18 @@ pub fn register(
         // consumers rely on it: `rustbuffer_free` frees against the true capacity, and the
         // argument-lowering path adopts the allocation instead of copying it. Without the
         // stamp, a lowered argument gets copied and this allocation is orphaned.
-        if rb.capacity > 0 {
-            unsafe {
-                reg_for_alloc
-                    .capacity_symbol
-                    .set(ctx.env.raw(), typedarray, rb.capacity)?
-            };
-        }
+        //
+        // Unconditional, including `rustbuffer_alloc(0)` where the capacity is 0: an
+        // absent marker means "not the library's, refuse to free", so a zero-capacity
+        // view is marked 0 — "ours, nothing to free" — rather than left bare.
+        //
+        // SAFETY: `ctx.env` is the active env for this callback, and `typedarray` is the
+        // view created just above.
+        unsafe {
+            reg_for_alloc
+                .capacity_symbol
+                .set(ctx.env.raw(), typedarray, rb.capacity)?
+        };
         unsafe { JsUnknown::from_raw(ctx.env.raw(), typedarray) }
     })?;
     result.set_named_property("rustbuffer_alloc", alloc_fn)?;
@@ -165,33 +170,41 @@ pub fn register(
                     "rustbuffer_free expected a Uint8Array argument".to_string(),
                 )
             })?;
-        // Empty views never carry a capacity hint (view-handoff short-
-        // circuits empty buffers, and `rustbuffer_alloc(0)` is itself a
-        // no-op). Bail out before the napi_ref + napi_has_property dance.
-        if length == 0 {
+        let _ = length;
+        // The marker is authoritative. Three cases:
+        //   (a) marker > 0 — library-owned. `rustbuffer_alloc(n)` views carry `n`;
+        //       lift-handoff views carry the true capacity, which may exceed
+        //       `byteLength` (that is `rb.len`). Free against the marker.
+        //   (b) marker == 0 — the view was already adopted as an FFI argument, so the
+        //       callee has freed the memory. Must be a no-op, not a double free.
+        //   (c) no marker — the bytes are not the library's. Reject.
+        //
+        // Rejecting (c) rather than ignoring it keeps a caller's mistake visible. Guessing
+        // the capacity from `byteLength` instead would pass V8-owned memory to Rust's
+        // allocator.
+        //
+        // SAFETY: raw_env / raw_val are valid for the current callback scope, and
+        // `raw_val` is the typed array the caller passed.
+        let capacity =
+            unsafe { reg_for_free.capacity_symbol.get(raw_env, raw_val)? }.ok_or_else(|| {
+                napi::Error::from_reason("rustbuffer_free received an unowned Uint8Array")
+            })?;
+        if capacity == 0 {
             return ctx.env.get_undefined().map(|u| u.into_unknown());
         }
-        // Capacity recovery. Three cases, all keyed off the hint:
-        //   (a) `rustbuffer_alloc(n)` views: hint == byteLength == n.
-        //   (b) Lift-handoff views: byteLength == rb.len, and the hint carries the true
-        //       capacity, which may be larger. Set at handoff time when capacity != len.
-        //   (c) Hint == 0: the view was already adopted as an FFI argument, so the callee
-        //       has freed the memory. `free_rustbuffer` skips zero-capacity buffers, which
-        //       turns this into the no-op it must be rather than a double free.
-        // No hint at all means the memory is not the library's to free; fall back to
-        // byteLength to preserve the historical behaviour for such views.
-        // SAFETY: raw_env / raw_val are valid for the current callback scope.
-        let capacity =
-            unsafe { reg_for_free.capacity_symbol.get(raw_env, raw_val) }.unwrap_or(length as u64);
+
+        // Mark the view released before handing its allocation back, so repeated
+        // cleanup is a no-op rather than a double free.
+        //
+        // SAFETY: as above — `raw_env` and `raw_val` are valid for this callback scope.
+        unsafe { reg_for_free.capacity_symbol.set(raw_env, raw_val, 0)? };
         let rb = RustBufferC {
             capacity,
             len: 0,
             data: data_ptr as *mut u8,
         };
-        // SAFETY: free_ptr was resolved at registration time. rb mirrors the
-        // buffer produced by the matching `rustbuffer_alloc` call OR a
-        // lift-handoff view whose `(data_ptr, capacity)` match the original
-        // RustBuffer that Rust returned across the FFI.
+        // SAFETY: free_ptr was resolved at registration time, and the marker ties this
+        // exact pointer and capacity to a buffer the library allocated.
         unsafe { napi_utils::free_rustbuffer(rb, free_module.rb_ops().free_ptr) };
         ctx.env.get_undefined().map(|u| u.into_unknown())
     })?;

--- a/runtimes/napi/tests/rust_buffer_free_safety.test.mjs
+++ b/runtimes/napi/tests/rust_buffer_free_safety.test.mjs
@@ -1,0 +1,147 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// `rustbuffer_free` must free only memory the library actually owns.
+//
+// The ownership marker is the sole authority: absent means "not ours, refuse"; 0 means
+// "ours, nothing left to free"; > 0 is the true allocation capacity. Guessing a capacity
+// for an unmarked view — from `byteLength`, say — would pass V8-owned memory to Rust's
+// allocator and corrupt the heap.
+//
+// That authority only holds if every view the runtime hands out is marked, so these also
+// pin the two cases where the capacity carries no information on its own:
+// `rustbuffer_alloc(0)`, and lift handoffs where `capacity == byteLength`.
+import { test } from "node:test";
+import assert from "node:assert";
+import lib from "../lib.js";
+const { UniffiNativeModule, FfiType } = lib;
+import { libPath } from "./helpers/lib-path.mjs";
+
+const SYMBOLS = {
+  rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+  rustbuffer_free: "uniffi_test_rustbuffer_free",
+  rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+};
+
+function openModule() {
+  return UniffiNativeModule.open(libPath("uniffi_napi_test_lib")).register({
+    symbols: SYMBOLS,
+    structs: {},
+    callbacks: {},
+    functions: {
+      uniffi_test_fn_make_buffer: {
+        args: [FfiType.UInt8, FfiType.UInt32],
+        ret: FfiType.RustBuffer,
+        hasRustCallStatus: true,
+      },
+      // Returns capacity = n with len = 0: spare capacity and no payload.
+      uniffi_test_rustbuffer_alloc: {
+        args: [FfiType.UInt64],
+        ret: FfiType.RustBuffer,
+        hasRustCallStatus: true,
+      },
+      uniffi_test_live_buffer_count: {
+        args: [],
+        ret: FfiType.Int32,
+        hasRustCallStatus: true,
+      },
+      uniffi_test_live_buffer_bytes: {
+        args: [],
+        ret: FfiType.Int64,
+        hasRustCallStatus: true,
+      },
+    },
+  });
+}
+
+const live = (nm) => ({
+  count: nm.uniffi_test_live_buffer_count({ code: 0 }),
+  bytes: Number(nm.uniffi_test_live_buffer_bytes({ code: 0 })),
+});
+
+test("freeing a plain JS Uint8Array is refused, not passed to the allocator", () => {
+  const nm = openModule();
+  // A view the runtime never handed out carries no marker, so its capacity is unknown
+  // and its memory is V8's. Refuse rather than guess.
+  assert.throws(
+    () => nm.rustbuffer_free(new Uint8Array(64)),
+    /unowned Uint8Array/,
+    "an unmarked view must be refused",
+  );
+  // A zero-length foreign view is refused too — it is still not ours.
+  assert.throws(
+    () => nm.rustbuffer_free(new Uint8Array(0)),
+    /unowned Uint8Array/,
+  );
+});
+
+test("a returned buffer whose capacity equals its length is still released", () => {
+  // `capacity == byteLength` is the case where the marker looks redundant. It is not:
+  // with an authoritative marker, skipping the write would make the view unfreeable.
+  const nm = openModule();
+  const before = live(nm);
+
+  const status = { code: 0 };
+  const view = nm.uniffi_test_fn_make_buffer(0x11, 32, status);
+  assert.strictEqual(status.code, 0);
+  assert.strictEqual(view.byteLength, 32);
+  nm.rustbuffer_free(view);
+
+  assert.deepStrictEqual(
+    live(nm),
+    before,
+    "the allocation must be fully released",
+  );
+});
+
+test("a returned buffer with spare capacity and no payload releases that capacity", () => {
+  // len == 0 with capacity > 0. A zero-length typed array cannot carry the data pointer
+  // forward, so the handoff must release the allocation itself: by the time a caller
+  // reaches `rustbuffer_free`, there is nothing left to work from.
+  const nm = openModule();
+  const before = live(nm);
+
+  const status = { code: 0 };
+  const view = nm.uniffi_test_rustbuffer_alloc(1024n, status);
+  assert.strictEqual(status.code, 0);
+  assert.strictEqual(view.byteLength, 0);
+  assert.deepStrictEqual(
+    live(nm),
+    before,
+    "spare capacity must already be released",
+  );
+
+  // Marked JS-owned, so cleanup is a no-op however often it runs.
+  nm.rustbuffer_free(view);
+  nm.rustbuffer_free(view);
+  assert.deepStrictEqual(live(nm), before);
+});
+
+test("rustbuffer_alloc(0) round-trips through free", () => {
+  const nm = openModule();
+  const before = live(nm);
+  const view = nm.rustbuffer_alloc(0);
+  assert.strictEqual(view.byteLength, 0);
+  nm.rustbuffer_free(view);
+  nm.rustbuffer_free(view);
+  assert.deepStrictEqual(live(nm), before);
+});
+
+test("repeated frees of a live returned buffer do not double free", () => {
+  const nm = openModule();
+  const before = live(nm);
+
+  const status = { code: 0 };
+  const view = nm.uniffi_test_fn_make_buffer(0x22, 128, status);
+  assert.strictEqual(status.code, 0);
+
+  nm.rustbuffer_free(view);
+  assert.deepStrictEqual(live(nm), before);
+  // The marker is reset on release, so the second call is a no-op rather than a
+  // double free of the same pointer.
+  nm.rustbuffer_free(view);
+  nm.rustbuffer_free(view);
+  assert.deepStrictEqual(live(nm), before);
+});


### PR DESCRIPTION
> Stacked on #440 — the base is `fix/napi-trampoline-cache`, so this PR's diff is
> just its own change. GitHub will retarget it to `main` when #440 merges.

### Reachability

**Not reachable through the generated wrappers.** This is hardening, plus an enabler — worth
knowing when prioritising it against the rest of the stack.

| what it fixes | reachable by |
|---|---|
| freeing an unmarked view against `byteLength` (heap corruption) | only code that drives the native module directly — codegen frees returned buffers, which always carry a marker |
| `len == 0, capacity > 0` leaking its whole allocation | nothing, via the wrappers — uniffi always writes a tag or length prefix, so `len > 0` |

So no user-visible leak is fixed here — this is hardening. What it buys is that the
ownership marker means exactly one thing: absent is *always* "not ours, refuse", never
"probably fine, guess the capacity from `byteLength`". That invariant is what makes the rest
of the scheme legible, and #442 applies the same idea one level up by making the symbol a
required parameter rather than an `Option` a caller can decline.

**This is not a prerequisite for #442**, to be clear. #442 sits on top and therefore calls
`capacity_symbol.get(...)?`, but that `?` is a consequence of the stacking, not a dependency:
drop it and the same code compiles against the previous `Option<u64>` signature, which is
exactly what the adoption path on `main` already does. If you would rather take #442 alone,
it can be restacked onto #440 with a couple of lines changed.

The two fixes here do have to travel together, though: the marker cannot be made
authoritative while either remains. Refusing an unmarked view is only safe once every view
the runtime hands out carries a marker, which is why the lift path and `rustbuffer_alloc(0)`
are changed in the same commit.

One flavour note, since the runtimes are meant to stay comparable: this is napi-only
hardening rather than parity work. JSI's `rustbuffer_free` does not treat an absent marker
as authoritative, and its `rustbuffer_alloc` still stamps conditionally (`if (rb.capacity >
0)`). Neither is a bug there, but napi ends up stricter than JSI on this detail.

### Problem

`rustbuffer_free` recovered the capacity as `marker.unwrap_or(byteLength)`, so a view
with **no** ownership marker was freed against its `byteLength` — handing a pointer into
V8's heap to Rust's allocator. Silent heap corruption.

Nothing in codegen does that: it frees returned buffers, and those carry a marker. But
`rustbuffer_free` is on the native module's public surface, and a defensive
`rustbuffer_free(someUint8Array)` from a hand-written caller was enough to trigger it.

The fallback existed to cover views the runtime handed out *without* a marker — which is
the real bug. So the fix is to always mark, and make the marker authoritative:

| marker | meaning | `rustbuffer_free` |
|---|---|---|
| absent | not the library's memory | **refuse** |
| `0` | ours, nothing left to free | no-op |
| `> 0` | the true allocation capacity | free against it, then reset to `0` |

`> 0` may exceed `byteLength` (that is `rb.len`, so converters decoding the whole view
see only the message bytes). Resetting to `0` on release makes repeated cleanup a no-op
rather than a double free.

### Two views that previously went unmarked

Both had to be fixed, or making the marker authoritative would reject them:

- **lift handoffs where `capacity == byteLength`** — these relied on recovering the
  capacity from `byteLength`;
- **`rustbuffer_alloc(0)`**, whose capacity is legitimately `0`. The existing suite
  caught this one (`empty rustbuffer_alloc view is accounted for`).

Marking every handed-off view means the marker now appears on buffers callers compare
structurally, so it is defined **non-enumerable** — `assert.deepStrictEqual(view, new
Uint8Array([...]))` compares enumerable own symbol properties and would otherwise break
for every caller. The lookup also moves to `napi_has_own_property`: a prototype-chain hit
would have taken the plain-set branch and created an enumerable own property shadowing it.

`CapacitySymbol::get` now returns `Result<Option<u64>>` instead of folding napi failures
into `None`. Absence now means "refuse to free", so mistaking a failed lookup for absence
would silently leak rather than corrupt.

### A real leak in the same path

A returned buffer with `len == 0` and `capacity > 0` leaked its whole allocation: a
zero-length typed array cannot carry the data pointer forward, and free short-circuited
on `byteLength == 0`, so nothing ever released it. The handoff now releases that spare
capacity immediately, and also frees the buffer on its own error paths — which previously
leaked whenever creating the view failed.

### Tests

Five new tests in `rust_buffer_free_safety.test.mjs`: a foreign view is refused rather
than freed, a return with `capacity == byteLength` is still released, spare capacity is
released, `rustbuffer_alloc(0)` round-trips, and repeated frees do not double free. They
assert against the fixture's exact live-allocation counters, not RSS.

### Provenance

The substance here — marker-keyed free, always stamping on lift, releasing spare
capacity on empty returns, `get` returning `Result`, the non-enumerable marker, and the
error-path frees — comes from @injaneity's work in #417, and the commit is co-authored
accordingly. That PR paired these fixes with an ownership-model change we decided against
(it made `rustbuffer_alloc` hand out V8-owned memory and copied every argument), so they
are extracted here on top of the existing adoption model instead. #417's Electron support
is still wanted and unaffected by this.

### Verification

macOS/arm64 Node 26: **106/106** runtime tests, **48/48** napi fixture tests, clippy
clean, `cargo fmt --check` clean. Linux via CI.
