### PR TITLE
fix(napi): adopt library-owned buffers on the callback path

### DIFF
--- a/fixtures/strict-byte-arrays/src/lib.rs
+++ b/fixtures/strict-byte-arrays/src/lib.rs
@@ -97,4 +97,31 @@ pub fn live_big_alloc_bytes() -> u64 {
     LIVE_BIG_BYTES.load(Ordering::Relaxed).max(0) as u64
 }
 
+// --- RustBuffer-return leak probe (callback direction) -----------------------
+//
+// The probe above only exercises the *argument* direction: JS lowers a buffer and
+// Rust consumes it. The mirror case is a foreign callback that *returns* a buffer,
+// where the foreign side lowers and Rust consumes what comes back.
+//
+// That direction had no coverage in any flavour, because this fixture had no
+// callback interface — which is how a runtime could copy instead of adopt on the
+// callback path and still pass a green suite. The counter makes it exact: if the
+// foreign-lowered buffer is orphaned, the live count climbs by one per call.
+#[uniffi::export(with_foreign)]
+pub trait BytesProducer: Send + Sync {
+    /// Returns a byte array the foreign side lowers into a `RustBuffer`. Rust owns
+    /// what comes back and drops it, so a balanced implementation leaves the live
+    /// count unchanged.
+    fn produce(&self, size: u32) -> Vec<u8>;
+}
+
+#[uniffi::export]
+/// Calls `produce` once and reports the length, dropping the returned buffer. Any
+/// growth in `live_big_alloc_count` across a loop of these is a buffer the foreign
+/// lowering allocated and nobody freed.
+pub fn consume_produced_bytes(producer: std::sync::Arc<dyn BytesProducer>, size: u32) -> u32 {
+    let bytes = producer.produce(size);
+    bytes.len() as u32
+}
+
 uniffi::setup_scaffolding!();

--- a/fixtures/strict-byte-arrays/tests/bindings/test_leak.ts
+++ b/fixtures/strict-byte-arrays/tests/bindings/test_leak.ts
@@ -9,19 +9,32 @@
 // To run:
 //   cargo test -p uniffi-fixture-strict-byte-arrays -- jsi::test_leak
 //
-// `measureBytes` takes a byte array (lowered via `rustbuffer_alloc`) and returns
-// a scalar, so only the argument direction allocates a big buffer. The fixture's
+// Both directions are covered:
+//
+//   * `measureBytes` takes a byte array (lowered via `rustbuffer_alloc`) and
+//     returns a scalar, so only the *argument* direction allocates a big buffer.
+//   * `consumeProducedBytes` calls back into a foreign `BytesProducer` whose
+//     `produce` returns a byte array, so the foreign side lowers and Rust consumes
+//     what comes back. This is the *callback-return* direction, and it had no
+//     coverage in any flavour until now — a runtime could copy instead of adopt
+//     there and still pass a green suite, which is exactly what napi did. The fixture's
 // counting allocator (see src/lib.rs) tracks live allocations >= 64 KiB, and we
 // assert the live count is unchanged across a loop of calls. If the runtime
 // copies the lowered view instead of adopting it, the allocation from
 // `rustbuffer_alloc` is orphaned — codegen never frees a lowered argument — and
 // the count climbs by exactly one per call.
-import {
+import myModule, {
   measureBytes,
+  consumeProducedBytes,
   liveBigAllocCount,
   liveBigAllocBytes,
+  type BytesProducer,
 } from "@/generated/uniffi_strict_byte_arrays";
 import { test } from "@/asserts";
+
+// The fixture now declares a callback interface, so its vtable has to be registered
+// before Rust can call back into JS.
+myModule.initialize();
 import "@/polyfills";
 
 // 256 KiB is comfortably above the allocator's 64 KiB threshold, so a leak is
@@ -55,5 +68,40 @@ test("lowered RustBuffer argument is not leaked across FFI calls", (t) => {
     beforeBytes,
     afterBytes,
     `leaked ${afterBytes - beforeBytes} bytes over ${ITERATIONS} calls`,
+  );
+});
+
+test("buffer returned from a foreign callback is not leaked", (t) => {
+  // The foreign side lowers `produce`'s return value through `rustbuffer_alloc`,
+  // and Rust owns what comes back. If the runtime copies that view instead of
+  // adopting it, the original allocation is orphaned — nothing frees a lowered
+  // return value — and the live count climbs by exactly one per call.
+  const producer: BytesProducer = {
+    produce: (size: number) => new Uint8Array(size),
+  };
+
+  // Warm up so one-time allocations are inside the `before` snapshot.
+  consumeProducedBytes(producer, PAYLOAD);
+
+  const beforeCount = liveBigAllocCount();
+  const beforeBytes = Number(liveBigAllocBytes());
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const len = consumeProducedBytes(producer, PAYLOAD);
+    t.assertEqual(len, PAYLOAD);
+  }
+
+  const afterCount = liveBigAllocCount();
+  const afterBytes = Number(liveBigAllocBytes());
+
+  t.assertEqual(
+    beforeCount,
+    afterCount,
+    `leaked ${afterCount - beforeCount} big buffers over ${ITERATIONS} callback returns`,
+  );
+  t.assertEqual(
+    beforeBytes,
+    afterBytes,
+    `leaked ${afterBytes - beforeBytes} bytes over ${ITERATIONS} callback returns`,
   );
 });

