### PR TITLE
chore(deps): align @types/node with the node CI runs

### DIFF
--- a/runtimes/napi/package-lock.json
+++ b/runtimes/napi/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "prettier": "^3.8.1",
         "typescript": "^5.4.0"
       }
@@ -33,13 +33,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/prettier": {
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/runtimes/napi/package.json
+++ b/runtimes/napi/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "prettier": "^3.8.1",
     "typescript": "^5.4.0"
   }

--- a/runtimes/wasm/package-lock.json
+++ b/runtimes/wasm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.31.0-5",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@types/node": "^20",
+        "@types/node": "^24",
         "@ubjs/core": "file:../../typescript",
         "tsx": "^4",
         "typescript": "^5"
@@ -470,13 +470,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@ubjs/core": {
@@ -598,9 +598,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/runtimes/wasm/package.json
+++ b/runtimes/wasm/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@ubjs/core": "file:../../typescript",
-    "@types/node": "^20",
+    "@types/node": "^24",
     "tsx": "^4",
     "typescript": "^5"
   },


### PR DESCRIPTION
Every workflow sets node-version: 24, but both runtimes declared @types/node ^20 — typechecking against a runtime we do not ship on. Both now resolve to 24.13.3.