### PR TITLE
Release 0.31.0-5

### DIFF
--- a/.github/workflows/napi-publish.yml
+++ b/.github/workflows/napi-publish.yml
@@ -64,8 +64,14 @@ jobs:
         with:
           node-version: 24
 
+      # Pinned, not `stable`. rustc 1.98.0 passes `--fix-cortex-a53-843419`
+      # to the linker for aarch64 targets, and the zig linker shim that
+      # @napi-rs/cli 2.x generates rejects it, so both aarch64 Linux builds
+      # fail and the publish job never runs. 1.97.1 does not pass the flag.
+      # Unpin once @napi-rs/cli is upgraded to a version that goes through
+      # cargo-zigbuild, which filters the flag.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/npm-core.yml
+++ b/.github/workflows/npm-core.yml
@@ -28,10 +28,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
         run: |
           echo "::notice::DRY RUN — not publishing to npm"
-          cd typescript && npm publish --dry-run --access public
+          cd typescript && npm publish --dry-run --access public --tag latest
 
       - name: "📦 npm publish: @ubjs/core"
         if: ${{ github.event_name == 'release' || github.event_name == 'workflow_call' || !inputs.dry-run }}
-        run: cd typescript && npm publish --provenance --access public
+        run: cd typescript && npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-wasm.yml
+++ b/.github/workflows/npm-wasm.yml
@@ -32,10 +32,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
         run: |
           echo "::notice::DRY RUN — not publishing to npm"
-          cd runtimes/wasm && npm publish --dry-run --access public
+          cd runtimes/wasm && npm publish --dry-run --access public --tag latest
 
       - name: "📦 npm publish: @ubjs/wasm"
         if: ${{ github.event_name == 'release' || github.event_name == 'workflow_call' || !inputs.dry-run }}
-        run: cd runtimes/wasm && npm publish --provenance --access public
+        run: cd runtimes/wasm && npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -28,10 +28,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
         run: |
           echo "::notice::DRY RUN — not publishing to npm"