--- a/runtimes/napi/fixtures/test_lib/src/lib.rs
+++ b/runtimes/napi/fixtures/test_lib/src/lib.rs
@@ -949,3 +949,27 @@ pub extern "C" fn uniffi_test_fn_get_scalar_echo_thread_result(status: &mut Rust
     status.code = 0;
     SCALAR_ECHO_THREAD_RESULT.load(Ordering::SeqCst)
 }
+
+// --- Callback that RETURNS a RustBuffer ---
+//
+// Mirrors uniffi's contract for a callback interface method returning a non-string
+// type: the foreign side lowers its return value into a `RustBuffer` and Rust, as
+// the caller, takes ownership and frees it. This is the path where a lowered value
+// used to be orphaned — the runtime copied the foreign buffer instead of adopting
+// it, and nothing ever freed the original.
+pub type BufferReturningCallback = extern "C" fn(u64, &mut RustCallStatus) -> RustBuffer;
+
+#[no_mangle]
+pub extern "C" fn uniffi_test_fn_call_buffer_returning_callback(
+    cb: BufferReturningCallback,
+    handle: u64,
+    status: &mut RustCallStatus,
+) -> u32 {
+    status.code = 0;
+    let mut cb_status = new_cb_status();
+    let rb = cb(handle, &mut cb_status);
+    let len = rb.len as u32;
+    // Rust owns what the callback returned.
+    free_buffer(rb);
+    len
+}

--- a/runtimes/napi/src/call/mod.rs
+++ b/runtimes/napi/src/call/mod.rs
@@ -51,7 +51,7 @@ pub(crate) fn call_ffi_function(
     module: &Arc<Module>,
     arg_types: &[FfiTypeDesc],
     has_rust_call_status: bool,
-    registration: &crate::register::Registration,
+    registration: &Arc<crate::register::Registration>,
 ) -> Result<JsUnknown> {
     let declared_arg_count = arg_types.len();
 
@@ -72,7 +72,7 @@ pub(crate) fn call_ffi_function(
                         env.raw(),
                         js_val,
                         module.rb_ops().from_bytes_ptr,
-                        Some(&registration.capacity_symbol),
+                        &registration.capacity_symbol,
                     )?
                 };
                 slot::write_rust_buffer(slot, rust_buffer);
@@ -82,7 +82,8 @@ pub(crate) fn call_ffi_function(
                     unreachable!("guard ensures inner is Struct");
                 };
                 let js_obj = unsafe { JsObject::from_raw(env.raw(), js_val.raw())? };
