### PR TITLE
perf: encode strings directly into the destination buffer

### DIFF
--- a/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelperTemplate.ts
+++ b/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/StringHelperTemplate.ts
@@ -7,13 +7,24 @@ const stringConverter = (() => {
         stringToBytes: (s: string) => encoder.encode(s),
         bytesToString: (ab: UniffiByteArray) => decoder.decode(ab),
         stringByteLength: (s: string) => encoder.encode(s).byteLength,
-        writeStringIntoBuffer: (s: string, buf: any, offset: number): number => {
-            const view = new Uint8Array(
-                buf.arrayBuffer,
-                offset,
-                buf.arrayBuffer.byteLength - offset,
-            );
-            return encoder.encodeInto(s, view).written;
+        // Returns the whole `encodeInto` result. `written` sizes the length
+        // prefix; `read` is the only reliable way to tell that the string did
+        // not fit, because `encodeInto` stops before a code point it cannot
+        // complete rather than filling the buffer — so a short `written` does
+        // not imply truncation.
+        writeStringIntoBuffer: (
+            s: string,
+            buf: any,
+            offset: number,
+            capacity: number,
+        ): { read: number; written: number } => {
+            // Bound the view by the caller's allocation, not by the backing
+            // buffer. They coincide when the buffer wraps exactly one
+            // allocation, but under wasm the backing buffer is the whole
+            // linear memory, and sizing from it would let `encodeInto` run
+            // past the allocation into neighbouring memory.
+            const view = new Uint8Array(buf.arrayBuffer, offset, capacity);
+            return encoder.encodeInto(s, view);
         },
         readStringFromBuffer: (buf: any, offset: number, length: number): string =>
             decoder.decode(new Uint8Array(buf.arrayBuffer, offset, length)),
@@ -56,13 +67,24 @@ const stringConverter = (() => {
         // Encode directly into the RustBuffer backing store via
         // TextEncoder.encodeInto — zero intermediate allocation. Replaces
         // the old C++ write_string_into_buffer helper.
-        writeStringIntoBuffer: (s: string, buf: any, offset: number): number => {
-            const view = new Uint8Array(
-                buf.arrayBuffer,
-                offset,
-                buf.arrayBuffer.byteLength - offset,
-            );
-            return encoder.encodeInto(s, view).written;
+        // Returns the whole `encodeInto` result. `written` sizes the length
+        // prefix; `read` is the only reliable way to tell that the string did
+        // not fit, because `encodeInto` stops before a code point it cannot
+        // complete rather than filling the buffer — so a short `written` does
+        // not imply truncation.
+        writeStringIntoBuffer: (
+            s: string,
+            buf: any,
+            offset: number,
+            capacity: number,
+        ): { read: number; written: number } => {
+            // Bound the view by the caller's allocation, not by the backing
+            // buffer. They coincide when the buffer wraps exactly one
+            // allocation, but under wasm the backing buffer is the whole
+            // linear memory, and sizing from it would let `encodeInto` run
+            // past the allocation into neighbouring memory.
+            const view = new Uint8Array(buf.arrayBuffer, offset, capacity);
+            return encoder.encodeInto(s, view);
         },
         // Dedicated C++ helper — avoids per-read Uint8Array allocation and
         // the double property-lookup in string_from_buffer.

--- a/runtimes/wasm/core/src/marshal.ts
+++ b/runtimes/wasm/core/src/marshal.ts
@@ -68,6 +68,14 @@ export function writeRustBufferPayload(
   bytes: Uint8Array,
 ): void {
   const len = bytes.byteLength;
+  // A lowered view may be narrower than the allocation behind it: the string
+  // converter sizes for the worst case, encodes, then shrinks the view to the
+  // bytes actually written, recording the real allocation size here. Rust
+  // frees a `RustBuffer` by its `capacity`, so passing `len` for a shrunk view
+  // would deallocate with the wrong size and corrupt the allocator.
+  const marked = (bytes as unknown as { __ubrnRustCapacity?: number })
+    .__ubrnRustCapacity;
+  let capacity = typeof marked === "number" && marked > len ? marked : len;
   let dataPtr = 0;
   if (len > 0) {
     if (bytes.buffer === m.buffer()) {
@@ -83,13 +91,21 @@ export function writeRustBufferPayload(
           "be held across any operation that can grow wasm memory.",
       );
     } else {
-      // JS-owned `Uint8Array` — allocate wasm memory and copy.
+      // JS-owned `Uint8Array` — allocate wasm memory and copy. The fresh
+      // allocation is exactly `len`, so any marker from the source view does
+      // not describe it.
       dataPtr = alloc(len, 1);
       m.writeBytes(dataPtr, bytes);
+      capacity = len;
     }
+  } else {
+    capacity = 0;
   }
-  const blen = BigInt(len);
-  writeRustBuffer(m, ptr, { capacity: blen, len: blen, dataPtr });
+  writeRustBuffer(m, ptr, {
+    capacity: BigInt(capacity),
+    len: BigInt(len),
+    dataPtr,
+  });
 }
 
 const RCS_CODE_OFF = 0;

--- a/typescript/src/ffi-converters.ts
+++ b/typescript/src/ffi-converters.ts
@@ -31,10 +31,21 @@ export abstract class AbstractFfiConverterByteArray<TsType>
     return this.readFromCursor(c);
   }
   lower(value: TsType, alloc: RustBufferAllocator): UniffiByteArray {
-    const view = alloc(this.allocationSize(value));
+    const capacity = this.allocationSize(value);
+    const view = alloc(capacity);
     const c = Cursor.fromUint8Array(view);
     this.writeIntoCursor(value, c);
-    return view;
+    const written = (c as any).pos;
+    if (written === capacity) {
+      // Exact sizing — every converter except strings knows its size up front.
+      return view;
+    }
+    // A string was sized by upper bound, so the tail of the allocation is
+    // slack. Shrink the view to the message bytes and record the real
+    // allocation size, which `rustbuffer_free` needs to free correctly.
+    const exact = view.subarray(0, written);
+    (exact as any).__ubrnRustCapacity = capacity;
+    return exact;
   }
 
   abstract readFromCursor(c: Cursor): TsType;
@@ -346,7 +357,17 @@ type StringConverter = {
   // `stringToBytes`/`bytesToString`. The `buf` argument is a RustBuffer; the
   // implementation encodes into / decodes from `buf.arrayBuffer` at the given
   // offset.
-  writeStringIntoBuffer?: (s: string, buf: any, offset: number) => number;
+  // Mirrors `TextEncoder.encodeInto`: `written` is the byte count, `read` the
+  // number of UTF-16 code units consumed. `read < s.length` means the string
+  // did not fit — `written` cannot show that, because `encodeInto` stops
+  // before a code point it lacks room to finish rather than filling the
+  // buffer.
+  writeStringIntoBuffer?: (
+    s: string,
+    buf: any,
+    offset: number,
+    capacity: number,
+  ) => { read: number; written: number };
   readStringFromBuffer?: (buf: any, offset: number, length: number) => string;
 };
 export function uniffiCreateFfiConverterString(
@@ -356,7 +377,54 @@ export function uniffiCreateFfiConverterString(
     lift(value: UniffiByteArray): string {
       return converter.bytesToString(value);
     }
-    lower(value: string, _alloc: RustBufferAllocator): UniffiByteArray {
+    lower(value: string, alloc: RustBufferAllocator): UniffiByteArray {
+      // A top-level string is the whole buffer — no length prefix, unlike the
+      // cursor path.
+      //
+      // `stringToBytes` transcodes into a native string and hands JS a buffer
+      // that the boundary then copies again. Encoding straight into the
+      // allocation removes both, the same way `writeIntoCursor` does for
+      // strings inside a container. Empty strings keep the old path: a
+      // zero-length allocation is not worth special-casing downstream.
+      if (converter.writeStringIntoBuffer && value.length > 0) {
+        // Size for ASCII first, where UTF-8 length equals UTF-16 length.
+        // Reserving the 3-bytes-per-code-unit worst case up front would ask
+        // the allocator for 3x the memory on every call, which costs more
+        // than the occasional second pass — and the buffers are Rust-owned,
+        // so on the JSI player they are only released when the view is
+        // collected.
+        //
+        // The extra byte makes truncation detectable: a string that fits
+        // leaves at least one byte unwritten, so `written === capacity` can
+        // only mean `encodeInto` ran out of room.
+        let capacity = value.length;
+        let view = alloc(capacity);
+        let result = converter.writeStringIntoBuffer(
+          value,
+          { arrayBuffer: view.buffer } as any,
+          view.byteOffset,
+          capacity,
+        );
+        if (result.read < value.length) {
+          // Some of the string didn't fit, so it holds at least one non-ASCII
+          // code point. Redo at the worst case, which always suffices.
+          capacity = 3 * value.length;
+          view = alloc(capacity);
+          result = converter.writeStringIntoBuffer(
+            value,
+            { arrayBuffer: view.buffer } as any,
+            view.byteOffset,
+            capacity,
+          );
+        }
+        const written = result.written;
+        if (written === capacity) {
+          return view;
+        }
+        const exact = view.subarray(0, written);
+        (exact as any).__ubrnRustCapacity = capacity;
+        return exact;
+      }
       return converter.stringToBytes(value);
     }
     readFromCursor(c: Cursor): string {
@@ -387,10 +455,13 @@ export function uniffiCreateFfiConverterString(
         // Synthetic buf with the cursor's underlying ArrayBuffer; helpers
         // use `buf.arrayBuffer` to construct a Uint8Array view.
         const buf: any = { arrayBuffer: (c as any).u8.buffer };
-        const bytesWritten = converter.writeStringIntoBuffer(
+        // `allocationSize` reserved the worst case for this string, so the
+        // encode always fits and `read` needs no checking here.
+        const { written: bytesWritten } = converter.writeStringIntoBuffer(
           value,
           buf,
           dataOffset,
+          3 * value.length,
         );
         // Backfill the length prefix (big-endian i32, matches Cursor.writeI32).
         (c as any).dv.setInt32(lengthPos, bytesWritten);
@@ -402,6 +473,18 @@ export function uniffiCreateFfiConverterString(
       c.writeBytes(bytes);
     }
     allocationSize(value: string): number {
+      if (converter.writeStringIntoBuffer) {
+        // Upper bound rather than an exact measurement. `stringByteLength`
+        // transcodes the whole string and keeps only its length, so sizing
+        // exactly costs a second full UTF-8 encode of every string — the
+        // dominant cost when lowering arrays of them.
+        //
+        // UTF-8 needs at most 3 bytes per UTF-16 code unit: a BMP character
+        // is one unit and at most 3 bytes, and a surrogate pair is two units
+        // and 4 bytes. `writeIntoCursor` backfills the true length and
+        // `lower()` shrinks the view to it.
+        return 4 + 3 * value.length;
+      }
       return 4 + converter.stringByteLength(value);
     }
   }


### PR DESCRIPTION
Lowering a string into Rust now transcodes it **once**, straight into the buffer that
crosses the FFI.

| | before | after |
| --- | --- | --- |
| lowering 1MB of string | 2.04ms | 0.46ms |
| arrays of strings | — | 1.4x – 4.7x faster, depending on shape |

### Problem

Lowering was transcoding every string twice.

`lower()` must know the exact size before it can allocate, and for strings
`allocationSize()` called `stringByteLength()` — a full UTF-8 transcode whose result is
discarded for its length. `writeIntoCursor` then transcoded the string a second time to
write it. For an array that meant two encodes per element, plus a native call per element
purely to measure.

Top-level strings avoided the sizing pass but were worse: `lower()` returned
`stringToBytes(value)`, ignoring the allocator entirely, so the bytes went into a native
buffer that the boundary then copied again.

### Change

Size once, encode once, into the destination.

- **`ffi-converters.ts`** — strings inside a container are sized by upper bound (3 bytes per
  UTF-16 code unit, which always suffices) rather than measured, so the
  `stringByteLength()` transcode disappears. `lower()` then shrinks the view to the bytes
  actually written. Top-level strings encode straight into the allocation, sized for ASCII
  first and retried at the worst case only when the string turns out not to fit — so the
  common case allocates exactly once and never over-reserves.
- **`StringHelperTemplate.ts`** — `writeStringIntoBuffer` returns the whole `encodeInto`
  result rather than just `written`, which is what lets the caller above skip the
  measurement pass. `read` is the truncation signal: `encodeInto` stops before a code point
  it cannot complete rather than filling the buffer, so a short `written` does not imply
  truncation.
- **`marshal.ts`** — wasm records the real allocation size when building the `RustBuffer`,
  since a shrunk view is now narrower than what was allocated.

### Two details the fast path depends on

Both are self-contained to this change; neither is reachable on `main` today.

The encode view is bounded by the caller's capacity rather than by the backing buffer.
Those coincide where the buffer wraps exactly one allocation, but under wasm the backing
buffer is the whole linear memory — and an unbounded view can never report truncation,
which is what the optimistic ASCII sizing relies on.

The allocation size is recorded alongside the shrunk view because Rust frees a `RustBuffer`
by its `capacity`, not its length.

### Testing

`callbacks`, `ext-types`, `coverall` and `benchmark` fixtures across `jsi`, `napi`, `wasm`
and `wasm2` — 18 tests, all passing.

Non-ASCII coverage is the part worth keeping an eye on for anything in this area: the
accented strings in the `callbacks` fixture exercise the truncation-and-retry path that the
pure-ASCII `benchmark` never touches.
