### PR TITLE
Release 0.31.0-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,64 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-3...main
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-4...main
+
+---
+
+# 0.31.0-4
+
+## ✨ What's New ✨
+
+### 🕸️ A new WASM flavour: `wasm2`
+
+`uniffi-bindgen-react-native` gains a second WASM target, built on the same player architecture as the Node.js runtime shipped in 0.31.0-3. There is no shim crate to generate and no per-library glue to compile: `ubrn build wasm2` compiles your crate once for `wasm32-unknown-unknown`, and the bindgen reads the UniFFI metadata straight out of that same `.wasm`, so the second native-only cargo build disappears. The generated wrapper opens no module itself, which leaves it environment-neutral — the same bindings bundle for Node, browsers and React Native alike.
+
+Getting started: your crate needs to be a `cdylib`, link the new [`uniffi-runtime-wasm`](https://crates.io/crates/uniffi-runtime-wasm) helper crate, and enable the `uniffi_core` feature that drops `Send + Sync` on exported objects. `ubrn build wasm2` checks all three up front rather than letting cargo fail later. The player runtime is published to npm as [`@ubjs/wasm`](https://www.npmjs.com/package/@ubjs/wasm).
+
+- The player runtime, plus the `uniffi-runtime-wasm` helper crate consuming cdylibs link ([#418](https://github.com/jhugman/uniffi-bindgen-react-native/pull/418)).
+- Post-link processing of the wasm module — staging, a growable function table for callback trampolines, and dead-export stripping — and the crate-manifest queries the build validates ([#424](https://github.com/jhugman/uniffi-bindgen-react-native/pull/424)).
+- The `Wasm2` ABI flavour in the bindgen, exporting `PLAYER_DEFINITIONS` and `setNativeModule` from the per-module wrapper, with a generated `index.ts` doing the opening ([#425](https://github.com/jhugman/uniffi-bindgen-react-native/pull/425)).
+- The `ubrn build wasm2` and `ubrn generate wasm2` subcommands, aliased `web2` ([#426](https://github.com/jhugman/uniffi-bindgen-react-native/pull/426)).
+- The full fixture suite now runs against the flavour ([#427](https://github.com/jhugman/uniffi-bindgen-react-native/pull/427)) in CI ([#428](https://github.com/jhugman/uniffi-bindgen-react-native/pull/428)). As with the existing `wasm` flavour, the `futures` fixture is excluded: its `TimerFuture` wakes itself with `std::thread::spawn`, which single-threaded wasm32 cannot do.
+
+### Other new features
+
+- `bindings.typescript.forceAsync` in `uniffi.toml` gives chosen types and functions an `async`/`Promise` surface in TypeScript without making them async in Rust, so call sites can be migrated to `await` ahead of any real off-main-thread work. Set it to `true` for the whole crate, or to a list of names. See [the reference](https://jhugman.github.io/uniffi-bindgen-react-native/reference/uniffi-toml.html#forcing-an-async-surface) — in particular, it moves no work off the main thread ([#408](https://github.com/jhugman/uniffi-bindgen-react-native/pull/408)).
+- `bindings.typescript.strictTypeChecking` drops the `// @ts-nocheck` header from generated files so `tsc` checks them ([#408](https://github.com/jhugman/uniffi-bindgen-react-native/pull/408)).
+- Lifting and lowering now share a cursor instead of creating a `DataView` per value, which speeds up types made of many small reads and writes — large or deeply nested records, recursive enums — on every backend ([#413](https://github.com/jhugman/uniffi-bindgen-react-native/pull/413)).
+- The supported `uniffi-rs` version is relaxed from `=0.31.0` to `=0.31`, so 0.31.x point releases no longer need a matching release here ([#431](https://github.com/jhugman/uniffi-bindgen-react-native/pull/431)).
+
+## 🦊 What's Changed
+
+### Memory leaks fixed
+
+Four leaks affecting the N-API backend, present in 0.31.0-3. Upgrading is recommended for anyone making calls in a loop.
+
+- The `RustBuffer` returned by an **async** call was never freed, leaking one buffer per async call returning a string, byte array, record or list. The `wasm` flavour was unaffected ([#420](https://github.com/jhugman/uniffi-bindgen-react-native/pull/420)).
+- The N-API runtime allocated every `RustBuffer` **argument** twice and freed only one of the two, leaking a copy of each buffer passed into Rust — roughly 2.4 KB per frame. Lowered arguments are now library-owned rather than copied ([#432](https://github.com/jhugman/uniffi-bindgen-react-native/pull/432)). Thank you [@1egoman](https://github.com/1egoman)!
+- Callback trampolines were rebuilt on every call that marshalled a callback argument, instead of once per callback type as intended. `rust_future_poll` marshals its continuation on every poll, so **every `await` of a uniffi async function** paid this — each construction leaking a pinned `napi_ref`, a `CallbackUserData`, and a fresh `ThreadsafeFunction` libuv handle. Trampolines are now cached per callback type ([#440](https://github.com/jhugman/uniffi-bindgen-react-native/pull/440)).
+- Callback interfaces implemented in TypeScript leaked their whole serialized return value on each invocation, for any method returning a record, enum, `Vec`, `Option` or byte array. #432 taught the **argument** path to adopt library-owned buffers; the **callback-return** path still copied, orphaning the original. `String` returns were never affected — their converter produces `TextEncoder` memory rather than a library allocation ([#442](https://github.com/jhugman/uniffi-bindgen-react-native/pull/442)).
+
+Alongside those, the runtime now refuses to free a buffer it cannot prove the library owns, rather than falling back to guessing the capacity from `byteLength`. Generated code always marks the buffers it frees, so this is hardening rather than a user-visible fix ([#441](https://github.com/jhugman/uniffi-bindgen-react-native/pull/441)).
+
+### Fixes
+
+- N-API: `is_js_thread` is now answered per callback rather than per process. Calling a library from a Node `worker_threads` worker — which is what Vitest and Jest do by default — hung on the first call, taking down `worker.terminate()` and `process.exit()` with it. Every async call was affected, not just calls with a callback of your own ([#433](https://github.com/jhugman/uniffi-bindgen-react-native/pull/433), fixing [#436](https://github.com/jhugman/uniffi-bindgen-react-native/issues/436)). Thank you [@stupside](https://github.com/stupside)!
+- Escape `*/` in generated TypeScript docstrings. TypeScript doesn't allow nested block comments, so a `*/` in a doc comment closed the docstring early and the rest was parsed as code, failing the build ([#438](https://github.com/jhugman/uniffi-bindgen-react-native/pull/438)). Thank you [@liamiepops](https://github.com/liamiepops)!
+- Export the `./package.json` subpath from the root package. The generated Android CMake resolves the package root with `require.resolve('uniffi-bindgen-react-native/package.json')`, which failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` where Node enforces the `exports` map ([#407](https://github.com/jhugman/uniffi-bindgen-react-native/pull/407), fixing [#404](https://github.com/jhugman/uniffi-bindgen-react-native/issues/404)). Thank you [@DeyLak](https://github.com/DeyLak)!
+- Android: replace the deprecated `TurboReactPackage` with `BaseReactPackage` in the generated Kotlin and Java packages ([#411](https://github.com/jhugman/uniffi-bindgen-react-native/pull/411), fixing [#410](https://github.com/jhugman/uniffi-bindgen-react-native/issues/410)). Thank you [@ANAMASGARD](https://github.com/ANAMASGARD)!
+- Emit `opt-level = 3` rather than `opt-level = "3"` in the generated WASM template's release profile ([#401](https://github.com/jhugman/uniffi-bindgen-react-native/pull/401)). Thank you [@MrCreativ3001](https://github.com/MrCreativ3001)!
+
+### CI
+
+- The React Native compatibility matrix is now date-derived: React Native versions, `create-react-native-library` versions and runner images are tied together by date, covering the last 12 months of React Native. Per-PR checks run the latest versions only; the historical sweep runs nightly. This fixes the frequent build breakages caused by old React Native versions no longer building on `macos-latest` ([#419](https://github.com/jhugman/uniffi-bindgen-react-native/pull/419)).
+- Node 24 in CI ([#439](https://github.com/jhugman/uniffi-bindgen-react-native/pull/439)).
+
+## ⚠️ Breaking Changes
+
+- The N-API `RustBuffer` fixes change the contract between the generated bindings and the runtime: regenerate your bindings and upgrade [`@ubjs/node`](https://www.npmjs.com/package/@ubjs/node) together. A new runtime with old bindings, or the reverse, will not behave correctly ([#420](https://github.com/jhugman/uniffi-bindgen-react-native/pull/420), [#432](https://github.com/jhugman/uniffi-bindgen-react-native/pull/432)).
+
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-3...0.31.0-4
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-react-native"
-version = "0.31.0-3"
+version = "0.31.0-4"
 dependencies = [
  "anyhow",
  "askama 0.13.1",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-javascript"
-version = "0.31.0-3"
+version = "0.31.0-4"
 dependencies = [
  "uniffi_core",
  "wasm-bindgen",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-wasm"
-version = "0.31.0-3"
+version = "0.31.0-4"
 
 [[package]]
 name = "uniffi_bindgen"

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.31.0-3"
+version = "0.31.0-4"
 edition = "2021"
 
 [lib]

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -156,6 +156,6 @@
     "version": "0.50.2"
   },
   "dependencies": {
-    "@ubjs/core": "^0.31.0-3"
+    "@ubjs/core": "^0.31.0-4"
   }
 }

--- a/crates/uniffi-runtime-javascript/Cargo.toml
+++ b/crates/uniffi-runtime-javascript/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "uniffi-runtime-javascript"
-version = "0.31.0-3"
+version = "0.31.0-4"
 edition = "2021"
 authors = ["James Hugman <james@hugman.tv>"]
-description = "Javascript runtime for UniFFI-generated bindings"
+description = "wasm-bindgen runtime for UniFFI-generated Javascript bindings crates"
 license = "MPL-2.0"
 repository = "https://github.com/jhugman/uniffi-bindgen-react-native"
 readme = "README.md"

--- a/crates/uniffi-runtime-javascript/README.md
+++ b/crates/uniffi-runtime-javascript/README.md
@@ -30,9 +30,9 @@ The crate is split into features, one per Javascript runtime:
 
 - `wasm32`: uses `wasm-bindgen`.
 
-Future features may be:
-
-- `napi`: which uses `napi-rs` to provide node bindings.
+There is no feature here for the runtimes that call a `cdylib` directly. Those
+load your compiled library and call the C ABI uniffi already exports, so
+nothing needs to be linked into your crate.
 
 ## Generating `uniffi` based bindings for other Javascript Runtimes without this crate
 

--- a/docs/src/contributing/cutting-a-release.md
+++ b/docs/src/contributing/cutting-a-release.md
@@ -1,18 +1,25 @@
 # Cutting a Release
 
-A release publishes four artifacts to three registries. All of them are
-triggered automatically when a GitHub Release is _published_, so the bulk of
-cutting a release is: get the version numbers right, land the bump, then draft
-the release.
+A release publishes seven artifacts to three registries, through six
+workflows. All of them are triggered automatically when a GitHub Release is
+_published_, so the bulk of cutting a release is: get the version numbers
+right, land the bump, then draft the release.
 
 ## What gets published
 
 | Artifact | Registry | Workflow | Source | Version comes from |
 | --- | --- | --- | --- | --- |
 | `uniffi-bindgen-react-native` | npm | [`npm.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm.yml) | repo root | `package.json` |
+| `@ubjs/core` | npm | [`npm-core.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm-core.yml) | `typescript` | `typescript/package.json` |
 | `@ubjs/node` + `@ubjs/node-<platform>` | npm | [`napi-publish.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/napi-publish.yml) | `runtimes/napi` | `runtimes/napi/package.json` |
+| `@ubjs/wasm` | npm | [`npm-wasm.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm-wasm.yml) | `runtimes/wasm` | `runtimes/wasm/package.json` |
 | `uniffi-runtime-javascript` | crates.io | [`crates-io.yaml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/crates-io.yaml) | `crates/uniffi-runtime-javascript` | `crates/uniffi-runtime-javascript/Cargo.toml` |
+| `uniffi-runtime-wasm` | crates.io | [`crates-io.yaml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/crates-io.yaml) | `runtimes/wasm/helper-crate` | `runtimes/wasm/helper-crate/Cargo.toml` |
 | `uniffi-bindgen-react-native` (Pod) | CocoaPods | [`cocoapods.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/cocoapods.yml) | `uniffi-bindgen-react-native.podspec` | `package.json` (the podspec reads `package['version']`) |
+
+`crates-io.yaml` publishes both crates from one matrixed job, with
+`fail-fast: false` — neither crate depends on the other, so one failure does
+not cancel the other's publish.
 
 `@ubjs/node` is the N-API runtime. Its workflow first builds a native binary
 for every supported target (macOS x64/arm64, Linux gnu/musl on x64/arm64,
@@ -21,13 +28,30 @@ Windows x64/arm64), publishes each as a platform package
 `@ubjs/node` root package whose `optionalDependencies` point at them. If the
 build matrix fails for any target, the publish job does not run.
 
+`@ubjs/wasm` is the wasm2 player runtime, and `uniffi-runtime-wasm` is the
+helper crate a consuming cdylib links. `@ubjs/wasm` declares `@ubjs/core` as a
+`peerDependency`, so that range has to move with the version too.
+
 ## Steps
 
-1. Increment the version number, keeping all four files in sync:
+1. Increment the version number, keeping all seven files in sync:
    - [`package.json`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/package.json#L3) (also drives the CocoaPod)
    - [`crates/ubrn_cli/Cargo.toml`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/crates/ubrn_cli/Cargo.toml#L3)
    - [`crates/uniffi-runtime-javascript/Cargo.toml`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/crates/uniffi-runtime-javascript/Cargo.toml#L3)
+   - [`typescript/package.json`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/typescript/package.json#L3) (the `@ubjs/core` runtime)
    - [`runtimes/napi/package.json`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/runtimes/napi/package.json#L3) (the `@ubjs/node` runtime)
+   - [`runtimes/wasm/package.json`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/runtimes/wasm/package.json#L3) (the `@ubjs/wasm` runtime — also its `@ubjs/core` `peerDependency` range)
+   - [`runtimes/wasm/helper-crate/Cargo.toml`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/runtimes/wasm/helper-crate/Cargo.toml#L3) (the `uniffi-runtime-wasm` crate)
+1. Update the lockfiles to follow, rather than editing them by hand:
+   - `cargo metadata --offline > /dev/null` refreshes `Cargo.lock`
+   - `npm install --package-lock-only` in each of `typescript`, `runtimes/napi`
+     and `runtimes/wasm`
+1. Update the version references outside the manifests:
+   - [`docs/src/reference/config-yaml.md`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/docs/src/reference/config-yaml.md) — the `runtimeVersion` default
+   - [`runtimes/wasm/helper-crate/README.md`](https://github.com/jhugman/uniffi-bindgen-react-native/blob/main/runtimes/wasm/helper-crate/README.md) — the `Cargo.toml` snippet
+   - `crates/ubrn_cli/fixtures/defaults/package.json` — the `@ubjs/core` dependency
+   - Leave statements dating a feature to the release that introduced it (e.g.
+     "As of `0.31.0-3`" in the Node.js reference) alone — those are history.
 1. Update the CHANGELOG. If the CHANGELOG is up-to-date, then this should be minimal.
    - Add a new version title at the top
    - Update the Full Changelog link to go from new release to main
@@ -40,22 +64,26 @@ build matrix fails for any target, the publish job does not run.
 1. Create a new tag (in the choose-a-tag dialog) with the version number (without a `v`).
 1. Use the version number again, but with a `v` prepended, for the release title: `v${VERSION_NUMBER}`.
 1. Publish the release.
-1. Wait for the four publish workflows to go green:
+1. Wait for the six publish workflows to go green:
    - [CocoaPods](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/cocoapods.yml)
    - [npm — `uniffi-bindgen-react-native`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm.yml)
+   - [npm — `@ubjs/core`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm-core.yml)
    - [npm — `@ubjs/node`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/napi-publish.yml)
-   - [crates.io](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/crates-io.yaml)
+   - [npm — `@ubjs/wasm`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm-wasm.yml)
+   - [crates.io](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/crates-io.yaml) — both crates
 1. [Verify the release landed](#after-publishing).
 1. Tell your friends, make a song and dance, you've done a new release.
 
 ## Testing a release before tagging
 
-Three of the four publish workflows can be run manually from the Actions tab
+Five of the six publish workflows can be run manually from the Actions tab
 (`workflow_dispatch`) with a **dry-run** input that defaults to `true`. Use this
 to validate packaging — `cargo publish --dry-run`, `npm publish --dry-run` —
 without pushing anything to a registry:
 
 - [`npm.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm.yml) — `dry-run` input
+- [`npm-core.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm-core.yml) — `dry-run` input
+- [`npm-wasm.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/npm-wasm.yml) — `dry-run` input
 - [`crates-io.yaml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/crates-io.yaml) — `dry_run` input
 - [`napi-publish.yml`](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/napi-publish.yml) — `dry-run` input
 
@@ -73,8 +101,10 @@ dry-run path is reachable only through manual `workflow_dispatch`.
 
 Confirm each artifact actually went out:
 
-- npm: `npm view uniffi-bindgen-react-native version` and `npm view @ubjs/node version`
-- crates.io: <https://crates.io/crates/uniffi-runtime-javascript/versions>
+- npm: `npm view <pkg> version` for `uniffi-bindgen-react-native`, `@ubjs/core`,
+  `@ubjs/node` and `@ubjs/wasm`
+- crates.io: <https://crates.io/crates/uniffi-runtime-javascript/versions> and
+  <https://crates.io/crates/uniffi-runtime-wasm/versions>
 - CocoaPods: `pod trunk info uniffi-bindgen-react-native`
 
 If a workflow fails part-way, re-run just that workflow from the Actions tab

--- a/docs/src/reference/config-yaml.md
+++ b/docs/src/reference/config-yaml.md
@@ -186,7 +186,7 @@ The `defaultFeatures` flag pairs with the `features` array: it is used to build 
 
 The boolean `workspace` controls if the wasm crate is part of [an existing Rust workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html). The default value assumes that the target crate doesn't know anything about the wasm-crate, so the wasm-crate is in its own workspace. If the target crate is in a workspace, and that can be changed, then this setting can be changed to `true`. Tip: [`members` can contain globs](https://doc.rust-lang.org/cargo/reference/workspaces.html#:~:text=the%20members%20list%20also%20supports%20globs) to point to crates that don't yet exist.
 
-`runtimeVersion` is the version of [`uniffi-runtime-javascript` crate](https://crates.io/crates/uniffi-runtime-javascript). By default this is the exact current version of uniffi-bindgen-react-native, so currently `=0.31.0-3`.
+`runtimeVersion` is the version of [`uniffi-runtime-javascript` crate](https://crates.io/crates/uniffi-runtime-javascript). By default this is the exact current version of uniffi-bindgen-react-native, so currently `=0.31.0-4`.
 
 `cargoExtras` is a list of extra arguments passed directly to the `cargo build` command when building for `wasm32-unknown-unknown`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {

--- a/runtimes/napi/package-lock.json
+++ b/runtimes/napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ubjs/node",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/node",
-      "version": "0.31.0-3",
+      "version": "0.31.0-4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",

--- a/runtimes/napi/package.json
+++ b/runtimes/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubjs/node",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "description": "Call Rust libraries from Node.js without hand-written glue — the N-API runtime backend for uniffi-bindgen-react-native.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/runtimes/napi",
   "repository": {

--- a/runtimes/wasm/helper-crate/Cargo.toml
+++ b/runtimes/wasm/helper-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-runtime-wasm"
-version = "0.31.0-3"
+version = "0.31.0-4"
 edition = "2021"
 description = "Runtime helpers (alloc/free/panic hook) for the wasm2 UniFFI player"
 license = "MPL-2.0"

--- a/runtimes/wasm/helper-crate/README.md
+++ b/runtimes/wasm/helper-crate/README.md
@@ -18,7 +18,7 @@ panic hook that forwards Rust panics to a JS function the player installs in
 crate-type = ["lib", "cdylib"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uniffi-runtime-wasm = "0.31.0-3"
+uniffi-runtime-wasm = "0.31.0-4"
 
 [dependencies]
 uniffi_core = { version = "0.31", features = ["wasm-unstable-single-threaded"] }

--- a/runtimes/wasm/package-lock.json
+++ b/runtimes/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ubjs/wasm",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/wasm",
-      "version": "0.31.0-3",
+      "version": "0.31.0-4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20",
@@ -15,12 +15,12 @@
         "typescript": "^5"
       },
       "peerDependencies": {
-        "@ubjs/core": "^0.31.0-3"
+        "@ubjs/core": "^0.31.0-4"
       }
     },
     "../../typescript": {
       "name": "@ubjs/core",
-      "version": "0.31.0-3",
+      "version": "0.31.0-4",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/runtimes/wasm/package.json
+++ b/runtimes/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubjs/wasm",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "description": "WebAssembly player runtime for uniffi-bindgen-react-native generated bindings.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "node --test --import tsx './core/tests/*.test.ts'"
   },
   "peerDependencies": {
-    "@ubjs/core": "^0.31.0-3"
+    "@ubjs/core": "^0.31.0-4"
   },
   "devDependencies": {
     "@ubjs/core": "file:../../typescript",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ubjs/core",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/core",
-      "version": "0.31.0-3",
+      "version": "0.31.0-4",
       "license": "MPL-2.0",
       "devDependencies": {
         "typescript": "^5.8.3"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubjs/core",
-  "version": "0.31.0-3",
+  "version": "0.31.0-4",
   "description": "Runtime support for uniffi-bindgen-javascript generated bindings.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {


### PR DESCRIPTION
Prepare release 0.31.0-4:

- incremented version numbers across the seven manifests, and let the lockfiles follow (cargo metadata, npm install --package-lock-only)
- added changelog