-                let struct_ptr = vtable::build_vtable_struct(env, module, struct_name, &js_obj)?;
+                let struct_ptr =
+                    vtable::build_vtable_struct(env, module, struct_name, &js_obj, registration)?;
                 slot::write_pointer(slot, struct_ptr);
             }
             FfiTypeDesc::Callback(cb_name) => {
@@ -117,8 +118,13 @@ pub(crate) fn call_ffi_function(
                         // the declared arg type is `Callback`, so a non-function here is a
                         // caller error surfaced as a JS exception.
                         let js_fn = unsafe { napi::JsFunction::from_raw(env.raw(), raw_fn_val)? };
-                        let user_data =
-                            callback::create_callback_user_data(env, js_fn, cb_name, module)?;
+                        let user_data = callback::create_callback_user_data(
+                            env,
+                            js_fn,
+                            cb_name,
+                            module,
+                            registration,
+                        )?;
                         let fn_ptr = module
                             .make_callback_trampoline(
                                 cb_name,

--- a/runtimes/napi/src/callback/marshal.rs
+++ b/runtimes/napi/src/callback/marshal.rs
@@ -64,6 +64,7 @@ pub fn marshal_js_struct_to_bytes(
     struct_name: &str,
     module: &Arc<Module>,
     rb_from_bytes_ptr: *const c_void,
+    registration: &Arc<crate::register::Registration>,
 ) -> Result<Vec<u8>> {
     let struct_def = module
         .spec_structs()
@@ -84,6 +85,7 @@ pub fn marshal_js_struct_to_bytes(
             slot,
             module,
             rb_from_bytes_ptr,
+            registration,
         )?;
     }
     Ok(buf)
@@ -97,6 +99,7 @@ fn marshal_field_to_bytes(
     slot: &mut [u8],
     module: &Arc<Module>,
     rb_from_bytes_ptr: *const c_void,
+    registration: &Arc<crate::register::Registration>,
 ) -> Result<()> {
     match field_type {
         FfiTypeDesc::UInt8 => {
@@ -142,16 +145,12 @@ fn marshal_field_to_bytes(
             slot::write_f64(slot, n.get_double()?);
         }
         FfiTypeDesc::RustBuffer => {
-            // No capacity symbol in scope on the callback path, so this keeps the copy
-            // behavior. Always memory-safe, but it means a `rustbuffer_alloc` view lowered
-            // as a callback argument is still orphaned. See the note in
-            // `js_uint8array_to_rust_buffer`.
             let rb = unsafe {
                 napi_utils::js_uint8array_to_rust_buffer(
                     env.raw(),
                     js_val,
                     rb_from_bytes_ptr,
-                    None,
+                    &registration.capacity_symbol,
                 )?
             };
             slot::write_rust_buffer(slot, rb);
@@ -159,8 +158,14 @@ fn marshal_field_to_bytes(
         FfiTypeDesc::Struct(name) => {
             // Recursively marshal nested struct
             let nested_obj: JsObject = js_val.try_into()?;
-            let nested_bytes =
-                marshal_js_struct_to_bytes(env, &nested_obj, name, module, rb_from_bytes_ptr)?;
+            let nested_bytes = marshal_js_struct_to_bytes(
+                env,
+                &nested_obj,
+                name,
+                module,
+                rb_from_bytes_ptr,
+                registration,
+            )?;
             slot[..nested_bytes.len()].copy_from_slice(&nested_bytes);
         }
         FfiTypeDesc::RustCallStatus => {
@@ -186,7 +191,7 @@ fn marshal_field_to_bytes(
                         env.raw(),
                         err_val,
                         rb_from_bytes_ptr,
-                        None,
+                        &registration.capacity_symbol,
                     )?
                 };
                 let u64_size = std::mem::size_of::<u64>();
@@ -206,8 +211,13 @@ fn marshal_field_to_bytes(
         FfiTypeDesc::Callback(cb_name) => {
             // Callback-typed struct field: create a trampoline and write the fn pointer.
             let js_fn = unsafe { napi::JsFunction::from_raw(env.raw(), js_val.raw())? };
-            let user_data =
-                crate::callback::create_callback_user_data(env, js_fn, cb_name, module)?;
+            let user_data = crate::callback::create_callback_user_data(
+                env,
+                js_fn,
+                cb_name,
+                module,
+                registration,
+            )?;
             let fn_ptr = module
                 .make_callback_trampoline(
                     cb_name,
@@ -254,6 +264,7 @@ fn marshal_arg_to_bytes(
     desc: &FfiTypeDesc,
     js_val: JsUnknown,
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) -> Result<Vec<u8>> {
     match desc {
         FfiTypeDesc::UInt8 => {
@@ -305,7 +316,7 @@ fn marshal_arg_to_bytes(
                     env.raw(),
                     js_val,
                     rb_from_bytes_ptr,
-                    None,
+                    &registration.capacity_symbol,
                 )?
             };
             // Transmute RustBufferC to its raw bytes.
@@ -316,7 +327,7 @@ fn marshal_arg_to_bytes(
         FfiTypeDesc::Struct(name) => {
             let rb_from_bytes_ptr = module.rb_ops().from_bytes_ptr;
             let js_obj: JsObject = js_val.try_into()?;
-            marshal_js_struct_to_bytes(env, &js_obj, name, module, rb_from_bytes_ptr)
+            marshal_js_struct_to_bytes(env, &js_obj, name, module, rb_from_bytes_ptr, registration)
         }
         FfiTypeDesc::VoidPointer
         | FfiTypeDesc::Callback(_)
@@ -351,6 +362,7 @@ pub fn create_fn_pointer_wrapper(
     fn_ptr: *const c_void,
     callback_name: &str,
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) -> Result<JsFunction> {
     // Validate that the callback exists in the spec.
     let cb_def = module
@@ -362,6 +374,7 @@ pub fn create_fn_pointer_wrapper(
     // Store fn_ptr as usize so the closure is Send (required by create_function_from_closure).
     let fn_ptr_val = fn_ptr as usize;
     let module_ref = Arc::clone(module);
+    let reg_ref = Arc::clone(registration);
     let cb_name = callback_name.to_string();
 
     let js_func = env.create_function_from_closure("fn_pointer_wrapper", move |ctx| {
@@ -370,7 +383,7 @@ pub fn create_fn_pointer_wrapper(
         let mut arg_buffers: Vec<Vec<u8>> = Vec::with_capacity(arg_types.len());
         for (i, desc) in arg_types.iter().enumerate() {
             let js_val = ctx.get::<JsUnknown>(i)?;
-            let buf = marshal_arg_to_bytes(ctx.env, desc, js_val, &module_ref)?;
+            let buf = marshal_arg_to_bytes(ctx.env, desc, js_val, &module_ref, &reg_ref)?;
             arg_buffers.push(buf);
         }
 

--- a/runtimes/napi/src/callback/mod.rs
+++ b/runtimes/napi/src/callback/mod.rs
@@ -104,6 +104,12 @@ struct CallbackUserData {
     tsfn: Mutex<Option<ThreadsafeFunction<DispatchPayload, ErrorStrategy::Fatal>>>,
     /// Reference to the Module, needed for fn_pointer wrapping (Callback-typed args).
     module: Arc<Module>,
+    /// Per-registration state, so marshalling a `RustBuffer` on the callback path can
+    /// reach the ownership marker and therefore *adopt* a library-owned buffer rather
+    /// than copy it. Copying orphaned the original: generated callback code lowers its
+    /// return value through `rustbuffer_alloc`, and nothing frees a lowered value, so
+    /// each invocation leaked one whole serialized payload.
+    registration: Arc<crate::register::Registration>,
 }
 
 // SAFETY: `CallbackUserData` is shared across threads. This is sound because:
@@ -112,6 +118,9 @@ struct CallbackUserData {
 // - `tsfn` is designed for cross-thread use and protected by a Mutex.
 // - `arg_types`, `ret_type`, `arg_layout`, `ret_size` are immutable after construction.
 // - `module` is an `Arc<Module>` which is Send+Sync.
+// - `registration` holds napi Symbols that, like `raw_env`/`fn_ref`, are only touched on
+//   `owner_thread` — marshalling always runs there, on the same-thread path or after the
+//   `tsfn` dispatch.
 unsafe impl Send for CallbackUserData {}
 unsafe impl Sync for CallbackUserData {}
 
@@ -201,7 +210,8 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
         // SAFETY: `args` points to a buffer of `arg_layout.total_size` bytes.
         // `slot.offset` and `slot.size` are within bounds.
         let arg_bytes = unsafe { std::slice::from_raw_parts(args.add(slot.offset), slot.size) };
-        let js_val = match read_arg_bytes_to_js(&env, desc, arg_bytes, &ud.module) {
+        let js_val = match read_arg_bytes_to_js(&env, desc, arg_bytes, &ud.module, &ud.registration)
+        {
             Ok(v) => v,
             Err(_e) => {
                 #[cfg(debug_assertions)]
@@ -275,6 +285,7 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
                             out_return_ptr,
                             &ud.ret_type,
                             &ud.module,
+                            &ud.registration,
                         );
                     }
                 }
@@ -288,6 +299,7 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
                         js_ret,
                         out_return_ptr as *mut u8,
                         &ud.module,
+                        &ud.registration,
                     );
                 }
             }
@@ -331,6 +343,7 @@ pub extern "C" fn on_js_thread(args: *const u8, ret: *mut u8, user_data: *const 
                             js_ret,
                             ret_bytes,
                             &ud.module,
+                            &ud.registration,
                         );
                     }
                 }
@@ -448,6 +461,7 @@ pub fn create_callback_user_data(
     js_fn: napi::JsFunction,
     callback_name: &str,
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) -> napi::Result<*const c_void> {
     let def = module
         .spec_callbacks()
@@ -500,6 +514,7 @@ pub fn create_callback_user_data(
         ret_size,
         tsfn: Mutex::new(None),
         module: Arc::clone(module),
+        registration: Arc::clone(registration),
     });
     let userdata_ptr = Box::into_raw(userdata);
 
@@ -563,6 +578,7 @@ fn read_arg_bytes_to_js(
     desc: &FfiTypeDesc,
     arg_bytes: &[u8],
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) -> napi::Result<napi::JsUnknown> {
     let rb_free_ptr = module.rb_ops().free_ptr;
     match desc {
@@ -610,7 +626,13 @@ fn read_arg_bytes_to_js(
         FfiTypeDesc::Callback(cb_name) => {
             // Read the function pointer from bytes and wrap it as a callable JS function.
             let fn_ptr = slot::read_pointer(arg_bytes) as *const c_void;
-            let js_fn = self::marshal::create_fn_pointer_wrapper(env, fn_ptr, cb_name, module)?;
+            let js_fn = self::marshal::create_fn_pointer_wrapper(
+                env,
+                fn_ptr,
+                cb_name,
+                module,
+                registration,
+            )?;
             Ok(js_fn.into_unknown())
         }
         FfiTypeDesc::VoidPointer | FfiTypeDesc::Reference(_) | FfiTypeDesc::MutReference(_) => {
@@ -635,6 +657,7 @@ unsafe fn write_js_return_to_bytes(
     js_val: napi::JsUnknown,
     ret_bytes: &mut [u8],
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) -> napi::Result<()> {
     let raw_env = env.raw();
     let rb_from_bytes_ptr = module.rb_ops().from_bytes_ptr;
@@ -696,8 +719,12 @@ unsafe fn write_js_return_to_bytes(
             // Read Uint8Array -> rustbuffer_from_bytes -> write RustBufferC bytes.
             // Truncating copy: caller may pass a `ret_bytes` smaller than RustBufferC
             // when the return slot is a different shape; preserve historical behavior.
-            let rb =
-                napi_utils::js_uint8array_to_rust_buffer(raw_env, js_val, rb_from_bytes_ptr, None)?;
+            let rb = napi_utils::js_uint8array_to_rust_buffer(
+                raw_env,
+                js_val,
+                rb_from_bytes_ptr,
+                &registration.capacity_symbol,
+            )?;
             let rb_bytes = slot::rust_buffer_to_bytes(&rb);
             let copy_len = rb_bytes.len().min(ret_bytes.len());
             ret_bytes[..copy_len].copy_from_slice(&rb_bytes[..copy_len]);
@@ -725,6 +752,7 @@ unsafe fn write_js_value_to_pointer(
     js_val: napi::JsUnknown,
     dest: *mut u8,
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) {
     // For Struct types, use fn_pointer::marshal_js_struct_to_bytes which handles
     // the full C struct layout (slot_size_align doesn't support Struct types).
@@ -737,6 +765,7 @@ unsafe fn write_js_value_to_pointer(
                 struct_name,
                 module,
                 rb_from_bytes_ptr,
+                registration,
             ) {
                 std::ptr::copy_nonoverlapping(bytes.as_ptr(), dest, bytes.len());
             }
@@ -754,7 +783,7 @@ unsafe fn write_js_value_to_pointer(
     // Max non-struct size is RustBufferC (24 bytes: {u64, u64, *mut u8}).
     let mut buf = [0u8; std::mem::size_of::<RustBufferC>()];
     debug_assert!(size <= buf.len());
-    if write_js_return_to_bytes(env, desc, js_val, &mut buf[..size], module).is_ok() {
+    if write_js_return_to_bytes(env, desc, js_val, &mut buf[..size], module, registration).is_ok() {
         std::ptr::copy_nonoverlapping(buf.as_ptr(), dest, size);
     }
 }
@@ -775,6 +804,7 @@ unsafe fn write_uniffi_result(
     out_return_ptr: *mut c_void,
     ret_type: &FfiTypeDesc,
     module: &Arc<Module>,
+    registration: &Arc<crate::register::Registration>,
 ) {
     let rb_from_bytes_ptr = module.rb_ops().from_bytes_ptr;
 
@@ -820,6 +850,7 @@ unsafe fn write_uniffi_result(
                     pointee,
                     out_return_ptr as *mut u8,
                     module,
+                    registration,
                 );
             }
         }

--- a/runtimes/napi/src/callback/vtable.rs
+++ b/runtimes/napi/src/callback/vtable.rs
@@ -35,6 +35,7 @@ pub fn build_vtable_struct(
     module: &Arc<Module>,
     struct_name: &str,
     js_obj: &JsObject,
+    registration: &Arc<crate::register::Registration>,
 ) -> Result<*const c_void> {
     let struct_def = module
         .spec_structs()
@@ -55,7 +56,7 @@ pub fn build_vtable_struct(
         };
 
         let js_fn: napi::JsFunction = js_obj.get_named_property(&field.name)?;
-        let user_data = create_callback_user_data(env, js_fn, cb_name, module)?;
+        let user_data = create_callback_user_data(env, js_fn, cb_name, module, registration)?;
 
         let fn_ptr = module
             .make_callback_trampoline(

--- a/runtimes/napi/src/napi_utils.rs
+++ b/runtimes/napi/src/napi_utils.rs
@@ -497,13 +497,16 @@ pub unsafe fn create_external_uint8array(
 /// - **V8-owned arrays**, i.e. any ordinary `Uint8Array` from JS. These are not ours to give
 ///   away, so they are **copied** into a fresh library allocation via `rustbuffer_from_bytes`.
 ///
-/// The capacity hint is the discriminator: the runtime knows a buffer's capacity precisely
-/// when the library allocated it. On adoption the hint is reset to `0`, which makes any later
+/// The capacity marker is the discriminator: the runtime knows a buffer's capacity precisely
+/// when the library allocated it. On adoption the marker is reset to `0`, which makes any later
 /// `rustbuffer_free(view)` a no-op rather than a double free, since `free_rustbuffer` skips
 /// zero-capacity buffers.
 ///
-/// Passing `None` for `capacity_symbol` forces the copy path. Call sites that have no symbol
-/// in scope use that, which is always memory-safe — it is the pre-adoption behavior.
+/// The symbol is a required parameter, deliberately. It used to be an `Option`, and a caller
+/// with no symbol in scope could pass `None` to force the copy path — memory-safe in itself,
+/// but it silently orphaned every library-owned view that reached it, because nothing else
+/// frees a lowered argument. Requiring the symbol makes that a compile error instead of a
+/// leak, so a marshalling path added later cannot opt out by accident.
 ///
 /// # Safety
 ///
@@ -514,7 +517,7 @@ pub unsafe fn js_uint8array_to_rust_buffer(
     raw_env: napi::sys::napi_env,
     js_val: JsUnknown,
     rb_from_bytes_ptr: *const c_void,
-    capacity_symbol: Option<&CapacitySymbol>,
+    capacity_symbol: &CapacitySymbol,
 ) -> napi::Result<RustBufferC> {
     let raw_val = js_val.raw();
     let (data_ptr, length) = read_typedarray_data(raw_env, raw_val).ok_or_else(|| {
@@ -527,25 +530,24 @@ pub unsafe fn js_uint8array_to_rust_buffer(
         return rustbuffer_from_raw_bytes(data_ptr, length, rb_from_bytes_ptr);
     }
 
-    if let Some(symbol) = capacity_symbol {
-        if let Some(capacity) = symbol.get(raw_env, raw_val)? {
-            if capacity == 0 {
-                // The hint exists but has been zeroed, so this view was already adopted and
-                // its memory has since been freed by the callee. Reading it would be a
-                // use-after-free, so refuse rather than hand the callee a dangling pointer.
-                return Err(napi::Error::from_reason(
-                    "RustBuffer argument was already consumed by a previous FFI call".to_string(),
-                ));
-            }
-            symbol.set(raw_env, raw_val, 0)?;
-            return Ok(RustBufferC {
-                capacity,
-                len: length as u64,
-                data: data_ptr as *mut u8,
-            });
+    if let Some(capacity) = capacity_symbol.get(raw_env, raw_val)? {
+        if capacity == 0 {
+            // The marker exists but has been zeroed, so this view was already adopted and
+            // its memory has since been freed by the callee. Reading it would be a
+            // use-after-free, so refuse rather than hand the callee a dangling pointer.
+            return Err(napi::Error::from_reason(
+                "RustBuffer argument was already consumed by a previous FFI call".to_string(),
+            ));
         }
+        capacity_symbol.set(raw_env, raw_val, 0)?;
+        return Ok(RustBufferC {
+            capacity,
+            len: length as u64,
+            data: data_ptr as *mut u8,
+        });
     }
 
+    // No marker: an ordinary V8-backed array from JS, which is not ours to give away.
     rustbuffer_from_raw_bytes(data_ptr, length, rb_from_bytes_ptr)
 }
 

--- a/runtimes/napi/tests/callback_buffer_adoption.test.mjs
+++ b/runtimes/napi/tests/callback_buffer_adoption.test.mjs
@@ -1,0 +1,157 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+// A buffer a callback returns must be adopted, not copied.
+//
+// Generated callback code lowers a non-string return value through
+// `rustbuffer_alloc`, which hands back a library-owned buffer, and then passes that
+// view out as the callback's result. Nothing frees a lowered value — codegen frees
+// returned buffers, never lowered ones — so if the runtime *copies* the view into a
+// second allocation, the original is orphaned and every invocation leaks one whole
+// serialized payload. That was #432's documented remaining limitation: no capacity
+// marker was reachable from the callback path, so it always copied.
+//
+// The marshalling path now carries the registration, so it adopts exactly what is
+// adoptable: a marked (library-owned) view is handed straight to the callee, an
+// ordinary V8 array is still copied.
+//
+// These assertions use the fixture's exact live-allocation counters rather than RSS.
+// That matters here beyond the usual noise argument: much of the RSS growth around
+// external ArrayBuffers is reclaimed by V8 weak callbacks that only run once the
+// event loop turns, so an RSS measurement in a tight loop conflates a genuine
+// never-freed allocation with memory that is merely pending. A counter cannot be
+// fooled either way.
+import { test } from "node:test";
+import assert from "node:assert";
+import lib from "../lib.js";
+const { UniffiNativeModule, FfiType } = lib;
+import { libPath } from "./helpers/lib-path.mjs";
+
+function openModule() {
+  return UniffiNativeModule.open(libPath("uniffi_napi_test_lib")).register({
+    symbols: {
+      rustbuffer_alloc: "uniffi_test_rustbuffer_alloc",
+      rustbuffer_free: "uniffi_test_rustbuffer_free",
+      rustbuffer_from_bytes: "uniffi_test_rustbuffer_from_bytes",
+    },
+    structs: {},
+    callbacks: {
+      buffer_returning_cb: {
+        args: [FfiType.UInt64],
+        ret: FfiType.RustBuffer,
+        hasRustCallStatus: true,
+      },
+    },
+    functions: {
+      uniffi_test_fn_call_buffer_returning_callback: {
+        args: [FfiType.Callback("buffer_returning_cb"), FfiType.UInt64],
+        ret: FfiType.UInt32,
+        hasRustCallStatus: true,
+      },
+      uniffi_test_live_buffer_count: {
+        args: [],
+        ret: FfiType.Int32,
+        hasRustCallStatus: true,
+      },
+      uniffi_test_live_buffer_bytes: {
+        args: [],
+        ret: FfiType.Int64,
+        hasRustCallStatus: true,
+      },
+    },
+  });
+}
+
+const live = (nm) => ({
+  count: nm.uniffi_test_live_buffer_count({ code: 0 }),
+  bytes: Number(nm.uniffi_test_live_buffer_bytes({ code: 0 })),
+});
+
+const PAYLOAD = 1024;
+const ITERATIONS = 64;
+
+test("a library-owned buffer returned from a callback is not orphaned", () => {
+  const nm = openModule();
+  const before = live(nm);
+
+  // Exactly what generated callback code does: lower the return value through
+  // `rustbuffer_alloc`, fill it, and hand the view back as the result.
+  const cb = (_handle) => {
+    const view = nm.rustbuffer_alloc(PAYLOAD);
+    view.fill(0x5a);
+    return view;
+  };
+
+  const status = { code: 0 };
+  for (let i = 0; i < ITERATIONS; i++) {
+    const len = nm.uniffi_test_fn_call_buffer_returning_callback(
+      cb,
+      1n,
+      status,
+    );
+    assert.strictEqual(status.code, 0);
+    assert.strictEqual(len, PAYLOAD, "Rust must see the whole payload");
+  }
+
+  const after = live(nm);
+  assert.strictEqual(
+    after.count,
+    before.count,
+    `orphaned ${after.count - before.count} buffers over ${ITERATIONS} callback returns`,
+  );
+  assert.strictEqual(
+    after.bytes,
+    before.bytes,
+    `orphaned ${after.bytes - before.bytes} bytes over ${ITERATIONS} callback returns`,
+  );
+});
+
+test("adoption is observable: the returned view's marker is cleared", () => {
+  const nm = openModule();
+  let captured;
+  const cb = (_handle) => {
+    captured = nm.rustbuffer_alloc(PAYLOAD);
+    captured.fill(1);
+    return captured;
+  };
+
+  const status = { code: 0 };
+  nm.uniffi_test_fn_call_buffer_returning_callback(cb, 1n, status);
+  assert.strictEqual(status.code, 0);
+
+  // A marker of 0 means the allocation was handed to the callee, so there is nothing
+  // left for us to free. Had the runtime copied instead, the marker would still hold
+  // the capacity and the original allocation would be unreachable.
+  const [marker] = Object.getOwnPropertySymbols(captured);
+  assert.ok(marker, "the lowered view should carry an ownership marker");
+  assert.strictEqual(captured[marker], 0n, "the view should have been adopted");
+});
+
+test("a plain JS Uint8Array returned from a callback is still copied", () => {
+  // Not ours to give away: V8 memory must never reach the library's allocator, so
+  // this path must keep copying. The copy is what the callee frees, so the books
+  // still balance.
+  const nm = openModule();
+  const before = live(nm);
+
+  const cb = (_handle) => {
+    const arr = new Uint8Array(PAYLOAD);
+    arr.fill(0x33);
+    return arr;
+  };
+
+  const status = { code: 0 };
+  for (let i = 0; i < ITERATIONS; i++) {
+    const len = nm.uniffi_test_fn_call_buffer_returning_callback(
+      cb,
+      1n,
+      status,
+    );
+    assert.strictEqual(status.code, 0);
+    assert.strictEqual(len, PAYLOAD);
+  }
+
+  assert.deepStrictEqual(live(nm), before, "the copies must all be released");
+});


### PR DESCRIPTION
> Stacked on #441, which is stacked on #440. The base is `napi/free-unmarked-safety`, so
> this PR's diff is just its own change; GitHub retargets as the stack merges.

### Reachability

**Reachable through the generated wrappers — affects any callback interface returning a
non-string type.**

Implementing a callback interface in TypeScript whose method returns a record, enum, `Vec`,
`Option` or byte array is ordinary usage, and each invocation leaked the whole serialized
payload. No native-module access required.

**The lowering was never the asymmetry** — worth being precise, because it is easy to read
this as though callback returns lower differently from arguments. They do not.
`CallBodyMacros.ts:79` (arguments) and `CallbackInterfaceImpl.ts:41` (callback returns) both
call `converter.lower(value, nativeModule().rustbuffer_alloc)`, with the same converters.
Both produce an identical library-owned view.

The difference was entirely in the two Rust consumers of that view:

| path | consumer on `main` | behaviour |
|---|---|---|
| argument | `call/mod.rs` → `Some(capacity_symbol)` | **adopts** — no orphan |
| callback return | `callback/mod.rs` → `None` | **copies** — original orphaned |

One exception worth stating, and this one *is* a lowering-side fact: **`String` returns were
never affected.** `FfiConverterString.lower()` ignores the allocator and returns
`TextEncoder`-produced V8 memory, so no library allocation exists to orphan on either path.
Only types whose converters actually call `alloc()` were leaking.

### Problem

Generated callback code lowers a non-string return value through `rustbuffer_alloc`,
which hands back a **library-owned** buffer, and passes that view out as the callback's
result. Nothing frees a lowered value — codegen frees returned buffers, never lowered
ones — so copying the view into a second allocation orphans the original. **One whole
serialized payload leaked per callback invocation.**

This is #432's documented remaining limitation. Adoption needs the ownership marker, and
no marker was reachable from the callback path, so it always copied.

### Fix

Carry the per-registration state into callback invocations: `CallbackUserData` holds an
`Arc<Registration>`, and the marshalling chain takes it as a parameter. Marshalling then
adopts exactly what is adoptable, because the marker decides:

| marker | action |
|---|---|
| `> 0` | library-owned — hand the allocation to the callee |
| `0` | already consumed — refuse, rather than pass a dangling pointer |
| absent | an ordinary V8 array — copy it; V8 memory must never reach the library's allocator |

Applies to all four sites that previously passed `None`: callback return values,
`RustBuffer` struct fields, `RustCallStatus.error_buf` (which generated code also lowers
through `rustbuffer_alloc`), and `RustBuffer` callback arguments.

**On the diff size:** this adds a parameter to nine signatures for what is conceptually
one piece of context. The marshallers sit several frames below any call site that has it,
so there is no shortcut short of a thread-local, which would be worse. Flagging it because
it is the bulk of the diff and none of it is interesting.

### Tests

The fixture had no callback that *returns* a buffer — plausibly why this survived — so one
is added. That makes the assertion exact: it reads the fixture's live-allocation counters
rather than sampling RSS. Reverting the callback-return site alone fails with

```
orphaned 64 buffers over 64 callback returns
```

one payload per invocation, counted rather than inferred. RSS would not do here even
setting noise aside: much of the growth around external ArrayBuffers is reclaimed by V8
weak callbacks that only run once the event loop turns, so a tight-loop RSS measurement
cannot distinguish a never-freed allocation from one merely pending.

Three tests: the library-owned return is not orphaned, adoption is observable (the view's
marker is cleared), and a plain `Uint8Array` return is still copied.

### What this deliberately does not change

Adoption is kept, so the contract it requires is kept with it: a view whose allocation has
been adopted is dangling, reading it afterwards is a use-after-free, and passing it twice
trips the "already consumed" guard.

That hazard is reachable only by code that reaches past the generated API into
`nativeModule()`. Every `lower(..., alloc)` call site is in generated code or
`typescript/src`; user-authored custom-type expressions receive the value, never the
allocator. So it is a footgun for this repo's own plumbing, not for consumers of generated
bindings.

The alternative — handing out V8-owned buffers and copying every argument — removes the
hazard entirely, but costs a copy per argument and measured **~25% on small returns on
Linux**, where aliasing is faster at every payload size. That trade was taken
deliberately; worth revisiting if the `-ffi` surface ever becomes a boundary third parties
build on.

### Cross-flavour coverage — and why this PR is not napi-only

`fixtures/strict-byte-arrays` had **no callback interface**, so no flavour tested the
callback-return direction at all. That absence is the reason this bug survived a green suite,
so the coverage goes in the shared fixture rather than only in the napi runtime's tests:

- a `BytesProducer` trait returning `Vec<u8>` — deliberately not `String`, since string
  lowering bypasses `rustbuffer_alloc` entirely and would test nothing;
- a `consume_produced_bytes` driver that calls it and drops the result;
- a second case in `test_leak.ts` asserting the fixture's counting allocator stays flat
  across 64 callback returns.

**The test is load-bearing.** Against the previous commit in the stack — the same runtime
without the adoption in this one — it fails with

```
leaked 64 big buffers over 64 callback returns: "1" !== "65"
```

one 256 KiB buffer per callback return. With the fix it passes on **jsi, wasm, wasm2 and
napi** (11/11 in that fixture's suite).

The other flavours already behaved correctly, and now say so in a test rather than by
inspection: jsi because `CallbackFunction.cpp` routes sync and async callback returns through
the same adopting conversion as arguments, and the wasm players because a lowered view *is*
linear memory, so there is no second allocation to orphan. This brings napi to parity and
pins it there.

That does mean this PR touches shared fixture code rather than being confined to
`runtimes/napi` — deliberately, for the reason above.

### Required, not optional

`js_uint8array_to_rust_buffer` also loses its `Option<&CapacitySymbol>` parameter. That
`None` is how this bug arrived: a marshalling path with no symbol in scope could pass it and
silently fall back to copying, orphaning every library-owned view that reached it. With all
four paths supplying the symbol there are no `None` callers left, so the parameter is
required and a path added later cannot opt out by accident — a compile error instead of a
leak.

Unmarked views are still copied, which is the correct handling for an ordinary V8-backed
array from JS. What is gone is a *consumer's* ability to force that path wholesale.

### Verification

macOS/arm64 Node 26: **109/109** runtime tests, **48/48** napi fixture tests, clippy
clean, `cargo fmt --check` clean. Linux via CI.