-          npm publish --dry-run --access public
+          npm publish --dry-run --access public --tag latest
 
       - name: "📦 npm publish: uniffi-bindgen-react-native"
         if: ${{ github.event_name == 'release' || !inputs.dry-run }}
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 [//]: # (## ⚠️ Breaking Changes)
 [//]: # (**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/{{previous}}...{{current}})
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-4...main
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-5...main
 
 ---
 
-# 0.31.0-4
+# 0.31.0-5
 
 ## ✨ What's New ✨
 
@@ -62,7 +62,7 @@ Alongside those, the runtime now refuses to free a buffer it cannot prove the li
 
 - The N-API `RustBuffer` fixes change the contract between the generated bindings and the runtime: regenerate your bindings and upgrade [`@ubjs/node`](https://www.npmjs.com/package/@ubjs/node) together. A new runtime with old bindings, or the reverse, will not behave correctly ([#420](https://github.com/jhugman/uniffi-bindgen-react-native/pull/420), [#432](https://github.com/jhugman/uniffi-bindgen-react-native/pull/432)).
 
-**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-3...0.31.0-4
+**Full Changelog**: https://github.com/jhugman/uniffi-bindgen-react-native/compare/0.31.0-3...0.31.0-5
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-react-native"
-version = "0.31.0-4"
+version = "0.31.0-5"
 dependencies = [
  "anyhow",
  "askama 0.13.1",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-javascript"
-version = "0.31.0-4"
+version = "0.31.0-5"
 dependencies = [
  "uniffi_core",
  "wasm-bindgen",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-runtime-wasm"
-version = "0.31.0-4"
+version = "0.31.0-5"
 
 [[package]]
 name = "uniffi_bindgen"

--- a/crates/ubrn_cli/Cargo.toml
+++ b/crates/ubrn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-react-native"
-version = "0.31.0-4"
+version = "0.31.0-5"
 edition = "2021"
 
 [lib]

--- a/crates/ubrn_cli/fixtures/defaults/package.json
+++ b/crates/ubrn_cli/fixtures/defaults/package.json
@@ -156,6 +156,6 @@
     "version": "0.50.2"
   },
   "dependencies": {
-    "@ubjs/core": "^0.31.0-4"
+    "@ubjs/core": "^0.31.0-5"
   }
 }

--- a/crates/uniffi-runtime-javascript/Cargo.toml
+++ b/crates/uniffi-runtime-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-runtime-javascript"
-version = "0.31.0-4"
+version = "0.31.0-5"
 edition = "2021"
 authors = ["James Hugman <james@hugman.tv>"]
 description = "wasm-bindgen runtime for UniFFI-generated Javascript bindings crates"

--- a/docs/src/contributing/cutting-a-release.md
+++ b/docs/src/contributing/cutting-a-release.md
@@ -61,8 +61,15 @@ helper crate a consuming cdylib links. `@ubjs/wasm` declares `@ubjs/core` as a
 1. (Optional but recommended) Run a dry-run of the publish workflows — see
    [Testing a release before tagging](#testing-a-release-before-tagging).
 1. Once the PR has landed, [draft a new release](https://github.com/jhugman/uniffi-bindgen-react-native/releases/new).
-1. Create a new tag (in the choose-a-tag dialog) with the version number (without a `v`).
-1. Use the version number again, but with a `v` prepended, for the release title: `v${VERSION_NUMBER}`.
+1. Create a new tag (in the choose-a-tag dialog). The tag is the version
+   **exactly as it appears in `package.json`**, with no `v` and no
+   abbreviation — `0.31.0-5`, never `v0.31.0-5` and never `0.31-5`. Copy it,
+   do not retype it:
+   ```sh
+   node -p "require('./package.json').version"
+   ```
+1. Use that same version with a `v` prepended for the release *title*:
+   `v${VERSION_NUMBER}`. The `v` belongs to the title only, never the tag.
 1. Publish the release.
 1. Wait for the six publish workflows to go green:
    - [CocoaPods](https://github.com/jhugman/uniffi-bindgen-react-native/actions/workflows/cocoapods.yml)
@@ -115,11 +122,72 @@ will skip the platform packages that already landed and publish the rest.
 
 ## Version numbers
 
-`uniffi-rs` uses a `semver` versioning scheme (e.g. `0.31.0`).
+A release version is always exactly this shape:
 
-`uniffi-bindgen-react-native` tracks the `uniffi-rs` version and appends a `-N` variant number. The variant number increases monotonically across releases and is **not** reset when the `uniffi-rs` version changes.
+```
+MAJOR . MINOR . 0 - N
+└────┬────┘    │   └── variant number, monotonic
+     │         └────── always literally 0
+     └──────────────── tracks the uniffi-rs release
+```
 
-For example, if the last release was `0.30.0-1` and `uniffi-rs` is bumped to `0.31.0`, the next release is `0.31.0-2` (not `0.31.0-0`).
+- **`MAJOR.MINOR`** tracks the `uniffi-rs` release the bindings are built
+  against. `uniffi-rs` `0.31.x` gives `0.31`.
+- **The patch is always `0`.** We do *not* mirror the `uniffi-rs` patch level.
+  If `uniffi-rs` goes `0.31.0` → `0.31.4`, our `MAJOR.MINOR` is unchanged and
+  only `N` moves. The `0` is a placeholder: semver requires three numeric
+  components, so we cannot write `0.31-5` (see below).
+- **`N`** increases monotonically across releases and is **not** reset when the
+  `uniffi-rs` version changes. If the last release was `0.30.0-1` and
+  `uniffi-rs` is bumped to `0.31`, the next release is `0.31.0-2`, not
+  `0.31.0-0`.
+
+Older releases (`0.28.3-5`, `0.29.3-1`) do carry a non-zero patch, from when the
+scheme mirrored the `uniffi-rs` patch level. They are history; do not copy them.
+
+### One string drives everything
+
+The same string is the npm version, the crate version, the CocoaPod version and
+the **git tag**, because the podspec derives its source tag from `package.json`:
+
+```ruby
+s.version = package['version']
+s.source  = { :git => ..., :tag => s.version.to_s }
+```
+
+So a tag that does not match `package.json` exactly fails CocoaPods lint with
+`Remote branch <version> not found in upstream origin`, and every other publish
+workflow goes red alongside it.
+
+### These are semver prereleases
+
+Anything after the `-` is a semver *prerelease* identifier, so `0.31.0-5` reads
+as "a prerelease of `0.31.0`" and sorts *below* `0.31.0`. Every release we have
+ever cut is, to npm and cargo, a prerelease. Two consequences:
+
+- **`npm publish` must pass `--tag latest`.** npm 11 (bundled with node 24)
+  refuses to publish a prerelease without an explicit dist-tag, rather than
+  silently moving `latest` onto it. All four npm publish workflows pass it on
+  every `npm publish` invocation, dry-run included; a new one must too.
+- **Consumers need an explicit version.** `npm install uniffi-bindgen-react-native`
+  resolves via the `latest` dist-tag, which we set — but a bare semver range
+  like `^0.31.0` will *not* match `0.31.0-5`.
+
+### The patch cannot be dropped from the string
+
+Tempting, but neither toolchain accepts it — semver mandates all three
+components before a `-` suffix:
+
+```console
+$ npm publish --dry-run          # version = "0.31-5"
+npm error Invalid version: "0.31-5"
+
+$ cargo metadata                 # version = "0.31-5"
+error: unexpected character '-' after minor version number
+```
+
+"Dropping the patch" is therefore a *policy* — we stop tracking the `uniffi-rs`
+patch level — not a change to the string. The `.0` stays.
 
 ### Compatibility with other packages
 

--- a/docs/src/reference/config-yaml.md
+++ b/docs/src/reference/config-yaml.md
@@ -186,7 +186,7 @@ The `defaultFeatures` flag pairs with the `features` array: it is used to build 
 
 The boolean `workspace` controls if the wasm crate is part of [an existing Rust workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html). The default value assumes that the target crate doesn't know anything about the wasm-crate, so the wasm-crate is in its own workspace. If the target crate is in a workspace, and that can be changed, then this setting can be changed to `true`. Tip: [`members` can contain globs](https://doc.rust-lang.org/cargo/reference/workspaces.html#:~:text=the%20members%20list%20also%20supports%20globs) to point to crates that don't yet exist.
 
-`runtimeVersion` is the version of [`uniffi-runtime-javascript` crate](https://crates.io/crates/uniffi-runtime-javascript). By default this is the exact current version of uniffi-bindgen-react-native, so currently `=0.31.0-4`.
+`runtimeVersion` is the version of [`uniffi-runtime-javascript` crate](https://crates.io/crates/uniffi-runtime-javascript). By default this is the exact current version of uniffi-bindgen-react-native, so currently `=0.31.0-5`.
 
 `cargoExtras` is a list of extra arguments passed directly to the `cargo build` command when building for `wasm32-unknown-unknown`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniffi-bindgen-react-native",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "description": "Uniffi bindings generator for calling Rust from React Native",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {

--- a/runtimes/napi/package-lock.json
+++ b/runtimes/napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ubjs/node",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/node",
-      "version": "0.31.0-4",
+      "version": "0.31.0-5",
       "license": "MPL-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",

--- a/runtimes/napi/package.json
+++ b/runtimes/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubjs/node",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "description": "Call Rust libraries from Node.js without hand-written glue — the N-API runtime backend for uniffi-bindgen-react-native.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native/tree/main/runtimes/napi",
   "repository": {

--- a/runtimes/wasm/helper-crate/Cargo.toml
+++ b/runtimes/wasm/helper-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-runtime-wasm"
-version = "0.31.0-4"
+version = "0.31.0-5"
 edition = "2021"
 description = "Runtime helpers (alloc/free/panic hook) for the wasm2 UniFFI player"
 license = "MPL-2.0"

--- a/runtimes/wasm/helper-crate/README.md
+++ b/runtimes/wasm/helper-crate/README.md
@@ -18,7 +18,7 @@ panic hook that forwards Rust panics to a JS function the player installs in
 crate-type = ["lib", "cdylib"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uniffi-runtime-wasm = "0.31.0-4"
+uniffi-runtime-wasm = "0.31.0-5"
 
 [dependencies]
 uniffi_core = { version = "0.31", features = ["wasm-unstable-single-threaded"] }

--- a/runtimes/wasm/package-lock.json
+++ b/runtimes/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ubjs/wasm",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/wasm",
-      "version": "0.31.0-4",
+      "version": "0.31.0-5",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20",
@@ -15,12 +15,12 @@
         "typescript": "^5"
       },
       "peerDependencies": {
-        "@ubjs/core": "^0.31.0-4"
+        "@ubjs/core": "^0.31.0-5"
       }
     },
     "../../typescript": {
       "name": "@ubjs/core",
-      "version": "0.31.0-4",
+      "version": "0.31.0-5",
       "dev": true,
       "license": "MPL-2.0",
       "devDependencies": {

--- a/runtimes/wasm/package.json
+++ b/runtimes/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubjs/wasm",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "description": "WebAssembly player runtime for uniffi-bindgen-react-native generated bindings.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "node --test --import tsx './core/tests/*.test.ts'"
   },
   "peerDependencies": {
-    "@ubjs/core": "^0.31.0-4"
+    "@ubjs/core": "^0.31.0-5"
   },
   "devDependencies": {
     "@ubjs/core": "file:../../typescript",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ubjs/core",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ubjs/core",
-      "version": "0.31.0-4",
+      "version": "0.31.0-5",
       "license": "MPL-2.0",
       "devDependencies": {
         "typescript": "^5.8.3"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubjs/core",
-  "version": "0.31.0-4",
+  "version": "0.31.0-5",
   "description": "Runtime support for uniffi-bindgen-javascript generated bindings.",
   "homepage": "https://github.com/jhugman/uniffi-bindgen-react-native",
   "repository": {


### PR DESCRIPTION
- incremented version numbers across the seven manifests, and let the lockfiles follow (cargo metadata, npm install --package-lock-only)
- added changelog
- pass --tag latest on every npm publish step. Each release version is a semver prerelease, and npm 11 refuses to publish a prerelease without an explicit dist-tag rather than silently moving `latest` onto it
- pin the napi publish toolchain to rustc 1.97.1. rustc 1.98.0 passes --fix-cortex-a53-843419 for aarch64, which the zig linker shim from @napi-rs/cli 2.x rejects, failing both aarch64 Linux builds and skipping the publish job
- document the version format in the runbook: MAJOR.MINOR.0-N, patch always 0 and no longer mirroring the uniffi-rs patch level, git tag matching package.json exactly